### PR TITLE
Fix for the Bash completion on OSX.

### DIFF
--- a/nimble.bash-completion
+++ b/nimble.bash-completion
@@ -5,7 +5,10 @@ _nimble()
     local cur=${COMP_WORDS[COMP_CWORD]}
     local prev=${COMP_WORDS[COMP_CWORD-1]}
     COMPREPLY=()
-    _init_completion || return
+
+    if declare -F _init_completions >/dev/null 2>&1; then
+        _init_completion || return
+    fi
 
     case "$prev" in
     init|update|refresh|publish|search|build)


### PR DESCRIPTION
On OSX there is no `_init_completions` even if `brew install bash-completion` was installed. The fix is to not call it if it is not defined. IMHO it is never needed, but I may be wrong here.