### PR TITLE
refactor

### DIFF
--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -18,39 +18,50 @@ proc initConfig(): Config =
 
   result.chcp = true
 
+proc parseConfigFile(confFile: string, curr: Config): Config =
+  result = curr # return same, but with overrides
+  var f = newFileStream(confFile, fmRead)
+  var p: CfgParser
+  open(p, f, confFile)
+  while true:
+    var e = next(p)
+    case e.kind
+    of cfgEof:
+      break
+    of cfgSectionStart: discard
+    of cfgKeyValuePair, cfgOption:
+      case e.key.normalize
+      of "nimbledir":
+        # Ensure we don't restore the deprecated nimble dir.
+        if e.value != getHomeDir() / ".babel":
+          result.nimbleDir = e.value
+      of "chcp":
+        result.chcp = parseBool(e.value)
+      else:
+        raise newException(NimbleError, "Unable to parse config file:" &
+                                    " Unknown key: " & e.key)
+    of cfgError:
+      raise newException(NimbleError, "Unable to parse config file: " & e.msg)
+  close(p)
+  close(f)
+
+proc readable(fname: string): bool =
+  # TODO: Make this simpler.
+  var f = newFileStream(fname, fmRead)
+  if f != nil:
+    result = true
+    close(f)
+
 proc parseConfig*(): Config =
   result = initConfig()
   var confFile = getConfigDir() / "nimble" / "nimble.ini"
 
-  var f = newFileStream(confFile, fmRead)
-  if f == nil:
+  if (not readable(confFile)):
     # Try the old deprecated babel.ini
     confFile = getConfigDir() / "babel" / "babel.ini"
-    f = newFileStream(confFile, fmRead)
-    if f != nil:
-      echo("[Warning] Using deprecated config file at ", confFile)
+    if (not readable(confFile)):
+      return
+    echo("[Warning] Using deprecated config file at ", confFile)
   
-  if f != nil:
-    echo("Reading from config file at ", confFile)
-    var p: CfgParser
-    open(p, f, confFile)
-    while true:
-      var e = next(p)
-      case e.kind
-      of cfgEof:
-        break
-      of cfgSectionStart: discard
-      of cfgKeyValuePair, cfgOption:
-        case e.key.normalize
-        of "nimbledir":
-          # Ensure we don't restore the deprecated nimble dir.
-          if e.value != getHomeDir() / ".babel":
-            result.nimbleDir = e.value
-        of "chcp":
-          result.chcp = parseBool(e.value)
-        else:
-          raise newException(NimbleError, "Unable to parse config file:" &
-                                     " Unknown key: " & e.key)
-      of cfgError:
-        raise newException(NimbleError, "Unable to parse config file: " & e.msg)
-    close(p)
+  echo("Reading from config file at ", confFile)
+  result = parseConfigFile(confFile, result)


### PR DESCRIPTION
This will eventually let us read multiple .ini files. Why? Because I also want to let the .ini define the URL for the origin of `nimbledata.json`. Then, that file can define a contour of a workspace. That would allow me to modify several open-source packages while I work on my own packages which use them. That way, **nimble** can support a workspace-based development model, something which **Go** build tools do well. (See #114 .)

TODO: a better implementation of `readable()`.