### PR TITLE
add critical install step to README

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -48,6 +48,7 @@ the following commands to clone nimble, compile it and then install it.
     git clone https://github.com/nim-lang/nimble.git
     cd nimble
     git clone -b v0.13.0 --depth 1 https://github.com/nim-lang/nim vendor/nim
+    ln -s vendor/nim/lib .
     nim -d:release c -r src/nimble install
 
 After these steps are completed successfully, nimble will be installed


### PR DESCRIPTION
Added critical unix/mac installation step to the readme github install instructions. Without it, the install fails on mac and unix.