### PR TITLE
Don't swallow control-C

### DIFF
--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -13,7 +13,7 @@
 #   - Normal for MediumPriority.
 
 import logging, terminal, sets, strutils, os
-import ./version
+import ./common
 
 when defined(windows):
   import winlean

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -13,6 +13,7 @@
 #   - Normal for MediumPriority.
 
 import logging, terminal, sets, strutils, os
+import ./version
 
 when defined(windows):
   import winlean
@@ -220,7 +221,7 @@ proc promptListInteractive(question: string, args: openarray[string]): string =
         break
       of '\3':
         showCursor(stdout)
-        quit(1)
+        raise newException(NimbleError, "Keyboard interrupt")
       else: discard
 
   # Erase all lines of the selection

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -218,6 +218,9 @@ proc promptListInteractive(question: string, args: openarray[string]): string =
       of '\r':
         selected = true
         break
+      of '\3':
+        showCursor(stdout)
+        quit(1)
       else: discard
 
   # Erase all lines of the selection


### PR DESCRIPTION
Fixes #587 

But doing `quit(1)` seems like the wrong thing to do.  Is there a better way to throw the error that Control-C normally causes?