### PR TITLE
Fix object variants - nim issue 1286

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1015,7 +1015,7 @@ proc test(options: Options) =
     let (_, name, ext) = file.path.splitFile()
     if ext == ".nim" and name[0] == 't' and file.kind in {pcFile, pcLinkToFile}:
       var optsCopy = options.briefClone()
-      optsCopy.action.typ = actionCompile
+      optsCopy.action = Action(typ: actionCompile)
       optsCopy.action.file = file.path
       optsCopy.action.backend = "c"
       optsCopy.action.compileOptions = @[]

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -238,7 +238,7 @@ proc getBinDir*(options: Options): string =
   options.getNimbleDir() / "bin"
 
 proc parseCommand*(key: string, result: var Options) =
-  result.action.typ = parseActionType(key)
+  result.action = Action(typ: parseActionType(key))
   initAction(result, key)
 
 proc parseArgument*(key: string, result: var Options) =
@@ -329,7 +329,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     raise newException(NimbleError, "Unknown option: --" & flag)
 
 proc initOptions*(): Options =
-  result.action.typ = actionNil
+  result.action = Action(typ: actionNil)
   result.pkgInfoCache = newTable[string, PackageInfo]()
   result.nimbleDir = ""
   result.verbosity = HighPriority

--- a/src/nimblepkg/version.nim
+++ b/src/nimblepkg/version.nim
@@ -130,34 +130,32 @@ proc contains*(ran: VersionRange, ver: Version): bool =
   return withinRange(ver, ran)
 
 proc makeRange*(version: string, op: string): VersionRange =
-  new(result)
   if version == "":
     raise newException(ParseVersionError,
         "A version needs to accompany the operator.")
   case op
   of ">":
-    result.kind = verLater
+    result = VersionRange(kind: verLater)
   of "<":
-    result.kind = verEarlier
+    result = VersionRange(kind: verEarlier)
   of ">=":
-    result.kind = verEqLater
+    result = VersionRange(kind: verEqLater)
   of "<=":
-    result.kind = verEqEarlier
+    result = VersionRange(kind: verEqEarlier)
   of "":
-    result.kind = verEq
+    result = VersionRange(kind: verEq)
   else:
     raise newException(ParseVersionError, "Invalid operator: " & op)
   result.ver = Version(version)
 
 proc parseVersionRange*(s: string): VersionRange =
   # >= 1.5 & <= 1.8
-  new(result)
   if s.len == 0:
-    result.kind = verAny
+    result = VersionRange(kind: verAny)
     return
 
   if s[0] == '#':
-    result.kind = verSpecial
+    result = VersionRange(kind: verSpecial)
     result.spe = s.Version
     return
 
@@ -169,7 +167,7 @@ proc parseVersionRange*(s: string): VersionRange =
     of '>', '<', '=':
       op.add(s[i])
     of '&':
-      result.kind = verIntersect
+      result = VersionRange(kind: verIntersect)
       result.verILeft = makeRange(version, op)
 
       # Parse everything after &
@@ -204,10 +202,10 @@ proc toVersionRange*(ver: Version): VersionRange =
   ## Converts a version to either a verEq or verSpecial VersionRange.
   new(result)
   if ver.isSpecial:
-    result.kind = verSpecial
+    result = VersionRange(kind: verSpecial)
     result.spe = ver
   else:
-    result.kind = verEq
+    result = VersionRange(kind: verEq)
     result.ver = ver
 
 proc parseRequires*(req: string): PkgTuple =
@@ -263,17 +261,14 @@ proc getSimpleString*(verRange: VersionRange): string =
     result = ""
 
 proc newVRAny*(): VersionRange =
-  new(result)
-  result.kind = verAny
+  result = VersionRange(kind: verAny)
 
 proc newVREarlier*(ver: string): VersionRange =
-  new(result)
-  result.kind = verEarlier
+  result = VersionRange(kind: verEarlier)
   result.ver = newVersion(ver)
 
 proc newVREq*(ver: string): VersionRange =
-  new(result)
-  result.kind = verEq
+  result = VersionRange(kind: verEq)
   result.ver = newVersion(ver)
 
 proc findLatest*(verRange: VersionRange,


### PR DESCRIPTION
Fix for https://github.com/nim-lang/Nim/issues/1286.

Right now, nimble is tested with an old commit on devel. I updated it to a commit from a week ago, before the fix for 1286 in PR https://github.com/nim-lang/nimble/pull/659. Once this PR is approved, we can upgrade to a newer version which fixes 1286.

This is part of the reason I prefer testing against #devel rather than a specific commit, we find out about issues immediately and there's no impact to everyone if CI fails. This change was made five days ago and there were mentions in IRC of failures. I also propose a daily build so that all nimble tests are run regularly regardless of whether there's general activity in this repo.

Alternative is to run nimble tests in the nim CI. For whatever reason, the important package tests are not failing.

Cc @Araq @narimiran