### PR TITLE
Error: cannot open 'compiler/ast'

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -83,6 +83,7 @@ the following commands to clone nimble, compile it and then install it.
 
     git clone https://github.com/nim-lang/nimble.git
     cd nimble
+    git clone -b v0.14.2 --depth 1 https://github.com/nim-lang/nim vendor/nim
     nim -d:release c -r src/nimble -y install
 
 After these steps are completed successfully, nimble will be installed


### PR DESCRIPTION
In the commit e95df37ebedaf7b530df8c8153762f9f8e8b1992, the command `git clone -b v0.13.0 --depth 1 https://github.com/nim-lang/nim vendor/nim` was deleted from the readme. I can't install nimble on OpenBSD or Arch Linux without that command. The build process shows this error:
```
[...]
Hint: config [Processing]                                                                        
Hint: download [Processing]                                                                      
Hint: packageparser [Processing]                                                                 
Hint: nimscriptsupport [Processing]                                                              
/tmp/nimble/src/nimblepkg/nimscriptsupport.nim(8, 11) Error: cannot open 'compiler/ast'
```
This PR adds back the missing command to the readme with the version updated.