### PR TITLE
Fixed compilation

### DIFF
--- a/src/nimblepkg/nimscriptsupport.nim
+++ b/src/nimblepkg/nimscriptsupport.nim
@@ -12,7 +12,7 @@ import
 
 from compiler/scriptconfig import setupVM
 from compiler/idents import getIdent
-from compiler/astalgo import strTableGet, `$`
+from compiler/astalgo import strTableGet
 
 import nimbletypes, version
 import os, strutils


### PR DESCRIPTION
This fixed nimble compilation which otherwise fails with
```
nimblepkg/nimscriptsupport.nim(15, 43) Error: undeclared identifier: '$'
```