### PR TITLE
 '^' used instead of '-'; negative indexing is obsolete

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -171,7 +171,7 @@ proc parseCmdLine(): Options =
           # Parse pkg@verRange
           if '@' in key:
             let i = find(key, '@')
-            let pkgTup = (key[0 .. i-1], key[i+1 .. -1].parseVersionRange())
+            let pkgTup = (key[0 .. i-1], key[i+1 .. ^1].parseVersionRange())
             result.action.packages.add(pkgTup)
           else:
             result.action.packages.add((key, VersionRange(kind: verAny)))

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -88,11 +88,11 @@ proc parseRequires(req: string): PkgTuple =
     if ' ' in req:
       var i = skipUntil(req, Whitespace)
       result.name = req[0 .. i].strip
-      result.ver = parseVersionRange(req[i .. -1])
+      result.ver = parseVersionRange(req[i .. ^1])
     elif '#' in req:
       var i = skipUntil(req, {'#'})
       result.name = req[0 .. i-1]
-      result.ver = parseVersionRange(req[i .. -1])
+      result.ver = parseVersionRange(req[i .. ^1])
     else:
       result.name = req.strip
       result.ver = VersionRange(kind: verAny)
@@ -201,7 +201,7 @@ proc requiredField(obj: JsonNode, name: string): string =
   ## Aborts execution if the field does not exist or is of invalid json type.
   result = optionalField(obj, name, nil)
   if result == nil:
-    raise newException(NimbleError, 
+    raise newException(NimbleError,
         "Package in packages.json file does not contain a " & name & " field.")
 
 proc fromJson(obj: JSonNode): Package =
@@ -297,7 +297,7 @@ proc findPkg*(pkglist: seq[tuple[pkginfo: PackageInfo, meta: MetaData]],
   ## packages are found the newest one is returned (the one with the highest
   ## version number)
   ##
-  ## **Note**: dep.name here could be a URL, hence the need for pkglist.meta. 
+  ## **Note**: dep.name here could be a URL, hence the need for pkglist.meta.
   for pkg in pkglist:
     if pkg.pkginfo.name.normalize != dep.name.normalize and
        pkg.meta.url.normalize != dep.name.normalize: continue
@@ -335,11 +335,11 @@ proc getNameVersion*(pkgpath: string): tuple[name, version: string] =
   if '-' notin tail:
     result.name = tail
     return
-  
+
   for i in countdown(tail.len-1, 0):
     if tail[i] == '-':
       result.name = tail[0 .. i-1]
-      result.version = tail[i+1 .. -1]
+      result.version = tail[i+1 .. ^1]
       break
 
 proc echoPackage*(pkg: Package) =

--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -9,7 +9,7 @@ proc doCmd*(cmd: string) =
   let bin = cmd.split(' ')[0]
   if findExe(bin) == "":
     raise newException(NimbleError, "'" & bin & "' not in PATH.")
-  
+
   # To keep output in sequence
   stdout.flushFile()
   stderr.flushFile()
@@ -53,7 +53,7 @@ proc samePaths*(p1, p2: string): bool =
   var cp2 = if not p2.endsWith("/"): p2 & "/" else: p2
   cp1 = cp1.replace('/', DirSep).replace('\\', DirSep)
   cp2 = cp2.replace('/', DirSep).replace('\\', DirSep)
-  
+
   return cmpPaths(cp1, cp2) == 0
 
 proc changeRoot*(origRoot, newRoot, path: string): string =
@@ -62,7 +62,7 @@ proc changeRoot*(origRoot, newRoot, path: string): string =
   ## path:     /home/dom/bar/blah/2/foo.txt
   ## Return value -> /home/test/bar/blah/2/foo.txt
   if path.startsWith(origRoot):
-    return newRoot / path[origRoot.len .. -1]
+    return newRoot / path[origRoot.len .. ^1]
   else:
     raise newException(ValueError,
       "Cannot change root of path: Path does not begin with original root.")
@@ -96,7 +96,7 @@ proc getDownloadDirName*(uri: string, verRange: VersionRange): string =
     of strutils.Letters, strutils.Digits:
       result.add i
     else: discard
-    
+
   let verSimple = getSimpleString(verRange)
   if verSimple != "":
     result.add "_"

--- a/src/nimblepkg/version.nim
+++ b/src/nimblepkg/version.nim
@@ -139,7 +139,7 @@ proc parseVersionRange*(s: string): VersionRange =
   new(result)
   if s[0] == '#':
     result.kind = verSpecial
-    result.spe = s[1 .. -1].Special
+    result.spe = s[1 .. ^1].Special
     return
 
   var i = 0
@@ -152,7 +152,7 @@ proc parseVersionRange*(s: string): VersionRange =
     of '&':
       result.kind = verIntersect
       result.verILeft = makeRange(version, op)
-      
+
       # Parse everything after &
       # Recursion <3
       result.verIRight = parseVersionRange(substr(s, i + 1))
@@ -162,7 +162,7 @@ proc parseVersionRange*(s: string): VersionRange =
       if result.verIRight.kind == verIntersect:
         raise newException(ParseVersionError,
             "Having more than one `&` in a version range is pointless")
-      
+
       break
 
     of '0'..'9', '.':
@@ -171,7 +171,7 @@ proc parseVersionRange*(s: string): VersionRange =
     of '\0':
       result = makeRange(version, op)
       break
-    
+
     of ' ':
       # Make sure '0.9 8.03' is not allowed.
       if version != "" and i < s.len:
@@ -282,7 +282,7 @@ when isMainModule:
   doAssert newSpecial("ab26saggdt362") == newSpecial("ab26saggdt362")
   doAssert newSpecial("head") == newSpecial("HEAD")
   doAssert newSpecial("head") == newSpecial("head")
-  
+
   var sp = parseVersionRange("#ab26sgdt362")
   doAssert newSpecial("ab26sgdt362") in sp
   doAssert newSpecial("ab26saggdt362") notin sp


### PR DESCRIPTION
	modified:   nimble.nim
	modified:   nimblepkg/download.nim
	modified:   nimblepkg/packageinfo.nim
	modified:   nimblepkg/tools.nim
	modified:   nimblepkg/version.nim