### PR TITLE
Strip whitespace from authentication token.

### DIFF
--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -62,7 +62,7 @@ proc getGithubAuth(o: Options): Auth =
     # try to read from disk, if it cannot be found write a new one
     try:
       let apiTokenFilePath = cfg.nimbleDir / ApiKeyFile
-      result.token = readFile(apiTokenFilePath)
+      result.token = readFile(apiTokenFilePath).strip()
       display("Info:", "Using GitHub API Token in file: " & apiTokenFilePath,
               priority = HighPriority)
     except IOError:


### PR DESCRIPTION
My token had a newline in the file, resulting in the following HTTP
request being made to Github:

```
GET /user HTTP/1.1
Host: api.github.com
Connection: Keep-Alive
authorization: token xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

content-type: application/x-www-form-urlencoded
accept: */*
user-agent: Nim httpclient/0.19.9
```

Unfortunately the friendly error message returned by the Github server
is lost in translation because getContent() throws an exception, never
handling the body.