### PR TITLE
Fixes #503 by creating directory if current and name differ

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -65,7 +65,8 @@ Commands:
   check                           Verifies the validity of a package in the
                                   current working directory.
   init         [pkgname]          Initializes a new Nimble project in the
-                                  current directory.
+                                  current directory or if a name is provided a
+                                  new directory of the same name.
   publish                         Publishes a package on nim-lang/packages.
                                   The current working directory needs to be the
                                   toplevel directory of the Nimble package.


### PR DESCRIPTION
An attempt to fix #503 without adding new flags or commands. If a package name is provided to `init` This will change attempts to _do the right thing_ depending on if the package name and the current directory are the same. If they are not a sub directory is created to contain the package files. If they are the current directory is populated with the package files.

If no package name is provided the behaviour is the same as before.

This implementation prevents one current behaviour. Currently nimble will create a package with a name different from the directory name if a name is provided and it is different.