### PR TITLE
Adds method to split and strip input config files.

### DIFF
--- a/packageinfo.nim
+++ b/packageinfo.nim
@@ -75,14 +75,14 @@ proc parseRequires(req: string): tuple[name: string, ver: PVersionRange] =
   except EParseVersion:
     quit("Unable to parse dependency version range: " & getCurrentExceptionMsg())
 
-proc multiSplit(s: string, sep: char): seq[string] =
-  ## Returns ``s`` split by the ``sep`` character.
+proc multiSplit(s: string): seq[string] =
+  ## Returns ``s`` split by newline and comma characters.
   ##
   ## Before returning, all individual entries are stripped of whitespace and
   ## also empty entries are purged from the list. If after all the cleanups are
   ## done no entries are found in the list, the proc returns a sequence with
   ## the original string as the only entry.
-  result = split(s, sep)
+  result = split(s, {char(0x0A), char(0x0D), ','})
   map(result, proc(x: var string) = x = x.strip())
   for i in countdown(result.len()-1, 0):
     if len(result[i]) < 1:
@@ -118,19 +118,19 @@ proc readPackageInfo*(path: string): TPackageInfo =
           of "license": result.license = ev.value
           of "srcdir": result.srcDir = ev.value
           of "skipdirs":
-            result.skipDirs.add(ev.value.multiSplit(','))
+            result.skipDirs.add(ev.value.multiSplit)
           of "skipfiles":
-            result.skipFiles.add(ev.value.multiSplit(','))
+            result.skipFiles.add(ev.value.multiSplit)
           of "skipext":
-            result.skipExt.add(ev.value.multiSplit(','))
+            result.skipExt.add(ev.value.multiSplit)
           of "installdirs":
-            result.installDirs.add(ev.value.multiSplit(','))
+            result.installDirs.add(ev.value.multiSplit)
           of "installfiles":
-            result.installFiles.add(ev.value.multiSplit(','))
+            result.installFiles.add(ev.value.multiSplit)
           of "installext":
-            result.installExt.add(ev.value.multiSplit(','))
+            result.installExt.add(ev.value.multiSplit)
           of "bin":
-            for i in ev.value.multiSplit(','):
+            for i in ev.value.multiSplit:
               result.bin.add(i.addFileExt(ExeExt))
           of "backend":
             result.backend = ev.value.toLower()
@@ -141,7 +141,7 @@ proc readPackageInfo*(path: string): TPackageInfo =
         of "deps", "dependencies":
           case ev.key.normalize
           of "requires":
-            for v in ev.value.multiSplit(','):
+            for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
           else:
             quit("Invalid field: " & ev.key, QuitFailure)

--- a/readme.markdown
+++ b/readme.markdown
@@ -77,8 +77,8 @@ license       = "MIT"
 
 SkipDirs = "SomeDir" ; ./SomeDir will not be installed
 SkipFiles = """
-file.txt,
-file2.txt,
+file.txt
+file2.txt
 """ ; ./{file.txt, file2.txt} will not be installed
 
 [Deps]


### PR DESCRIPTION
This allows using triple quote variables specifying comma separated
files on different lines.
