### PR TITLE
Option to continue tests on failure

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -677,9 +677,15 @@ proc getPackageByPattern(pattern: string, options: Options): PackageInfo =
       )
     result = getPkgInfoFromFile(skeletonInfo.myPath, options)
 
+proc projName(options: Options): string =
+  if options.action.projName != "":
+    options.action.projName
+  else:
+    os.getCurrentDir().splitPath.tail.toValidPackageName()
+
 proc dump(options: Options) =
   cli.setSuppressMessages(true)
-  let p = getPackageByPattern(options.action.projName, options)
+  let p = getPackageByPattern(projName(options), options)
   echo "name: ", p.name.escape
   echo "version: ", p.version.escape
   echo "author: ", p.author.escape
@@ -699,11 +705,7 @@ proc dump(options: Options) =
 
 proc init(options: Options) =
   # Determine the package name.
-  let pkgName =
-    if options.action.projName != "":
-      options.action.projName
-    else:
-      os.getCurrentDir().splitPath.tail.toValidPackageName()
+  let pkgName = projName(options)
 
   # Validate the package name.
   validatePackageName(pkgName)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -992,7 +992,9 @@ proc develop(options: Options) =
 proc test(options: Options) =
   ## Executes all tests starting with 't' in the ``tests`` directory.
   ## Subdirectories are not walked.
-  var files = toSeq(walkDir(getCurrentDir() / "tests"))
+  var
+    files = toSeq(walkDir(getCurrentDir() / "tests"))
+    tests, failures: int
 
   if files.len < 1:
     display("Warning:", "No tests found!", Warning, HighPriority)
@@ -1015,10 +1017,11 @@ proc test(options: Options) =
         existsBefore = existsFile(binFileName)
 
       if options.continueTestsOnFailure:
+        inc tests
         try:
           execBackend(optsCopy)
         except NimbleError:
-          discard
+          inc failures
       else:
         execBackend(optsCopy)
 
@@ -1028,7 +1031,11 @@ proc test(options: Options) =
       if canRemove:
         removeFile(binFileName)
 
-  display("Success:", "All tests passed", Success, HighPriority)
+  if failures == 0:
+    display("Success:", "All tests passed", Success, HighPriority)
+  else:
+    let error = "Only " & $(tests - failures) & "/" & $tests & " tests passed"
+    display("Error:", error, Error, HighPriority)
 
 proc check(options: Options) =
   ## Validates a package a in the current working directory.

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1014,7 +1014,13 @@ proc test(options: Options) =
         binFileName = file.path.changeFileExt(ExeExt)
         existsBefore = existsFile(binFileName)
 
-      execBackend(optsCopy)
+      if options.continueTestsOnFailure:
+        try:
+          execBackend(optsCopy)
+        except NimbleError:
+          discard
+      else:
+        execBackend(optsCopy)
 
       let
         existsAfter = existsFile(binFileName)

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -23,6 +23,7 @@ type
     showVersion*: bool
     noColor*: bool
     disableValidation*: bool
+    continueTestsOnFailure*: bool
     ## Whether packages' repos should always be downloaded with their history.
     forceFullClone*: bool
 
@@ -77,6 +78,7 @@ Commands:
   c, cc, js    [opts, ...] f.nim  Builds a file inside a package. Passes options
                                   to the Nim compiler.
   test                            Compiles and executes tests
+               [-c, --continue]   Don't stop execution on a failed test.
   doc, doc2    [opts, ...] f.nim  Builds documentation for a file inside a
                                   package. Passes options to the Nim compiler.
   refresh      [url]              Refreshes the package list. A package list URL
@@ -316,6 +318,9 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       else:
         result.action.compileOptions.add(prefix & flag & ":" & val)
     of actionCustom:
+      if result.action.command.normalize == "test":
+        if f == "continue" or f == "c":
+          result.continueTestsOnFailure = true
       result.action.flags[flag] = val
     else:
       wasFlagHandled = false


### PR DESCRIPTION
- add -c/--continue flags to "nimble test", to prevent it from exiting on the first test failure
- at the end of a test run, if there were failures, show an error with the success rate

A near equivalent is the following custom task:

```nim
task test, "Run test suite":
  exec """for x in tests/t*.nim; do nim c --path:"../src" -r $x; done"""
```

Abbreviated example output with these patches:

```
# ../nimble/nimble test -c
  Executing task test in /Users/jfondren/nim/modsec/modsec.nimble
  Verifying dependencies for modsec@0.1.0
      Info: Dependency on npeg@>= 0.10.0 already satisfied
  Verifying dependencies for npeg@0.10.0
  Compiling /Users/jfondren/nim/modsec/tests/test_actions_oddities.nim (from package modsec) using c backend
[FAILED] can parse actions that end in a comma
[FAILED] can parse actions that end in a stray single quote
Error: execution of an external program failed: '/Users/jfondren/nim/modsec/tests/test_actions_oddities '
  Verifying dependencies for modsec@0.1.0
      Info: Dependency on npeg@>= 0.10.0 already satisfied
  Verifying dependencies for npeg@0.10.0
  Compiling /Users/jfondren/nim/modsec/tests/test_normal.nim (from package modsec) using c backend
[OK] can parse rule with escaped quote in string
...
[OK] can parse rule with unicode double-quotes within double-quoted strings
   Success: Execution finished
     Error: Only 2/3 tests passed
```