### PR TITLE
Add credential caching

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1028,7 +1028,7 @@ proc doAction(options: Options) =
     init(options)
   of actionPublish:
     var pkgInfo = getPkgInfo(getCurrentDir(), options)
-    publish(pkgInfo)
+    publish(pkgInfo, options)
   of actionDump:
     dump(options)
   of actionTasks:


### PR DESCRIPTION
This change stores the user's github API token in ~/.nimble/api_token for
ease of publishing.

closes https://github.com/nim-lang/nimble/issues/307