### PR TITLE
Use MIT instead of BSD

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -769,7 +769,7 @@ proc init(options: Options) =
     outFile.writeln("version       = \"0.1.0\"")
     outFile.writeln("author        = \"Anonymous\"")
     outFile.writeln("description   = \"New Nimble project for Nim\"")
-    outFile.writeln("license       = \"BSD\"")
+    outFile.writeln("license       = \"MIT\"")
     outFile.writeln("")
     outFile.writeln("[Deps]")
     outFile.writeln("Requires: \"nim >= 0.10.0\"")


### PR DESCRIPTION
MIT has the same terms as BSD, but it is less ambiguous
compared to the 3+ variants of BSD.