### PR TITLE
Make nimble init create a package without prompting unless --prompt is provided

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -290,11 +290,14 @@ which can be useful to read the bundled documentation. Example:
 
 ### nimble init
 
-The nimble ``init`` command will start a simple wizard which will create
-a quick ``.nimble`` file for your project.
+The nimble ``init`` command will quickly create a ready to use nimble package.
 
 As of version 0.7.0, the ``.nimble`` file that this command creates will
 use the new NimScript format.
+
+Also, version 0.8.9 nimble and later no longer prompts the user for information
+by default.
+
 Check out the [Creating Packages](#creating-packages) section for more info.
 
 ### nimble publish
@@ -374,9 +377,12 @@ These files specify information about the package including its author,
 license, dependencies and more. Without one, Nimble is not able to install
 a package.
 
-A .nimble file can be created easily using Nimble's ``init`` command. This
-command will ask you a bunch of questions about your package, then generate a
-.nimble file for you.
+In order to easily create a valid Nimble package you can use use Nimble's
+``init`` command. This command will generate a package for you with a
+``.nimble`` file, along with a nice initial package structure. If you would like
+more control over the process you can provide the ``--prompt`` flag and nimble
+will ask you questions about your package and proceed to create your new
+package.
 
 A bare minimum .nimble file follows:
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -698,6 +698,10 @@ proc init(options: Options) =
        "In order to initialise a new Nimble package, I will need to ask you\n" &
        "some questions. Default values are shown in square brackets, press\n" &
        "enter to use them.", priority = HighPriority)
+  else:
+    # NOTE: This message will probably needs to be removed in a future version.
+    display("Hint:", "Nimble no longer prompts by default. See --help for info",
+      priority = HighPriority)
 
   # Ask for package name.
   let pkgName = hideablePrompt(options.showPrompt, "Package name?",

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -160,6 +160,15 @@ proc promptCustom*(question, default: string): string =
     if user == "": return default
     else: return user
 
+proc hideablePrompt*(show: bool, question, default: string;
+  alternate: string = ""): string =
+  return if show:
+      promptCustom(question, default)
+    elif not isNilOrEmpty(alternate):
+      alternate
+    else:
+      default
+
 proc setVerbosity*(level: Priority) =
   globalCLI.level = level
 

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -20,6 +20,7 @@ type
     pkgInfoCache*: TableRef[string, PackageInfo]
     showHelp*: bool
     showVersion*: bool
+    showPrompt*: bool
     noColor*: bool
     disableValidation*: bool
 
@@ -174,6 +175,7 @@ proc initAction*(options: var Options, key: string) =
     else: options.action.backend = keyNorm
   of actionInit:
     options.action.projName = ""
+    options.showPrompt = false
   of actionDump:
     options.action.projName = ""
   of actionRefresh:
@@ -280,6 +282,19 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
         result.queryInstalled = true
       of "ver":
         result.queryVersions = true
+      else:
+        wasFlagHandled = false
+    of actionInit:
+      case f
+      of "prompt":
+        case val
+        of "on":
+          result.showPrompt = true
+        of "off":
+          result.showPrompt = false
+        of nil, "":
+          result.showPrompt = true
+        else: discard
       else:
         wasFlagHandled = false
     of actionInstall:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -63,7 +63,8 @@ Commands:
                                   in the current working directory.
   check                           Verifies the validity of a package in the
                                   current working directory.
-  init         [pkgname]          Initializes a new Nimble project.
+  init         [pkgname]          Initializes a new Nimble project. To restore
+                                  old behavior use --prompt.
   publish                         Publishes a package on nim-lang/packages.
                                   The current working directory needs to be the
                                   toplevel directory of the Nimble package.
@@ -103,6 +104,8 @@ Options:
       --verbose                   Show all non-debug output.
       --debug                     Show all output including debug messages.
       --noColor                   Don't colorise output.
+      --prompt:on|off             Show or hide prompts when initializing a
+                                  package. --prompt is the same as --prompt:on.
 
 For more information read the Github readme:
   https://github.com/nim-lang/nimble#readme


### PR DESCRIPTION
My attempt at implementing #288. Let me know if there's anything you'd like changed.