### PR TITLE
Add binDir checking/auto creation.  Fixes #215

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -313,6 +313,11 @@ proc buildFromDir(pkgInfo: PackageInfo, paths: seq[string], forRelease: bool) =
     let outputOpt = "-o:\"" & pkgInfo.getOutputDir(bin) & "\""
     echo("Building ", pkginfo.name, "/", bin, " using ", pkgInfo.backend,
          " backend...")
+
+    let outputDir = pkgInfo.getOutputDir("")
+    if not existsDir(outputDir):
+      createDir(outputDir)
+
     try:
       doCmd(getNimBin() & " $# $# --noBabelPath $# $# \"$#\"" %
             [pkgInfo.backend, releaseOpt, args, outputOpt,


### PR DESCRIPTION
FWIW: I think perhaps pkgInfo.getOutputDir could use a renaming as it seems to return the output path (including the binary) rather than the output directory.  Could also be that I misunderstand the use of that function though.