### PR TITLE
Terminate copy iteration when hitting in-place nimbleDir

### DIFF
--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -510,13 +510,13 @@ proc iterInstallFiles*(realDir: string, pkgInfo: PackageInfo,
     for kind, file in walkDir(realDir):
       if kind == pcDir:
         let skip = pkgInfo.checkInstallDir(realDir, file)
-
         if skip: continue
+        # we also have to stop recursing if we reach an in-place nimbleDir
+        if file == options.getNimbleDir().expandFilename(): continue
 
         iterInstallFiles(file, pkgInfo, options, action)
       else:
         let skip = pkgInfo.checkInstallFile(realDir, file)
-
         if skip: continue
 
         action(file)

--- a/tests/issue428/dummy.nimble
+++ b/tests/issue428/dummy.nimble
@@ -1,0 +1,10 @@
+# Package
+
+version       = "0.1.0"
+author        = "Author"
+description   = "dummy"
+license       = "MIT"
+
+# Dependencies
+
+requires "nim >= 0.17.3"

--- a/tests/issue428/dummy.nimble
+++ b/tests/issue428/dummy.nimble
@@ -7,4 +7,4 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.17.3"
+requires "nim >= 0.17.0"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -354,6 +354,12 @@ test "issue #338":
   cd "issue338":
     check execNimble("install", "-y").exitCode == QuitSuccess
 
+test "issue #428":
+  cd "issue428":
+    # Note: Can't use execNimble because it patches nimbleDir
+    check execCmdEx(nimblePath & " -y --nimbleDir=./nimbleDir install").exitCode == QuitSuccess
+    check dirExists("nimbleDir/pkgs/dummy-0.1.0")
+
 test "can list":
   check execNimble("list").exitCode == QuitSuccess
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -359,9 +359,8 @@ test "issue #428":
     # Note: Can't use execNimble because it patches nimbleDir
     check execCmdEx(nimblePath & " -y --nimbleDir=./nimbleDir install").exitCode == QuitSuccess
     discard execShellCmd("pwd")
-    discard execShellCmd("ls -l")
     discard execShellCmd("ls -l nimbleDir")
-    discard execShellCmd("ls -l ..")
+    discard execShellCmd("ls -l nimbleDir/pkgs")
     check dirExists("nimbleDir/pkgs/dummy-0.1.0")
 
 test "can list":

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -358,11 +358,8 @@ test "issue #428":
   cd "issue428":
     # Note: Can't use execNimble because it patches nimbleDir
     check execCmdEx(nimblePath & " -y --nimbleDir=./nimbleDir install").exitCode == QuitSuccess
-    discard execShellCmd(nimblePath & " -y --nimbleDir=./nimbleDir install")
-    discard execShellCmd("pwd")
-    discard execShellCmd("ls -l nimbleDir")
-    discard execShellCmd("ls -l nimbleDir/pkgs")
     check dirExists("nimbleDir/pkgs/dummy-0.1.0")
+    check(not dirExists("nimbleDir/pkgs/dummy-0.1.0/nimbleDir"))
 
 test "can list":
   check execNimble("list").exitCode == QuitSuccess

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -358,6 +358,7 @@ test "issue #428":
   cd "issue428":
     # Note: Can't use execNimble because it patches nimbleDir
     check execCmdEx(nimblePath & " -y --nimbleDir=./nimbleDir install").exitCode == QuitSuccess
+    discard execShellCmd(nimblePath & " -y --nimbleDir=./nimbleDir install")
     discard execShellCmd("pwd")
     discard execShellCmd("ls -l nimbleDir")
     discard execShellCmd("ls -l nimbleDir/pkgs")

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -358,6 +358,10 @@ test "issue #428":
   cd "issue428":
     # Note: Can't use execNimble because it patches nimbleDir
     check execCmdEx(nimblePath & " -y --nimbleDir=./nimbleDir install").exitCode == QuitSuccess
+    discard execShellCmd("pwd")
+    discard execShellCmd("ls -l")
+    discard execShellCmd("ls -l nimbleDir")
+    discard execShellCmd("ls -l ..")
     check dirExists("nimbleDir/pkgs/dummy-0.1.0")
 
 test "can list":


### PR DESCRIPTION
I think the problem I observed in #428 has nothing to do with the directory name itself. The behavior was just a coincidence of the order `walkFiles` works. The real issue is probably that the iteration does not terminate when the `nimbleDir` is part of the directory to be installed.