### PR TITLE
Documentation: Build release binary of nimble

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -48,7 +48,7 @@ the following commands to clone nimble, compile it and then install it.
     git clone https://github.com/nim-lang/nimble.git
     cd nimble
     git clone -b v0.13.0 --depth 1 https://github.com/nim-lang/nim vendor/nim
-    nim c -r src/nimble install
+    nim -d:release c -r src/nimble install
 
 After these steps are completed successfully, nimble will be installed
 in ``~/.nimble/bin``. You must then add
@@ -80,7 +80,7 @@ On Windows installing Nimble from source is slightly more complex:
 
     git clone https://github.com/nim-lang/nimble.git
     cd nimble
-    nim c src/nimble
+    nim -d:release c src/nimble
     cp src/nimble.exe src/nimble1.exe
     src/nimble1.exe install
 


### PR DESCRIPTION
This speeds up the building process by a factor of 2 because afterwards
nimble builds itself again, but using -d:release.