### PR TITLE
Improvements for nimble build.

### DIFF
--- a/developers.markdown
+++ b/developers.markdown
@@ -211,10 +211,11 @@ their own packages to it! Take a look at
   Separated by commas.
 * ``srcDir`` - Specifies the directory which contains the .nim source files.
   **Default**: The directory in which the .nimble file resides; i.e. root dir of
-  package.
-* ``buildDir`` - Specifies the directory which contains the .nim source files.
-  **Default**: The directory in which the .nimble file resides; i.e. root dir of
-  package.
+  the package.
+* ``buildDir`` - Specifies the directory where ``nimble build`` will output
+  binaries.  
+  **Default**: The directory in which the .nimble file resides; i.e.
+  root dir of the package.
 * ``bin`` - A list of files which should be built separated by commas with
   no file extension required. This option turns your package into a *binary
   package*, nimble will build the files specified and install them appropriately.

--- a/developers.markdown
+++ b/developers.markdown
@@ -212,6 +212,9 @@ their own packages to it! Take a look at
 * ``srcDir`` - Specifies the directory which contains the .nim source files.
   **Default**: The directory in which the .nimble file resides; i.e. root dir of
   package.
+* ``buildDir`` - Specifies the directory which contains the .nim source files.
+  **Default**: The directory in which the .nimble file resides; i.e. root dir of
+  package.
 * ``bin`` - A list of files which should be built separated by commas with
   no file extension required. This option turns your package into a *binary
   package*, nimble will build the files specified and install them appropriately.

--- a/readme.markdown
+++ b/readme.markdown
@@ -158,8 +158,12 @@ Similar to the ``install`` command you can specify a version range, for example:
 ### nimble build
 
 The ``build`` command is mostly used by developers who want to test building
-their ``.nimble`` package. The ``install`` command calls ``build`` implicitly,
-so there is rarely any reason to use this command directly.
+their ``.nimble`` package. This command will build the package in debug mode,
+without installing anything. The ``install`` command will build the package
+in release mode instead.
+
+If you are a developer willing to produce new Nimble packages please read the
+[developers.markdown file](developers.markdown) for detailed information.
 
 ### nimble list
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -425,10 +425,11 @@ proc buildFromDir(pkgInfo: TPackageInfo, paths: seq[string]) =
   var args = ""
   for path in paths: args.add("--path:\"" & path & "\" ")
   for bin in pkgInfo.bin:
+    let outputOpt = pkgInfo.getOutputOption(bin)
     echo("Building ", pkginfo.name, "/", bin, " using ", pkgInfo.backend,
          " backend...")
-    doCmd(getNimBin() & " $# -d:release --noBabelPath $# \"$#\"" %
-          [pkgInfo.backend, args, realDir / bin.changeFileExt("nim")])
+    doCmd(getNimBin() & " $# -d:release --noBabelPath $#$# \"$#\"" %
+          [pkgInfo.backend, args, outputOpt, realDir / bin.changeFileExt("nim")])
 
 proc saveNimbleMeta(pkgDestDir, url: string, filesInstalled: TSet[string]) =
   var nimblemeta = %{"url": %url}

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -327,7 +327,7 @@ proc getOutputOption*(pkgInfo: TPackageInfo, bin: string): string =
   if pkgInfo.buildDir != "":
     result = " -o:\"" & pkgInfo.mypath.splitFile.dir / pkgInfo.buildDir / bin & "\""
   else:
-    result = ""
+    result = " -o:\"" & pkgInfo.mypath.splitFile.dir / bin & "\""
 
 proc getNameVersion*(pkgpath: string): tuple[name, version: string] =
   ## Splits ``pkgpath`` in the format ``/home/user/.nimble/pkgs/package-0.1``

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -21,6 +21,7 @@ type
     installExt*: seq[string]
     requires*: seq[TPkgTuple]
     bin*: seq[string]
+    buildDir*: string
     srcDir*: string
     backend*: string
 
@@ -56,6 +57,7 @@ proc initPackageInfo(): TPackageInfo =
   result.requires = @[]
   result.bin = @[]
   result.srcDir = ""
+  result.buildDir = ""
   result.backend = "c"
 
 proc validatePackageInfo(pkgInfo: TPackageInfo, path: string) =
@@ -140,6 +142,7 @@ proc readPackageInfo*(path: string): TPackageInfo =
           of "description": result.description = ev.value
           of "license": result.license = ev.value
           of "srcdir": result.srcDir = ev.value
+          of "builddir": result.buildDir = ev.value
           of "skipdirs":
             result.skipDirs.add(ev.value.multiSplit)
           of "skipfiles":
@@ -317,6 +320,14 @@ proc getRealDir*(pkgInfo: TPackageInfo): string =
     result = pkgInfo.mypath.splitFile.dir / pkgInfo.srcDir
   else:
     result = pkgInfo.mypath.splitFile.dir
+
+proc getOutputOption*(pkgInfo: TPackageInfo, bin: string): string =
+  ## Returns an output option for the nim compiler if a build directory
+  ## has been set.
+  if pkgInfo.buildDir != "":
+    result = " -o:\"" & pkgInfo.mypath.splitFile.dir / pkgInfo.buildDir / bin & "\""
+  else:
+    result = ""
 
 proc getNameVersion*(pkgpath: string): tuple[name, version: string] =
   ## Splits ``pkgpath`` in the format ``/home/user/.nimble/pkgs/package-0.1``


### PR DESCRIPTION
- `nimble build` now compiles in debug mode while `nimble install` compiles in release mode.
- add a `builddir` option to .nimble files to specify where built binaries/libs should go.