### PR TITLE
updating git command to fetch the url of the remote origin

### DIFF
--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -122,7 +122,7 @@ proc editJson(p: PackageInfo; url, tags, downloadMethod: string) =
 proc getPackageOriginUrl(a: Auth): string =
   ## Adds 'user:pw' to the URL so that the user is not asked *again* for it.
   ## We need this for 'git push'.
-  let (output, exitCode) = doCmdEx("git config --get remote.origin.url")
+  let (output, exitCode) = doCmdEx("git ls-remote --get-url")
   result = "origin"
   if exitCode == 0:
     result = output.string.strip


### PR DESCRIPTION
this changes the command from querying the git config to using `ls-remote --get-url` for when the `git config` command fails to return any data. There should be some more hardening of this code from errors due to a potential crash if this command exits with a non-zero code (the `url` variable never gets set and this results in a failure in the `uri` module when it attempts to parse the string `"ssh://"`.