### PR TITLE
Add backend selection to nimble init

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -802,6 +802,14 @@ This should ideally be a valid SPDX identifier. See https://spdx.org/licenses/.
 Please specify a valid SPDX identifier.""",
       "MIT"
     )
+  var pkgBackend = options.promptList(
+    """Package Backend?
+c    - Compile using C backend.
+cpp  - Compile using C++ backend.
+objc - Compile using Objective-C backend.
+js   - Compile using JavaScript backend.""",
+    ["c", "cpp", "objc", "js"]
+  )
 
   # Ask for Nim dependency
   let nimDepDef = getNimrodVersion()
@@ -816,6 +824,7 @@ Please specify a valid SPDX identifier.""",
       pkgAuthor,
       pkgDesc,
       pkgLicense,
+      pkgBackend,
       pkgSrcDir,
       pkgNimDep,
       pkgType

--- a/src/nimblepkg/init.nim
+++ b/src/nimblepkg/init.nim
@@ -9,6 +9,7 @@ type
     pkgAuthor: string
     pkgDesc: string
     pkgLicense: string
+    pkgBackend: string
     pkgSrcDir: string
     pkgNimDep: string
     pkgType: string
@@ -149,6 +150,10 @@ test "correct welcome":
 
   # Write the nimble file
   let nimbleFile = pkgRoot / info.pkgName.changeFileExt("nimble")
+  # Only write backend if it isn't "c"
+  var pkgBackend = ""
+  if (info.pkgBackend != "c"):
+    pkgBackend = "backend       = " & info.pkgbackend.escape()
   writeFile(nimbleFile, """# Package
 
 version       = $#
@@ -157,6 +162,7 @@ description   = $#
 license       = $#
 srcDir        = $#
 $#
+$#
 
 # Dependencies
 
@@ -164,7 +170,7 @@ requires "nim >= $#"
 """ % [
       info.pkgVersion.escape(), info.pkgAuthor.escape(), info.pkgDesc.escape(),
       info.pkgLicense.escape(), info.pkgSrcDir.escape(), nimbleFileOptions,
-      info.pkgNimDep
+      pkgBackend, info.pkgNimDep
     ]
   )
 


### PR DESCRIPTION
This adds a menu to select the backend within the `nimble init` subcommand.