### PR TITLE
Tests for the existence of project.nim file

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -498,12 +498,15 @@ proc build(options: Options) =
   buildFromDir(pkgInfo, paths, args)
 
 proc execBackend(options: Options) =
-  let bin = options.action.file
+  let
+    bin = options.action.file
+    binDotNim = bin.addFileExt("nim")
   if bin == "":
     raise newException(NimbleError, "You need to specify a file.")
 
-  if not fileExists(bin):
-    raise newException(NimbleError, "Specified file does not exist.")
+  if not (fileExists(bin) or fileExists(binDotNim)):
+    raise newException(NimbleError,
+      "Specified file, " & bin & " or " & binDotNim & ", does not exist.")
 
   var pkgInfo = getPkgInfo(getCurrentDir(), options)
   nimScriptHint(pkgInfo)


### PR DESCRIPTION
Matches nim's command line handling of 'nim c project'
The error message also states the files being tested.

This is not really essential, but I was confused by the error for a while, because I had trouble figuring out what the "Specified file" is.

If you decide not to permit the possible omission of the extension, ".nim", perhaps it is better to change the exception message such that it mentions the name.