### PR TITLE
Choose USER-specific tmpdir

### DIFF
--- a/src/nimblepkg/nimscriptsupport.nim
+++ b/src/nimblepkg/nimscriptsupport.nim
@@ -15,7 +15,7 @@ from compiler/scriptconfig import setupVM
 from compiler/astalgo import strTableGet
 import compiler/options as compiler_options
 
-import common, version, options, packageinfo, cli
+import common, version, options, packageinfo, cli, tools
 import os, strutils, strtabs, tables, times, osproc, sets, pegs
 
 when not declared(resetAllModulesHard):
@@ -382,7 +382,7 @@ proc execScript(scriptName: string, flags: Flags, options: Options): PSym =
 
   # Ensure that "nimblepkg/nimscriptapi" is in the PATH.
   block:
-    let t = getTempDir() / "nimblecache"
+    let t = getNimbleUserTempDir() / "nimblecache"
     let tmpNimscriptApiPath = t / "nimblepkg" / "nimscriptapi.nim"
     createDir(tmpNimscriptApiPath.splitFile.dir)
     writeFile(tmpNimscriptApiPath, nimscriptApi)

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -155,7 +155,7 @@ proc editJson(p: PackageInfo; url, tags, downloadMethod: string) =
 proc publish*(p: PackageInfo, o: Options) =
   ## Publishes the package p.
   let auth = getGithubAuth(o)
-  var pkgsDir = getTempDir() / "nimble-packages-fork"
+  var pkgsDir = getNimbleUserTempDir() / "nimble-packages-fork"
   if not forkExists(auth):
     createFork(auth)
     display("Info:", "Waiting 10s to let Github create a fork",

--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -162,3 +162,17 @@ proc getNimbleTempDir*(): string =
     result.add($GetCurrentProcessId())
   else:
     result.add($getpid())
+
+proc getNimbleUserTempDir*(): string =
+  ## Returns a path to a temporary directory.
+  ##
+  ## The returned path will be the same for the duration of the process but
+  ## different for different runs of it. You have to make sure to create it
+  ## first. In release builds the directory will be removed when nimble finishes
+  ## its work.
+  var tmpdir: string
+  if existsEnv("TMPDIR") and existsEnv("USER"):
+    tmpdir = joinPath(getEnv("TMPDIR"), getEnv("USER"))
+  else:
+    tmpdir = getTempDir()
+  return tmpdir


### PR DESCRIPTION
re: #80

The question is what to do on Windows. Here, we check for `$USER` in the environment, and use it iff set.

The other question is how to find `/tmp`. It's more common to check `$TMPDIR` on Linux and OSX, and `getTempDir()` is discouraged in Nim.

This will use `$TMPDIR/$USER/nimble-$PID/nimblecache` if possible, and `getTempDir()/nimble-$PID/nimblecache` otherwise. That way current behavior can (almost) be maintained on systems which lack USER or TMPDIR, but people have ways around this when needed.