### PR TITLE
Change the way `dump` locates the project file

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -74,7 +74,10 @@ Commands:
   path         pkgname ...        Shows absolute path to the installed packages
                                   specified.
   dump         [pkgname]          Outputs Nimble package information for
-                                  external tools.
+                                  external tools. The argument can be a
+                                  .nimble file, a project directory or
+                                  the name of an installed package.
+
 
 Options:
   -h, --help                      Print this help message.

--- a/tests/testdump/testdump.nimble
+++ b/tests/testdump/testdump.nimble
@@ -1,0 +1,4 @@
+description = "Test package for dump command"
+version = "0.1.0"
+author = "nigredo-tori"
+license = "BSD"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -299,3 +299,31 @@ test "can uninstall":
   check(not dirExists(installDir / "pkgs" / "PackageA-0.2.0"))
 
   check execNimble("uninstall", "-y", "nimscript").exitCode == QuitSuccess
+
+test "can dump for current project":
+  cd "testdump":
+    let (outp, exitCode) = execNimble("dump")
+    check: exitCode == 0
+    check: outp.processOutput.inLines("desc: \"Test package for dump command\"")
+
+test "can dump for project directory":
+  let (outp, exitCode) = execNimble("dump", "testdump")
+  check: exitCode == 0
+  check: outp.processOutput.inLines("desc: \"Test package for dump command\"")
+
+test "can dump for project file":
+  let (outp, exitCode) = execNimble("dump", "testdump" / "testdump.nimble")
+  check: exitCode == 0
+  check: outp.processOutput.inLines("desc: \"Test package for dump command\"")
+
+test "can dump for installed package":
+  cd "testdump":
+    check: execNimble("install", "-y").exitCode == 0
+  defer:
+    discard execNimble("remove", "-y", "testdump")
+
+  # Otherwise we might find subdirectory instead
+  cd "..":
+    let (outp, exitCode) = execNimble("dump", "testdump")
+    check: exitCode == 0
+    check: outp.processOutput.inLines("desc: \"Test package for dump command\"")


### PR DESCRIPTION
- Look in current directory (only if no argument is present).
- If the argument is a path to a project file - use it.
- If the argument is a path to a directory - try to find a project file there.
- Try to interpret the argument as the name of an installed package.

Fixes #291