### PR TITLE
Access GitHub API token through environment variable

### DIFF
--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -51,6 +51,9 @@ proc getGithubAuth(cfg: Config): Auth =
   # always prefer the environment variable to asking for a new one
   if existsEnv(ApiTokenEnvironmentVariable):
     result.token = getEnv(ApiTokenEnvironmentVariable)
+    display("Info:", "Using the '" & ApiTokenEnvironmentVariable & 
+            "' environment varaible for the GitHub API Token.",
+            priority = HighPriority)
   else:
     # try to read from disk, if it cannot be found write a new one
     try:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -43,6 +43,7 @@ proc requestNewToken(cfg: Config): string =
   display("Info:", "Writing access token to file:" & token_write_path, 
           priority = HighPriority)
   writeFile(token_write_path, token)
+  sleep(3000)
   return token
 
 proc getGithubAuth(cfg: Config): Auth =

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -39,10 +39,10 @@ proc requestNewToken(cfg: Config): string =
   openDefaultBrowser("https://github.com/settings/tokens/new")
   let token = promptCustom("Personal access token?", "").strip()
   # inform the user that their token will be written to disk
-  let token_write_path = cfg.nimbleDir / ApiKeyFile
-  display("Info:", "Writing access token to file:" & token_write_path, 
+  let tokenWritePath = cfg.nimbleDir / ApiKeyFile
+  display("Info:", "Writing access token to file:" & tokenWritePath, 
           priority = HighPriority)
-  writeFile(token_write_path, token)
+  writeFile(tokenWritePath, token)
   sleep(3000)
   return token
 
@@ -57,9 +57,9 @@ proc getGithubAuth(cfg: Config): Auth =
   else:
     # try to read from disk, if it cannot be found write a new one
     try:
-      let api_token_file_path = cfg.nimbleDir / ApiKeyFile
-      result.token = readFile(api_token_file_path)
-      display("Info:", "Using GitHub API Token in file: " & api_token_file_path,
+      let apiTokenFilePath = cfg.nimbleDir / ApiKeyFile
+      result.token = readFile(apiTokenFilePath)
+      display("Info:", "Using GitHub API Token in file: " & apiTokenFilePath,
               priority = HighPriority)
     except IOError:
       result.token = requestNewToken(cfg)

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -52,12 +52,15 @@ proc getGithubAuth(cfg: Config): Auth =
   if existsEnv(ApiTokenEnvironmentVariable):
     result.token = getEnv(ApiTokenEnvironmentVariable)
     display("Info:", "Using the '" & ApiTokenEnvironmentVariable & 
-            "' environment varaible for the GitHub API Token.",
+            "' environment variable for the GitHub API Token.",
             priority = HighPriority)
   else:
     # try to read from disk, if it cannot be found write a new one
     try:
-      result.token = readFile(cfg.nimbleDir / ApiKeyFile)
+      let api_token_file_path = cfg.nimbleDir / ApiKeyFile
+      result.token = readFile(api_token_file_path)
+      display("Info:", "Using GitHub API Token in file: " & api_token_file_path,
+              priority = HighPriority)
     except IOError:
       result.token = requestNewToken(cfg)
 


### PR DESCRIPTION
This adds functionality to default to using an environment variable for getting the user's GitHub API Token through an environment variable as a higher preference than one written to disk. It also adds an additional line of displayed text to inform the user that their access token will be written to disk (and includes the location of that file). 

While i think the ability to reuse the access token (rather than request a new one each time) is great, the implementation caught me off guard with leaking this to disk without informing the user of it happening. This changeset preserves the existing behavior but uses it as a fall-back to a more standard approach to providing access to api tokens/secrets.