### PR TITLE
Added better url detection to publish

### DIFF
--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -206,7 +206,7 @@ proc publish*(p: PackageInfo, o: Options) =
     if parsed.scheme == "":
       # Assuming that we got an ssh write/read URL.
       let sshUrl = parseUri("ssh://" & url)
-      url = "https://github.com/" & sshUrl.port & sshUrl.path
+      url = "https://" & sshUrl.hostname & "/" & sshUrl.port & sshUrl.path
   elif dirExists(os.getCurrentDir() / ".hg"):
     downloadMethod = "hg"
     # TODO: Retrieve URL from hg.


### PR DESCRIPTION
Publish will now look at the hostname part of the ssh url to figure out
what git server to use. This definitely works with both github and
gitlab, and adds gitlab support to `nimble publish`.