### PR TITLE
Mentions nimrod 0.9.2 won't work with babel.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -6,9 +6,9 @@ language](http://nimrod-lang.org).
 ## Installation
 
 You will need the latest [Nimrod compiler from
-github](https://github.com/Araq/Nimrod) to compile babel (version 0.9.2 may
-work). To run babel you will need to have installed some of the tools it
-depends on to check out source code. For instance, if a package is hosted on
+github](https://github.com/Araq/Nimrod) to compile babel (version 0.9.2 does
+**not** work). To run babel you will need to have installed some of the tools
+it depends on to check out source code. For instance, if a package is hosted on
 [Github](https://github.com) you require to have [git](http://www.git-scm.com)
 installed and added to your environment ``PATH``. Same goes for
 [Mercurial](http://mercurial.selenic.com) repositories on


### PR DESCRIPTION
Users are [having trouble installing it](http://stackoverflow.com/questions/22549197/trouble-installing-babel-for-nimrod).
