### PR TITLE
Package names are case insensitive (#190)

### DIFF
--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -142,7 +142,7 @@ proc getPackage*(pkg: string, options: Options,
     let packages = parseFile(options.getNimbleDir() /
         "packages_" & name.toLower() & ".json")
     for p in packages:
-      if p["name"].str == pkg:
+      if normalize(p["name"].str) == normalize(pkg):
         resPkg = p.fromJson()
         return true
 


### PR DESCRIPTION
Issue #190 says **style** insensitive, but the example only highlights case sensitivity. This is a fix for case sensitivity. Are package names meant to be style insensitive in the same way that identifiers are in the Nim language? If so, I can update the PR.