### PR TITLE
Fixed https://github.com/nim-lang/nimble/issues/339

### DIFF
--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -52,6 +52,10 @@ test "can distinguish package reading in nimbleDir vs. other dirs (#304)":
   cd "issue304" / "package-test":
     check execNimble("tasks").exitCode == QuitSuccess
 
+test "can accept short flags (#329)":
+  cd "nimscript":
+    check execNimble("c", "-d:release", "nimscript.nim").exitCode == QuitSuccess
+
 test "can build with #head and versioned package (#289)":
   cd "issue289":
     check execNimble(["install", "-y"]).exitCode == QuitSuccess


### PR DESCRIPTION
I had to dispatch by action first, in order to handle both the case where `-d` is an alias for `depsonly` and the case where `-d` should be passed to the nim compiler. In general it makes more sense to handle aciton specific flags after having found which action we are in