### PR TITLE
Print nimscript errors

### DIFF
--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -50,7 +50,7 @@ proc execNimscript(nimsFile, projectDir, actionName: string, options: Options,
       result.output = outFile.readFile()
       discard outFile.tryRemoveFile()
   else:
-    result = execCmdEx(cmd, options = {poUsePath})
+    result = execCmdEx(cmd, options = {poUsePath, poStdErrToStdOut})
 
 proc getNimsFile(scriptName: string, options: Options): string =
   let


### PR DESCRIPTION
Piping stderr now gives better error messages when printPkgInfo fails.

E.g. https://github.com/vegansk/nimfp is currently failing install since `import ospaths` doesn't work on devel but was painful to debug since nimble wasn't printing the error. I am fixing the ospaths issue separately.

cc @Araq