### PR TITLE
use displayLine rather than display with displayCategory prompt

### DIFF
--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -140,7 +140,7 @@ proc prompt*(forcePrompts: ForcePrompt, question: string): bool =
     display("Prompt:", question & " -> [forced no]", Warning, HighPriority)
     return false
   of dontForcePrompt:
-    display("Prompt:", question & " [y/N]", Warning, HighPriority)
+    displayLine("Prompt:", question & " [y/N]", Warning, HighPriority)
     displayCategory("Answer:", Warning, HighPriority)
     let yn = stdin.readLine()
     case yn.normalize


### PR DESCRIPTION
The problem with #640 isn't the projname actually.

Tracing through nimble:

```
 nimble dump
    Answer: ^CTraceback (most recent call last)
nimble.nim(1123)         nimble
nimble.nim(1090)         doAction
nimble.nim(682)          dump
nimble.nim(662)          getPackageByPattern
packageparser.nim(410)   getPkgInfo
packageparser.nim(398)   getPkgInfoFromFile
packageparser.nim(382)   readPackageInfo
packageparser.nim(190)   validatePackageInfo
packageparser.nim(160)   validatePackageStructure
packageinfo.nim(502)     iterInstallFiles
options.nim(201)         prompt
cli.nim(145)             prompt
sysio.nim(185)           readLine
sysio.nim(158)           readLine
SIGINT: Interrupted by Ctrl-C.
```

It's trying to ask this question: "Missing file /Users/jfondren/nim/nim-syslog/README.md. Continue?", by calling src/nimblepkg/options.nim:prompt

```
proc prompt*(options: Options, question: string): bool =
  ## Asks an interactive question and returns the result.
  ##
  ## The proc will return immediately without asking the user if the global
  ## forcePrompts has a value different than dontForcePrompt.
  return prompt(options.forcePrompts, question)
```

where `options.forcePrompt` is `dontForcePrompt`, so it gets to this case in src/nimblepkg/cli.nim:prompt

```
  of dontForcePrompt:
    display("Prompt:", question & " [y/N]", Warning, HighPriority)
    displayCategory("Answer:", Warning, HighPriority)
    let yn = stdin.readLine()
    case yn.normalize
    of "y", "yes":
      return true
    of "n", "no":
      return false
    else:
      return false
```

where that first display returns without displaying anything, by this test:

```
  if globalCLI.suppressMessages and displayType >= Warning and
     globalCLI.level == HighPriority:
    return
```

Indeed, a `nimble dump --verbose` drops globalCLI.level to LowPriority and allows the prompt to be displayed:

```
$ nimble dump --verbose
    Prompt: Missing file /Users/jfondren/nim/nim-syslog/README.md. Continue? [y/N]
    Answer:
```

But it's obviously an error that the display() fails where the displayCategory() succeeds. I think an underlying error is probably that prompts are treated equivalently to possibly-suppressed output: it doesn't make sense for --verbose to result in additional interactivity. I'd expect a different flag, possibly multiple flags, to tell nimble to pick the default answers for me, rather than ask.

This PR changes display() to displayLine(), which itself calls displayCategory() and then unconditionally echo's the prompt. It would be a new error if displayCategory() could ever fail here, since the echo is unconditional, but that would only result in this interaction:

```
$ nimble dump
Missing file /Users/jfondren/nim/nim-syslog/README.md. Continue? [y/N]
```
with the cursor after the "[y/N]", and `stdin.readline()` waiting on the answer.