### PR TITLE
Prevent reserved names on Windows from being package names

### DIFF
--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -16,6 +16,31 @@ type
     warnInstalled*: bool # Determines whether to show a warning for installed pkgs
     warnAll*: bool
 
+const reservedNames = [
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  "COM1",
+  "COM2",
+  "COM3",
+  "COM4",
+  "COM5",
+  "COM6",
+  "COM7",
+  "COM8",
+  "COM9",
+  "LPT1",
+  "LPT2",
+  "LPT3",
+  "LPT4",
+  "LPT5",
+  "LPT6",
+  "LPT7",
+  "LPT8",
+  "LPT9",
+]
+
 proc newValidationError(msg: string, warnInstalled: bool,
                         hint: string, warnAll: bool): ref ValidationError =
   result = newException(ValidationError, msg)
@@ -57,6 +82,9 @@ proc validatePackageName*(name: string) =
   if name.endsWith("pkg"):
     raiseNewValidationError("\"$1\" is an invalid package name: cannot end" &
                             " with \"pkg\"" % name, false)
+  if name.toUpperAscii() in reservedNames:
+    raiseNewValidationError(
+      "\"$1\" is an invalid package name: reserved name" % name, false)
 
 proc validateVersion*(ver: string) =
   for c in ver:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -354,6 +354,46 @@ test "issue #338":
   cd "issue338":
     check execNimble("install", "-y").exitCode == QuitSuccess
 
+test "issue #349":
+  let reservedNames = [
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+  ]
+
+  proc checkName(name: string) =
+    let (outp, code) = execNimble("init", "-y", name)
+    let msg = outp.strip.splitLines()
+    check code == QuitFailure
+    check inLines(msg,
+      "\"$1\" is an invalid package name: reserved name" % name)
+    removeFile(name.changeFileExt("nimble"))
+    removeDir("src")
+    removeDir("tests")
+
+  for reserved in reservedNames:
+    checkName(reserved.toUpperAscii())
+    checkName(reserved.toLowerAscii())
+
 test "issue #428":
   cd "issue428":
     # Note: Can't use execNimble because it patches nimbleDir


### PR DESCRIPTION
Fixes #349