### PR TITLE
Remove quotes around "test"

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -464,7 +464,7 @@ To make testing even more convenient, you may wish to define a ``test`` task
 in your ``.nimble`` file. Like so:
 
 ```nim
-task "test", "Runs the test suite":
+task test, "Runs the test suite":
   exec "nim c -r tests/tester"
 ```
 


### PR DESCRIPTION
The example for adding a test section uses quotes around the
test target, "test".

However, this doesn't work, as it's not a valid identifier and
nimble package builds fail with:

    Error: identifier expected, but found '`"test" Task`'.

Remove the quotes in the example.