### PR TITLE
Modifying how package install path is validated

### DIFF
--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -79,7 +79,14 @@ proc changeRoot*(origRoot, newRoot, path: string): string =
   ## newRoot:  /home/test/
   ## path:     /home/dom/bar/blah/2/foo.txt
   ## Return value -> /home/test/bar/blah/2/foo.txt
-  if path.startsWith(origRoot):
+
+  ## The additional check of `path.samePaths(origRoot)` is necessary to prevent 
+  ## a regression, where by ending the `srcDir` defintion in a nimble file in a 
+  ## trailing separator would cause the `path.startsWith(origRoot)` evaluation to
+  ## fail because of the value of `origRoot` would be longer than `path` due to 
+  ## the trailing separator. This would cause this method to throw during package
+  ## installation.
+  if path.startsWith(origRoot) or path.samePaths(origRoot):
     return newRoot / path[origRoot.len .. path.len-1]
   else:
     raise newException(ValueError,

--- a/tests/issue338/issue338.nimble
+++ b/tests/issue338/issue338.nimble
@@ -1,0 +1,7 @@
+# Package
+version = "0.1.0"
+author = "Samantha Marshall"
+description = "test case to validate successful install when `srcDir` value ends in a directory separator"
+license = "MIT"
+
+srcDir = "src/"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -286,6 +286,10 @@ test "issue #206":
     (output, exitCode) = execNimble("install", "-y")
     check exitCode == QuitSuccess
 
+test "issue #338":
+  cd "issue338":
+    check execNimble("install", "-y").exitCode == QuitSuccess
+
 test "can list":
   check execNimble("list").exitCode == QuitSuccess
 


### PR DESCRIPTION
Fix:
  * This addresses a bug where nimble will throw an exception in the middle of installation due to trying to evaluate paths that are not normalized. This was fixed by adding some additional validation checks that involve comparing paths by normalizing them first. [#338]