### PR TITLE
Fixed cygwin stub

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -439,7 +439,7 @@ proc installFromDir(dir: string, latest: bool, options: Options,
         # For bash on Windows (Cygwin/Git bash).
         let bashDest = dest.changeFileExt("")
         echo("Creating Cygwin stub: ", pkgDestDir / bin, " -> ", bashDest)
-        writeFile(bashDest, "\"" & pkgDestDir / bin & "\" \"$@\"\n")
+        writeFile(bashDest, "\"$(cygpath '" & pkgDestDir / bin & "')\" \"$@\"\l")
       else:
         {.error: "Sorry, your platform is not supported.".}
   else:


### PR DESCRIPTION
Fixed broken cygwin stub.
1. Use cygpath to convert windows path to unix path.
2. Use linefeed at the end. Cygwin doesnt like windows line endings.
before:
```
"C:\Users\boost\.nimble\pkgs\nimble-0.7.0\nimble.exe" "$@"
```
after:
```
"$(cygpath --unix 'C:\Users\boost\.nimble\pkgs\nimble-0.7.0\nimble.exe')" "$@"
```
