### PR TITLE
Reuse -y to mean accept defaults for init command for #288

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -760,6 +760,8 @@ proc init(options: Options) =
     $nimDepDef)
   validateVersion(pkgNimDep)
 
+  let pkgTestDir = "tests"
+
   # Create source directory
   os.createDir(pkgSrcDir)
 
@@ -770,8 +772,26 @@ proc init(options: Options) =
   cd pkgSrcDir:
     pkgName.changeFileExt("nim").writeContents "echo \"Hello, World!\"\n"
 
-  display("Success:", "Created initial source file successfully", Success,
+    display("Success:", "Created initial source file successfully", Success,
+      MediumPriority)
+
+  # Create test directory
+  os.createDir(pkgTestDir)
+
+  display("Success:", "Test directory created successfully", Success,
     MediumPriority)
+
+  cd pkgTestDir:
+    "tester.nims".writeContents("""switch("path", "$$projectDir/../$#")""" %
+      [pkgSrcDir])
+
+    display("Success:", "Test config file created successfully", Success,
+      MediumPriority)
+
+    "tester.nim".writeContents("doAssert(1 + 1 == 2)\n")
+
+    display("Success:", "Test file created successfully", Success,
+      MediumPriority)
 
   # Write the nimble file
   nimbleFile.writeContents """# Package

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -714,21 +714,27 @@ proc init(options: Options) =
   display("Using", "$# for new package name" % [pkgName.escape()],
     priority = HighPriority)
 
+  # Ask for package author
+  proc getAuthor(): string =
+    if findExe("git") != "":
+      let (name, exitCode) = doCmdEx("git config --global user.name")
+      if exitCode == QuitSuccess and name.len > 0:
+        result = name.strip()
+        display("Using", "$# for new package author" % [result.escape()],
+          priority = HighPriority)
+    elif findExe("hg") != "":
+      let (name, exitCode) = doCmdEx("hg config ui.username")
+      if exitCode == QuitSuccess and name.len > 0:
+        result = name.strip()
+        display("Using", "$# for new package author" % [result.escape()],
+          priority = HighPriority)
+    else:
+      result = promptCustom(options, "Your name?", "Anonymous")
+  let pkgAuthor = getAuthor()
+
   # Ask for package version.
   let pkgVersion = promptCustom(options, "Initial version of package?", "0.1.0")
   validateVersion(pkgVersion)
-
-  # Ask for package author
-  var defaultAuthor = "Anonymous"
-  if findExe("git") != "":
-    let (name, exitCode) = doCmdEx("git config --global user.name")
-    if exitCode == QuitSuccess and name.len > 0:
-      defaultAuthor = name.strip()
-  elif defaultAuthor == "Anonymous" and findExe("hg") != "":
-    let (name, exitCode) = doCmdEx("hg config ui.username")
-    if exitCode == QuitSuccess and name.len > 0:
-      defaultAuthor = name.strip()
-  let pkgAuthor = promptCustom(options, "Your name?", defaultAuthor)
 
   # Ask for description
   let pkgDesc = promptCustom(options, "Package description?",

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -693,10 +693,11 @@ proc dump(options: Options) =
 proc init(options: Options) =
   var nimbleFile: string = ""
 
-  display("Info:",
-       "In order to initialise a new Nimble package, I will need to ask you\n" &
-       "some questions. Default values are shown in square brackets, press\n" &
-       "enter to use them.", priority = HighPriority)
+  if options.forcePrompts != forcePromptYes:
+    display("Info:",
+         "In order to initialise a new Nimble package, I will need to ask you\n" &
+         "some questions. Default values are shown in square brackets, press\n" &
+         "enter to use them.", priority = HighPriority)
 
   # Ask for package name.
   if options.action.projName != "":
@@ -704,7 +705,7 @@ proc init(options: Options) =
     nimbleFile = pkgName.changeFileExt("nimble")
   else:
     var pkgName = os.getCurrentDir().splitPath.tail.toValidPackageName()
-    pkgName = promptCustom("Package name?", pkgName)
+    pkgName = promptCustom(options, "Package name?", pkgName)
     nimbleFile = pkgName.changeFileExt("nimble")
 
   validatePackageName(nimbleFile.changeFileExt(""))
@@ -713,7 +714,7 @@ proc init(options: Options) =
     raise newException(NimbleError, "Nimble file already exists.")
 
   # Ask for package version.
-  let pkgVersion = promptCustom("Initial version of package?", "0.1.0")
+  let pkgVersion = promptCustom(options, "Initial version of package?", "0.1.0")
   validateVersion(pkgVersion)
 
   # Ask for package author
@@ -726,18 +727,20 @@ proc init(options: Options) =
     let (name, exitCode) = doCmdEx("hg config ui.username")
     if exitCode == QuitSuccess and name.len > 0:
       defaultAuthor = name.strip()
-  let pkgAuthor = promptCustom("Your name?", defaultAuthor)
+  let pkgAuthor = promptCustom(options, "Your name?", defaultAuthor)
 
   # Ask for description
-  let pkgDesc = promptCustom("Package description?", "")
+  let pkgDesc = promptCustom(options, "Package description?",
+    "A new awesome nimble package")
 
   # Ask for license
   # TODO: Provide selection of licenses, or select random default license.
-  let pkgLicense = promptCustom("Package license?", "MIT")
+  let pkgLicense = promptCustom(options, "Package license?", "MIT")
 
   # Ask for Nim dependency
   let nimDepDef = getNimrodVersion()
-  let pkgNimDep = promptCustom("Lowest supported Nim version?", $nimDepDef)
+  let pkgNimDep = promptCustom(options, "Lowest supported Nim version?",
+    $nimDepDef)
   validateVersion(pkgNimDep)
 
   var outFile: File

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -734,8 +734,12 @@ proc init(options: Options) =
     "A new awesome nimble package")
 
   # Ask for license
-  # TODO: Provide selection of licenses, or select random default license.
-  let pkgLicense = promptCustom(options, "Package license?", "MIT")
+  let pkgLicense = options.promptList("Package License?", @[
+    "MIT",
+    "BSD2",
+    "GPL3",
+    "Apache2",
+  ])
 
   # Ask for Nim dependency
   let nimDepDef = getNimrodVersion()

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -700,18 +700,19 @@ proc init(options: Options) =
          "enter to use them.", priority = HighPriority)
 
   # Ask for package name.
-  if options.action.projName != "":
-    let pkgName = options.action.projName
-    nimbleFile = pkgName.changeFileExt("nimble")
-  else:
-    var pkgName = os.getCurrentDir().splitPath.tail.toValidPackageName()
-    pkgName = promptCustom(options, "Package name?", pkgName)
-    nimbleFile = pkgName.changeFileExt("nimble")
+  let pkgName = if options.action.projName != "":
+      options.action.projName
+    else:
+      os.getCurrentDir().splitPath.tail.toValidPackageName()
 
+  nimbleFile = pkgName.changeFileExt("nimble")
   validatePackageName(nimbleFile.changeFileExt(""))
 
   if existsFile(os.getCurrentDir() / nimbleFile):
     raise newException(NimbleError, "Nimble file already exists.")
+
+  display("Using", "$# for new package name" % [pkgName.escape()],
+    priority = HighPriority)
 
   # Ask for package version.
   let pkgVersion = promptCustom(options, "Initial version of package?", "0.1.0")

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -734,10 +734,11 @@ proc init(options: Options) =
     "A new awesome nimble package")
 
   # Ask for license
-  let pkgLicense = options.promptList("Package License?", @[
+  let pkgLicense = options.promptList("Package License?", [
     "MIT",
     "BSD2",
     "GPL3",
+    "LGPL3",
     "Apache2",
   ])
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -755,9 +755,8 @@ proc init(options: Options) =
     $nimDepDef)
   validateVersion(pkgNimDep)
 
-  var outFile: File
-  if open(f = outFile, filename = nimbleFile, mode = fmWrite):
-    outFile.writeLine """# Package
+  # Write the nimble file
+  nimbleFile.writeContents """# Package
 
 version       = $#
 author        = $#
@@ -769,10 +768,6 @@ license       = $#
 requires "nim >= $#"
 """ % [pkgVersion.escape(), pkgAuthor.escape(), pkgDesc.escape(),
        pkgLicense.escape(), pkgNimDep]
-    close(outFile)
-  else:
-    raise newException(NimbleError, "Unable to open file " & nimbleFile &
-                       " for writing: " & osErrorMsg(osLastError()))
 
   display("Success:", "Nimble file created successfully", Success, HighPriority)
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -760,10 +760,17 @@ proc init(options: Options) =
     $nimDepDef)
   validateVersion(pkgNimDep)
 
-  # Create package directory structure
+  # Create source directory
   os.createDir(pkgSrcDir)
 
   display("Success:", "Source directory created successfully", Success,
+    MediumPriority)
+
+  # Create initial source file
+  cd pkgSrcDir:
+    pkgName.changeFileExt("nim").writeContents "echo \"Hello, World!\"\n"
+
+  display("Success:", "Created initial source file successfully", Success,
     MediumPriority)
 
   # Write the nimble file

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -732,6 +732,11 @@ proc init(options: Options) =
       result = promptCustom(options, "Your name?", "Anonymous")
   let pkgAuthor = getAuthor()
 
+  # Declare the src/ directory
+  let pkgSrcDir = "src"
+  display("Using", "$# for new package source directory" % [pkgSrcDir.escape()],
+    priority = HighPriority)
+
   # Ask for package version.
   let pkgVersion = promptCustom(options, "Initial version of package?", "0.1.0")
   validateVersion(pkgVersion)
@@ -755,6 +760,12 @@ proc init(options: Options) =
     $nimDepDef)
   validateVersion(pkgNimDep)
 
+  # Create package directory structure
+  os.createDir(pkgSrcDir)
+
+  display("Success:", "Source directory created successfully", Success,
+    MediumPriority)
+
   # Write the nimble file
   nimbleFile.writeContents """# Package
 
@@ -762,12 +773,13 @@ version       = $#
 author        = $#
 description   = $#
 license       = $#
+srcDir        = $#
 
 # Dependencies
 
 requires "nim >= $#"
 """ % [pkgVersion.escape(), pkgAuthor.escape(), pkgDesc.escape(),
-       pkgLicense.escape(), pkgNimDep]
+       pkgLicense.escape(), pkgSrcDir.escape(), pkgNimDep]
 
   display("Success:", "Nimble file created successfully", Success, HighPriority)
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -695,9 +695,9 @@ proc init(options: Options) =
 
   if options.forcePrompts != forcePromptYes:
     display("Info:",
-         "In order to initialise a new Nimble package, I will need to ask you\n" &
-         "some questions. Default values are shown in square brackets, press\n" &
-         "enter to use them.", priority = HighPriority)
+      "In order to initialise a new Nimble package, I will need to ask you\n" &
+      "some questions. Default values are shown in square brackets, press\n" &
+      "enter to use them.", priority = HighPriority)
 
   # Ask for package name.
   let pkgName = if options.action.projName != "":

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -808,7 +808,11 @@ requires "nim >= $#"
 """ % [pkgVersion.escape(), pkgAuthor.escape(), pkgDesc.escape(),
        pkgLicense.escape(), pkgSrcDir.escape(), pkgNimDep]
 
-  display("Success:", "Nimble file created successfully", Success, HighPriority)
+  display("Success:", "Nimble file created successfully", Success,
+    MediumPriority)
+
+  display("Success:", "Package $# created successfully" % [pkgName], Success,
+    HighPriority)
 
 proc uninstall(options: Options) =
   if options.action.packages.len == 0:

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -146,19 +146,25 @@ proc prompt*(forcePrompts: ForcePrompt, question: string): bool =
     else:
       return false
 
-proc promptCustom*(question, default: string): string =
-  if default == "":
-    display("Prompt:", question, Warning, HighPriority)
-    displayCategory("Answer:", Warning, HighPriority)
-    let user = stdin.readLine()
-    if user.len == 0: return promptCustom(question, default)
-    else: return user
+proc promptCustom*(question, default: string, forcePrompts = dontForcePrompt): string =
+  case forcePrompts:
+  of forcePromptYes:
+    display("Prompt: ", question & " -> [forced " & default & "]", Warning,
+      HighPriority)
+    return default
   else:
-    display("Prompt:", question & " [" & default & "]", Warning, HighPriority)
-    displayCategory("Answer:", Warning, HighPriority)
-    let user = stdin.readLine()
-    if user == "": return default
-    else: return user
+    if default == "":
+      display("Prompt:", question, Warning, HighPriority)
+      displayCategory("Answer:", Warning, HighPriority)
+      let user = stdin.readLine()
+      if user.len == 0: return promptCustom(question, default)
+      else: return user
+    else:
+      display("Prompt:", question & " [" & default & "]", Warning, HighPriority)
+      displayCategory("Answer:", Warning, HighPriority)
+      let user = stdin.readLine()
+      if user == "": return default
+      else: return user
 
 proc setVerbosity*(level: Priority) =
   globalCLI.level = level

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -166,6 +166,21 @@ proc promptCustom*(question, default: string, forcePrompts = dontForcePrompt): s
       if user == "": return default
       else: return user
 
+proc promptList*(forcePrompts: ForcePrompt, question: string, args: openarray[string]): string =
+  case forcePrompts:
+  of forcePromptYes:
+    result = args[0]
+    display("Prompt: ", question & " -> [forced " & result & "]", Warning,
+      HighPriority)
+  else:
+    display("Prompt:", question & " [" & join(args, "/") & "]", Warning, HighPriority)
+    displayCategory("Answer:", Warning, HighPriority)
+    result = stdin.readLine()
+    for arg in args:
+      if result.cmpIgnoreCase(result) == 0:
+        return arg
+    return promptList(forcePrompts, question, args)
+
 proc setVerbosity*(level: Priority) =
   globalCLI.level = level
 

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -177,7 +177,7 @@ proc promptList*(forcePrompts: ForcePrompt, question: string, args: openarray[st
     displayCategory("Answer:", Warning, HighPriority)
     result = stdin.readLine()
     for arg in args:
-      if result.cmpIgnoreCase(result) == 0:
+      if arg.cmpIgnoreCase(result) == 0:
         return arg
     return promptList(forcePrompts, question, args)
 

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -149,7 +149,7 @@ proc prompt*(forcePrompts: ForcePrompt, question: string): bool =
 proc promptCustom*(question, default: string, forcePrompts = dontForcePrompt): string =
   case forcePrompts:
   of forcePromptYes:
-    display("Prompt: ", question & " -> [forced " & default & "]", Warning,
+    display("Prompt:", question & " -> [forced " & default & "]", Warning,
       HighPriority)
     return default
   else:
@@ -170,7 +170,7 @@ proc promptList*(forcePrompts: ForcePrompt, question: string, args: openarray[st
   case forcePrompts:
   of forcePromptYes:
     result = args[0]
-    display("Prompt: ", question & " -> [forced " & result & "]", Warning,
+    display("Prompt:", question & " -> [forced " & result & "]", Warning,
       HighPriority)
   else:
     display("Prompt:", question & " [" & join(args, "/") & "]", Warning, HighPriority)

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -146,7 +146,7 @@ proc prompt*(forcePrompts: ForcePrompt, question: string): bool =
     else:
       return false
 
-proc promptCustom*(question, default: string, forcePrompts = dontForcePrompt): string =
+proc promptCustom*(forcePrompts: ForcePrompt, question, default: string): string =
   case forcePrompts:
   of forcePromptYes:
     display("Prompt:", question & " -> [forced " & default & "]", Warning,
@@ -157,7 +157,7 @@ proc promptCustom*(question, default: string, forcePrompts = dontForcePrompt): s
       display("Prompt:", question, Warning, HighPriority)
       displayCategory("Answer:", Warning, HighPriority)
       let user = stdin.readLine()
-      if user.len == 0: return promptCustom(question, default)
+      if user.len == 0: return promptCustom(forcePrompts, question, default)
       else: return user
     else:
       display("Prompt:", question & " [" & default & "]", Warning, HighPriority)
@@ -165,6 +165,9 @@ proc promptCustom*(question, default: string, forcePrompts = dontForcePrompt): s
       let user = stdin.readLine()
       if user == "": return default
       else: return user
+
+proc promptCustom*(question, default: string): string =
+  return promptCustom(dontForcePrompt, question, default)
 
 proc promptList*(forcePrompts: ForcePrompt, question: string, args: openarray[string]): string =
   case forcePrompts:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -199,7 +199,7 @@ proc promptCustom*(options: Options, question, default: string): string =
   ##
   ## The proc will return "default" without asking the user if the global
   ## forcePrompts is forcePromptYes.
-  return promptCustom(question, default, options.forcePrompts)
+  return promptCustom(options.forcePrompts, question, default)
 
 proc promptList*(options: Options, question: string, args: openarray[string]): string =
   ## Asks an interactive question and returns the result.

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -201,6 +201,13 @@ proc promptCustom*(options: Options, question, default: string): string =
   ## forcePrompts is forcePromptYes.
   return promptCustom(question, default, options.forcePrompts)
 
+proc promptList*(options: Options, question: string, args: openarray[string]): string =
+  ## Asks an interactive question and returns the result.
+  ##
+  ## The proc will return one of the provided args. If not prompting the first
+  ## options is selected.
+  return promptList(options.forcePrompts, question, args)
+
 proc renameBabelToNimble(options: Options) {.deprecated.} =
   let babelDir = getHomeDir() / ".babel"
   let nimbleDir = getHomeDir() / ".nimble"

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -199,10 +199,7 @@ proc promptCustom*(options: Options, question, default: string): string =
   ##
   ## The proc will return "default" without asking the user if the global
   ## forcePrompts is forcePromptYes.
-  result = if options.forcePrompts == forcePromptYes:
-      default
-    else:
-      promptCustom(question, default)
+  return promptCustom(question, default, options.forcePrompts)
 
 proc renameBabelToNimble(options: Options) {.deprecated.} =
   let babelDir = getHomeDir() / ".babel"

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -194,6 +194,16 @@ proc prompt*(options: Options, question: string): bool =
   ## forcePrompts has a value different than dontForcePrompt.
   return prompt(options.forcePrompts, question)
 
+proc promptCustom*(options: Options, question, default: string): string =
+  ## Asks an interactive question and returns the result.
+  ##
+  ## The proc will return "default" without asking the user if the global
+  ## forcePrompts is forcePromptYes.
+  result = if options.forcePrompts == forcePromptYes:
+      default
+    else:
+      promptCustom(question, default)
+
 proc renameBabelToNimble(options: Options) {.deprecated.} =
   let babelDir = getHomeDir() / ".babel"
   let nimbleDir = getHomeDir() / ".nimble"

--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -98,16 +98,6 @@ proc copyFileD*(fro, to: string): string =
   copyFileWithPermissions(fro, to)
   result = to
 
-proc writeContents*(filename, contents: string) =
-  ## Simlar to os.writeFile but throws a NimbleError
-  var outFile: File
-  if open(f = outFile, filename = filename, mode = fmWrite):
-    outFile.writeLine contents
-    close(outFile)
-  else:
-    raise newException(NimbleError, "Unable to open file " & filename &
-                       " for writing: " & osErrorMsg(osLastError()))
-
 proc copyDirD*(fro, to: string): seq[string] =
   ## Returns the filenames of the files in the directory that were copied.
   result = @[]

--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -80,10 +80,10 @@ proc changeRoot*(origRoot, newRoot, path: string): string =
   ## path:     /home/dom/bar/blah/2/foo.txt
   ## Return value -> /home/test/bar/blah/2/foo.txt
 
-  ## The additional check of `path.samePaths(origRoot)` is necessary to prevent 
-  ## a regression, where by ending the `srcDir` defintion in a nimble file in a 
+  ## The additional check of `path.samePaths(origRoot)` is necessary to prevent
+  ## a regression, where by ending the `srcDir` defintion in a nimble file in a
   ## trailing separator would cause the `path.startsWith(origRoot)` evaluation to
-  ## fail because of the value of `origRoot` would be longer than `path` due to 
+  ## fail because of the value of `origRoot` would be longer than `path` due to
   ## the trailing separator. This would cause this method to throw during package
   ## installation.
   if path.startsWith(origRoot) or path.samePaths(origRoot):
@@ -97,6 +97,16 @@ proc copyFileD*(fro, to: string): string =
   display("Copying", "file $# to $#" % [fro, to], priority = LowPriority)
   copyFileWithPermissions(fro, to)
   result = to
+
+proc writeContents*(filename, contents: string) =
+  ## Simlar to os.writeFile but throws a NimbleError
+  var outFile: File
+  if open(f = outFile, filename = filename, mode = fmWrite):
+    outFile.writeLine contents
+    close(outFile)
+  else:
+    raise newException(NimbleError, "Unable to open file " & filename &
+                       " for writing: " & osErrorMsg(osLastError()))
 
 proc copyDirD*(fro, to: string): seq[string] =
   ## Returns the filenames of the files in the directory that were copied.


### PR DESCRIPTION
An alternative to #435 for #288. `-y` is reused/overloaded to mean "shut up and give me the defaults".

I had to supply a default description that wasn't empty. If not then right after "Success: Created nimble file" an exception is thrown complaining about an empty description.