### PR TITLE
Update packageparser.nim and config.nim

### DIFF
--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -68,11 +68,12 @@ proc parseConfig*(): Config =
       var e = next(p)
       case e.kind
       of cfgEof:
-        if currentPackageList.urls.len == 0 and currentPackageList.path == "":
-          raise newException(NimbleError, "Package list '$1' requires either url or path" % currentPackageList.name)
-        if currentPackageList.urls.len > 0 and currentPackageList.path != "":
-          raise newException(NimbleError, "Attempted to specify `url` and `path` for the same package list '$1'" % currentPackageList.name)
-        addCurrentPkgList(result, currentPackageList)
+        if currentSection.len > 0:
+          if currentPackageList.urls.len == 0 and currentPackageList.path == "":
+            raise newException(NimbleError, "Package list '$1' requires either url or path" % currentPackageList.name)
+          if currentPackageList.urls.len > 0 and currentPackageList.path != "":
+            raise newException(NimbleError, "Attempted to specify `url` and `path` for the same package list '$1'" % currentPackageList.name)
+          addCurrentPkgList(result, currentPackageList)
         break
       of cfgSectionStart:
         addCurrentPkgList(result, currentPackageList)

--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -68,12 +68,11 @@ proc parseConfig*(): Config =
       var e = next(p)
       case e.kind
       of cfgEof:
-        if currentSection.len > 0:
-          if currentPackageList.urls.len == 0 and currentPackageList.path == "":
-            raise newException(NimbleError, "Package list '$1' requires either url or path" % currentPackageList.name)
-          if currentPackageList.urls.len > 0 and currentPackageList.path != "":
-            raise newException(NimbleError, "Attempted to specify `url` and `path` for the same package list '$1'" % currentPackageList.name)
-          addCurrentPkgList(result, currentPackageList)
+        if currentPackageList.urls.len == 0 and currentPackageList.path == "":
+          raise newException(NimbleError, "Package list '$1' requires either url or path" % currentPackageList.name)
+        if currentPackageList.urls.len > 0 and currentPackageList.path != "":
+          raise newException(NimbleError, "Attempted to specify `url` and `path` for the same package list '$1'" % currentPackageList.name)
+        addCurrentPkgList(result, currentPackageList)
         break
       of cfgSectionStart:
         addCurrentPkgList(result, currentPackageList)
@@ -81,6 +80,7 @@ proc parseConfig*(): Config =
         case currentSection.normalize
         of "packagelist":
           currentPackageList = initPackageList()
+        of "": discard
         else:
           raise newException(NimbleError, "Unable to parse config file:" &
                              " Unknown section: " & e.key)
@@ -116,6 +116,7 @@ proc parseConfig*(): Config =
           else: assert false
         of "nimlibprefix":
           result.nimLibPrefix = e.value
+        of "": discard
         else:
           raise newException(NimbleError, "Unable to parse config file:" &
                                      " Unknown key: " & e.key)

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -259,6 +259,7 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             case result.backend.normalize
             of "javascript": result.backend = "js"
             else: discard
+          of "": discard     
           else:
             raise newException(NimbleError, "Invalid field: " & ev.key)
         of "deps", "dependencies":
@@ -266,8 +267,10 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           of "requires":
             for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
+          of "": discard     
           else:
             raise newException(NimbleError, "Invalid field: " & ev.key)
+        of "": discard
         else: raise newException(NimbleError,
               "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,


### PR DESCRIPTION
`parsecfg.nim` module supports annotation statements, does not delete comment statements and redundant blank characters, leaving the original style and you can specify annotation delimiters.
Since the `parsecfg.nim`module returns null `section` and empty `key`, the `nimble`module also adds statements that handle null values accordingly. 
`AppVeyor` build failed，It didnundefinedt handle it, causing the check to fail.
For more information, please see:
https://github.com/nim-lang/Nim/pull/10932