### PR TITLE
Add test target

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -673,6 +673,28 @@ proc execBackend(options: Options) =
         [backend, args, bin], showOutput = true)
   display("Success:", "Execution finished", Success, HighPriority)
 
+proc tempOutArg(file: string): string =
+  ## Returns the `--out` argument to pass to the compiler, using a temp file
+  let (_, name, _) = splitFile(file)
+  let dir = getNimbleTempDir() / "tests"
+  createDir(dir)
+  result = "--out:" & (dir / name)
+
+proc test(options: Options) =
+  ## Executes all tests
+  var files = toSeq(walkDir(getCurrentDir() / "tests"))
+  files.sort do (a, b: auto) -> int:
+    result = cmp(a.path, b.path)
+
+  for file in files:
+    if file.path.endsWith(".nim") and file.kind in { pcFile, pcLinkToFile }:
+      var optsCopy = options
+      optsCopy.action.file = file.path
+      optsCopy.action.backend = "c -r"
+      optsCopy.action.compileOptions.add("--path:.")
+      optsCopy.action.compileOptions.add(file.path.tempOutArg)
+      execBackend(optsCopy)
+
 proc search(options: Options) =
   ## Searches for matches in ``options.action.search``.
   ##
@@ -1030,6 +1052,8 @@ proc doAction(options: Options) =
     listPaths(options)
   of actionBuild:
     build(options)
+  of actionTest:
+    test(options)
   of actionCompile, actionDoc:
     execBackend(options)
   of actionInit:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -25,7 +25,7 @@ type
   ActionType* = enum
     actionNil, actionRefresh, actionInit, actionDump, actionPublish,
     actionInstall, actionSearch,
-    actionList, actionBuild, actionPath, actionUninstall, actionCompile,
+    actionList, actionBuild, actionTest, actionPath, actionUninstall, actionCompile,
     actionDoc, actionCustom, actionTasks
 
   Action* = object
@@ -39,7 +39,7 @@ type
       search*: seq[string] # Search string.
     of actionInit, actionDump:
       projName*: string
-    of actionCompile, actionDoc, actionBuild:
+    of actionCompile, actionDoc, actionBuild, actionTest:
       file*: string
       backend*: string
       compileOptions*: seq[string]
@@ -63,6 +63,7 @@ Commands:
   build                           Builds a package.
   c, cc, js    [opts, ...] f.nim  Builds a file inside a package. Passes options
                                   to the Nim compiler.
+  test                            Compiles and executes tests
   doc, doc2    [opts, ...] f.nim  Builds documentation for a file inside a
                                   package. Passes options to the Nim compiler.
   refresh      [url]              Refreshes the package list. A package list URL
@@ -117,6 +118,8 @@ proc parseActionType*(action: string): ActionType =
     result = actionPath
   of "build":
     result = actionBuild
+  of "test":
+    result = actionTest
   of "c", "compile", "js", "cpp", "cc":
     result = actionCompile
   of "doc", "doc2":
@@ -147,7 +150,7 @@ proc initAction*(options: var Options, key: string) =
   case options.action.typ
   of actionInstall, actionPath:
     options.action.packages = @[]
-  of actionCompile, actionDoc, actionBuild:
+  of actionCompile, actionDoc, actionBuild, actionTest:
     options.action.compileOptions = @[]
     options.action.file = ""
     if keyNorm == "c" or keyNorm == "compile": options.action.backend = ""
@@ -231,7 +234,7 @@ proc parseArgument*(key: string, result: var Options) =
     result.action.projName = key
   of actionCompile, actionDoc:
     result.action.file = key
-  of actionList, actionBuild, actionPublish:
+  of actionList, actionBuild, actionTest, actionPublish:
     result.showHelp = true
   of actionCustom:
     result.action.arguments.add(key)
@@ -269,7 +272,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
         result.depsOnly = true
       else:
         wasFlagHandled = false
-    of actionCompile, actionDoc, actionBuild:
+    of actionCompile, actionDoc, actionBuild, actionTest:
       let prefix = if kind == cmdShortOption: "-" else: "--"
       if val == "":
         result.action.compileOptions.add(prefix & flag)

--- a/tests/nimscript/nimscript.nimble
+++ b/tests/nimscript/nimscript.nimble
@@ -11,7 +11,7 @@ bin = @["nimscript"]
 
 requires "nim >= 0.12.1"
 
-task test, "test description":
+task work, "test description":
   echo(5+5)
 
 task c_test, "Testing `setCommand \"c\", \"nimscript.nim\"`":

--- a/tests/testsFail/testing123.nim
+++ b/tests/testsFail/testing123.nim
@@ -1,0 +1,4 @@
+
+proc myFunc*() =
+    echo "Executing my func"
+

--- a/tests/testsFail/testing123.nimble
+++ b/tests/testsFail/testing123.nimble
@@ -1,0 +1,4 @@
+version       = "0.1.0"
+author        = "John Doe"
+description   = "Nimble Test"
+license       = "BSD"

--- a/tests/testsFail/tests/a.nim
+++ b/tests/testsFail/tests/a.nim
@@ -1,0 +1,6 @@
+import testing123, unittest
+
+test "can compile nimble":
+  echo "First test"
+  myFunc()
+

--- a/tests/testsFail/tests/b.nim
+++ b/tests/testsFail/tests/b.nim
@@ -1,0 +1,6 @@
+import testing123, unittest
+
+test "can compile nimble":
+  echo "Failing Second test"
+  assert(false)
+

--- a/tests/testsFail/tests/c.nim
+++ b/tests/testsFail/tests/c.nim
@@ -1,0 +1,7 @@
+import testing123, unittest
+
+test "can compile nimble":
+  echo "Third test"
+  myFunc()
+
+

--- a/tests/testsPass/testing123.nim
+++ b/tests/testsPass/testing123.nim
@@ -1,0 +1,4 @@
+
+proc myFunc*() =
+    echo "Executing my func"
+

--- a/tests/testsPass/testing123.nimble
+++ b/tests/testsPass/testing123.nimble
@@ -1,0 +1,4 @@
+version       = "0.1.0"
+author        = "John Doe"
+description   = "Nimble Test"
+license       = "BSD"

--- a/tests/testsPass/tests/one.nim
+++ b/tests/testsPass/tests/one.nim
@@ -1,0 +1,6 @@
+import testing123, unittest
+
+test "can compile nimble":
+  echo "First test"
+  myFunc()
+

--- a/tests/testsPass/tests/three.nim
+++ b/tests/testsPass/tests/three.nim
@@ -1,0 +1,7 @@
+import testing123, unittest
+
+test "can compile nimble":
+  echo "Third test"
+  myFunc()
+
+

--- a/tests/testsPass/tests/two.nim
+++ b/tests/testsPass/tests/two.nim
@@ -1,0 +1,7 @@
+import testing123, unittest
+
+test "can compile nimble":
+  echo "Second test"
+  myFunc()
+
+


### PR DESCRIPTION
As you can likely guess, this adds `nimble test` as a target. This target iterates through all the nim files in the `tests` directory and executes them. If any fail, the target fails.

My only concern with this change is that there are quite a few packages that have defined a custom `test` target of their own. In fact, `nimble` itself is one of them. By defining _this_ test target, any custom defined targets will cease running. However, a quick scan through Github shows that quite a bit are doing exactly what this change implements.

One option I considered to assuage this behavior is by allowing custom targets to override default targets. But this is a bigger change that I thought best discussed before being implemented.