### PR TITLE
Fix issue #655

### DIFF
--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -119,7 +119,13 @@ proc execScript(scriptName, actionName: string, options: Options):
     (output, exitCode) = execNimscript(nimsFile, scriptName.parentDir(), actionName, options)
 
   if exitCode != 0:
-    raise newException(NimbleError, output)
+    let
+      errOut =
+        if output.len != 0:
+          output
+        else:
+          "Exception raised during nimble script execution"
+    raise newException(NimbleError, errOut)
 
   let
     j =

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -119,13 +119,12 @@ proc execScript(scriptName, actionName: string, options: Options):
     (output, exitCode) = execNimscript(nimsFile, scriptName.parentDir(), actionName, options)
 
   if exitCode != 0:
-    let
-      errOut =
-        if output.len != 0:
-          output
-        else:
-          "Exception raised during nimble script execution"
-    raise newException(NimbleError, errOut)
+    let errMsg =
+      if output.len != 0:
+        output
+      else:
+        "Exception raised during nimble script execution"
+    raise newException(NimbleError, errMsg)
 
   let
     j =


### PR DESCRIPTION
If child `nim e` process crashes, no output json is returned. In release mode, nimble looks at the output to verify if it should exit with non-zero value. Since it is blank, it doesn't.

I have updated the code to return an error string instead which results in the correct behavior.