### PR TITLE
Fixed permission issue when installing package

### DIFF
--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -70,7 +70,7 @@ proc changeRoot*(origRoot, newRoot, path: string): string =
 proc copyFileD*(fro, to: string): string =
   ## Returns the destination (``to``).
   echo(fro, " -> ", to)
-  copyFile(fro, to)
+  copyFileWithPermissions(fro, to)
   result = to
 
 proc copyDirD*(fro, to: string): seq[string] =


### PR DESCRIPTION
If there are executables in Git repo of the project with set FS permission bits, files must be copied via copyFileWithPermissions()