### PR TITLE
Don't prepend file:// twice

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -942,8 +942,7 @@ proc developFromDir(dir: string, options: Options) =
   writeNimbleLink(nimbleLinkPath, nimbleLink)
 
   # Save a nimblemeta.json file.
-  saveNimbleMeta(pkgDestDir, "file://" & dir, vcsRevisionInDir(dir),
-                 nimbleLinkPath)
+  saveNimbleMeta(pkgDestDir, dir, vcsRevisionInDir(dir), nimbleLinkPath)
 
   # Save the nimble data (which might now contain reverse deps added in
   # processDeps).


### PR DESCRIPTION
Minor annoyance, `saveNimbleMeta` already prepends the `file://`.