### PR TITLE
Updated README syntax

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -489,7 +489,7 @@ A package is automatically a binary package as soon as it sets at least one
 ``bin`` value, like so:
 
 ```ini
-bin = "main"
+bin = @["main"]
 ```
 
 In this case when ``nimble install`` is invoked, nimble will build the ``main.nim``

--- a/readme.markdown
+++ b/readme.markdown
@@ -489,7 +489,7 @@ A package is automatically a binary package as soon as it sets at least one
 ``bin`` value, like so:
 
 ```ini
-bin = @["main"]
+bin = "main" # NimScript config expects a seq instead, e.g. @["main"]
 ```
 
 In this case when ``nimble install`` is invoked, nimble will build the ``main.nim``


### PR DESCRIPTION
It appears the `bin` directive now expects a seq rather than a string. Otherwise I get this error:

> Error: type mismatch: got (string) but expected 'seq[string]'. [NimbleError]