### PR TITLE
Update packageinfo.nim

### DIFF
--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 import parsecfg, json, streams, strutils, parseutils, os, sets, tables
-import version, tools, nimbletypes, options
+import version, tools, nimbletypes, options, sequtils
 
 type
   Package* = object


### PR DESCRIPTION
#198
This fixes a problem I get compiling nimble "undeclared identifier 'map'".
Fixes bug(?) #198