### PR TITLE
Add a postinstall hook

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -468,6 +468,14 @@ Similar to this an ``after`` block is also available for post hooks,
 which are executed after Nimble finished executing a command. You can
 also return ``false`` from these blocks to stop further execution.
 
+A ``postinstall`` block can be defined. This block will be executed after nimble
+has installed your package. Example:  
+
+```nim
+postinstall:
+  echo("Echo after installing")
+```
+
 The ``nimscriptapi.nim`` module specifies this and includes other definitions
 which are also useful. Take a look at it for more information.
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -454,7 +454,8 @@ proc installFromDir(dir: string, latest: bool, options: Options,
                                   pkgInfo)
   # If a post install hook is defined, run it
   if pkgInfo.postInstallHook.len>0 :
-    discard executePostInstall(pkgInfo.mypath,options)
+    discard executePostInstall(pkgDestDir / pkgInfo.mypath.extractFilename,options)
+
   # Save a nimblemeta.json file.
   saveNimbleMeta(pkgDestDir, url, filesInstalled)
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -452,7 +452,9 @@ proc installFromDir(dir: string, latest: bool, options: Options,
   else:
     filesInstalled = copyFilesRec(realDir, realDir, pkgDestDir, options,
                                   pkgInfo)
-
+  # If a post install hook is defined, run it
+  if pkgInfo.postInstallHook.len>0 :
+    discard executePostInstall(pkgInfo.mypath,options)
   # Save a nimblemeta.json file.
   saveNimbleMeta(pkgDestDir, url, filesInstalled)
 

--- a/src/nimblepkg/nimbletypes.nim
+++ b/src/nimblepkg/nimbletypes.nim
@@ -34,3 +34,4 @@ type
     binDir*: string
     srcDir*: string
     backend*: string
+    postInstallHook*: string # Execute a single hook after installing 

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -24,6 +24,11 @@ proc requires*(deps: varargs[string]) =
   ## package.
   for d in deps: requiresData.add(d)
 
+template postinstall*(body: untyped): untyped =
+  ## Defines a block of code which is evaluated after installing.
+  proc `installHook`*() =
+    body
+
 template before*(action: untyped, body: untyped): untyped =
   ## Defines a block of code which is evaluated before ``action`` is executed.
   proc `action Before`*(): bool =

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -27,8 +27,12 @@ proc requires*(deps: varargs[string]) =
 template postinstall*(body: untyped): untyped =
   ## Defines a block of code which is evaluated after installing.
   proc `installHook`*() =
-    body
-
+    let curDir = thisDir() # ensure postinstall runs in the install dir
+    try:
+      cd(curDir)
+      body
+    finally:
+      cd(curDir)
 template before*(action: untyped, body: untyped): untyped =
   ## Defines a block of code which is evaluated before ``action`` is executed.
   proc `action Before`*(): bool =

--- a/tests/nimscript/nimscript.nimble
+++ b/tests/nimscript/nimscript.nimble
@@ -41,4 +41,3 @@ task hooks2, "Testing the hooks again":
 
 postinstall:
   echo("Postinstall echoing")
-  writeFile("postinstalltest.txt","Postinstall dir")

--- a/tests/nimscript/nimscript.nimble
+++ b/tests/nimscript/nimscript.nimble
@@ -38,3 +38,6 @@ before hooks2:
 
 task hooks2, "Testing the hooks again":
   echo("Shouldn't happen")
+
+postinstall:
+  echo("Postinstall echoing")

--- a/tests/nimscript/nimscript.nimble
+++ b/tests/nimscript/nimscript.nimble
@@ -41,3 +41,4 @@ task hooks2, "Testing the hooks again":
 
 postinstall:
   echo("Postinstall echoing")
+  writeFile("postinstalltest.txt","Postinstall dir")

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -110,7 +110,7 @@ test "can use nimscript's setCommand with flags":
     let (output, exitCode) = execCmdEx("../" & path & " cr")
     let lines = output.strip.splitLines()
     check exitCode == QuitSuccess
-    check "Hint: operation successful".normalize in lines[^2].normalize
+    check "Hint: operation successful".normalize in lines[^3].normalize
     check "Hello World".normalize in lines[^1].normalize
 
 test "can list nimscript tasks":

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -84,6 +84,13 @@ test "can install nimscript package":
   cd "nimscript":
     check execCmdEx("../" & path & " install -y").exitCode == QuitSuccess
 
+test "can execute postinstall hook":
+  cd "nimscript":
+    let (output, exitCode) = execCmdEx("../" & path & " install -y")
+    let lines = output.strip.splitLines()
+    check exitCode == QuitSuccess
+    check lines[^2] == "Postinstall echoing"
+
 test "can execute nimscript tasks":
   cd "nimscript":
     let (output, exitCode) = execCmdEx("../" & path & " test")


### PR DESCRIPTION
Adds the possibility to run a hook when nimble installs a package.
The hook is set by adding a block in the `.nimble` file:
```nim
postinstall:
  echo "Post install hook"
```
This is useful for example when installing packages that use [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) or when a binary needs to register with application, run tests on install, run custom scripts etc.

I used execTask as a base and modified it to run the hook, so this may not be the best/cleanest way of implementing. Any feedback is appreciated.