### PR TITLE
Add note about SSH key to the section on nimble publish

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -313,7 +313,7 @@ Check out the [Creating Packages](#creating-packages) section for more info.
 
 Publishes your Nimble package to the official Nimble package repository.
 
-**Note:** Requires a valid GitHub account.
+**Note:** Requires a valid GitHub account with an SSH key attached to it. To upload your public key onto your GitHub account, follow [this link](https://github.com/settings/keys).
 
 ### nimble tasks
 


### PR DESCRIPTION
This was an issue I was trying to figure out for a solid few minutes, and it wasn't mentioned anywhere else as far as I could find.