### PR TITLE
Option to continue tests on failure

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -23,6 +23,7 @@ type
     showVersion*: bool
     noColor*: bool
     disableValidation*: bool
+    continueTestsOnFailure*: bool
     ## Whether packages' repos should always be downloaded with their history.
     forceFullClone*: bool
 
@@ -77,6 +78,7 @@ Commands:
   c, cc, js    [opts, ...] f.nim  Builds a file inside a package. Passes options
                                   to the Nim compiler.
   test                            Compiles and executes tests
+               [-c, --continue]   Don't stop execution on a failed test.
   doc, doc2    [opts, ...] f.nim  Builds documentation for a file inside a
                                   package. Passes options to the Nim compiler.
   refresh      [url]              Refreshes the package list. A package list URL
@@ -316,6 +318,9 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       else:
         result.action.compileOptions.add(prefix & flag & ":" & val)
     of actionCustom:
+      if result.action.command.normalize == "test":
+        if f == "continue" or f == "c":
+          result.continueTestsOnFailure = true
       result.action.flags[flag] = val
     else:
       wasFlagHandled = false


### PR DESCRIPTION
### cleaned-up version of #641

- add -c/--continue flags to "nimble test", to prevent it from exiting on the first test failure
- at the end of a test run, if there were failures, show an error with the success rate

A near equivalent is the following custom task:

```nim
task test, "Run test suite":
  exec """for x in tests/t*.nim; do nim c --path:"../src" -r $x; done"""
```

Abbreviated example output with these patches:

```
# ../nimble/nimble test -c
  Executing task test in /Users/jfondren/nim/modsec/modsec.nimble
  Verifying dependencies for modsec@0.1.0
      Info: Dependency on npeg@>= 0.10.0 already satisfied
  Verifying dependencies for npeg@0.10.0
  Compiling /Users/jfondren/nim/modsec/tests/test_actions_oddities.nim (from package modsec) using c backend
[FAILED] can parse actions that end in a comma
[FAILED] can parse actions that end in a stray single quote
Error: execution of an external program failed: '/Users/jfondren/nim/modsec/tests/test_actions_oddities '
  Verifying dependencies for modsec@0.1.0
      Info: Dependency on npeg@>= 0.10.0 already satisfied
  Verifying dependencies for npeg@0.10.0
  Compiling /Users/jfondren/nim/modsec/tests/test_normal.nim (from package modsec) using c backend
[OK] can parse rule with escaped quote in string
...
[OK] can parse rule with unicode double-quotes within double-quoted strings
   Success: Execution finished
     Error: Only 2/3 tests passed
```