### PR TITLE
Fix issues with spaces in bin path

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -317,7 +317,7 @@ proc buildFromDir(pkgInfo: PackageInfo, paths: seq[string], forRelease: bool) =
       createDir(outputDir)
 
     try:
-      doCmd(getNimBin() & " $# $# --noBabelPath $# $# \"$#\"" %
+      doCmd("\"" & getNimBin() & "\" $# $# --noBabelPath $# $# \"$#\"" %
             [pkgInfo.backend, releaseOpt, args, outputOpt,
              realDir / bin.changeFileExt("nim")])
     except NimbleError:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -628,7 +628,7 @@ proc compile(options: Options) =
 
   echo("Compiling ", bin, " (", pkgInfo.name, ") using ", backend,
        " backend...")
-  doCmd(getNimBin() & " $# --noBabelPath $# \"$#\"" %
+  doCmd("\"" & getNimBin() & "\" $# --noBabelPath $# \"$#\"" %
         [backend, args, bin])
 
 proc search(options: Options) =


### PR DESCRIPTION
'build' and 'compile' commands would fail on windows when the nim binary path contained spaces.

Hopefully this doesn't any other systems

As per https://github.com/nim-lang/nimble/issues/266