### PR TITLE
This change sorts the list of the installed modules by name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ nimcache/
 /src/babel
 /src/nimble
 /tests/tester
+
+# executables from test and build
+/nimble
+/tests/nimscript/nimscript
+/tests/issue27/issue27

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -631,7 +631,7 @@ proc list(options: Options) =
     echo(" ")
 
 proc listInstalled(options: Options) =
-  var h = initTable[string, seq[string]]()
+  var h = initOrderedTable[string, seq[string]]()
   let pkgs = getInstalledPkgs(options.getPkgsDir(), options)
   for x in pkgs.items():
     let
@@ -641,6 +641,8 @@ proc listInstalled(options: Options) =
     var s = h[pName]
     add(s, pVer)
     h[pName] = s
+
+  h.sort(proc (a,b: auto): int = cmpIgnoreCase(a[0],b[0]))
   for k in keys(h):
     echo k & "  [" & h[k].join(", ") & "]"
 


### PR DESCRIPTION
I thought that it is easier to skim the installed modules if the list is sortet by package name.

P.S.: I also added some files to `.gitignore` not sure if that needs to be an extra PR.