### PR TITLE
Consolidate NIMBLE_DIR use, and fix a bug in iterFilesWithExt

### DIFF
--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -463,7 +463,8 @@ proc iterFilesWithExt(dir: string, pkgInfo: PackageInfo,
     if kind == pcDir:
       iterFilesWithExt(path, pkgInfo, action)
     else:
-      if path.splitFile.ext[1 .. ^1] in pkgInfo.installExt:
+      var ext = path.splitFile.ext
+      if ext.len > 1 and ext[1 .. ^1] in pkgInfo.installExt:
         action(path)
 
 proc iterFilesInDir(dir: string, action: proc (f: string)) =


### PR DESCRIPTION
I moved `NIMBLE_DIR` related things in `getNimbleDir` and changed the `display` to `Warning`.

The `iterFilesWithExt` should make it happy with file names without extension.