### PR TITLE
Properly guard access to NimCompilerApiVersion.

### DIFF
--- a/src/nimblepkg/nimscriptsupport.nim
+++ b/src/nimblepkg/nimscriptsupport.nim
@@ -42,11 +42,11 @@ proc isStrLit(n: PNode): bool = n.kind in {nkStrLit..nkTripleStrLit}
 
 when declared(NimCompilerApiVersion):
   const finalApi = NimCompilerApiVersion >= 2
+
+  when NimCompilerApiVersion >= 3:
+    import compiler / pathutils
 else:
   const finalApi = false
-
-when NimCompilerApiVersion >= 3:
-  import compiler / pathutils
 
 proc getGlobal(g: ModuleGraph; ident: PSym): string =
   when finalApi:


### PR DESCRIPTION
Makes master compile on latest released Nim 0.18.0.

Fixes #544. 