### PR TITLE
Update submodules at checkout time to fix #675

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -24,6 +24,7 @@ proc doCheckout(meth: DownloadMethod, downloadDir, branch: string) =
       # clone has happened. Like in the case of git on Windows where it
       # messes up the damn line endings.
       doCmd("git checkout --force " & branch)
+      doCmd("git submodule update --recursive")
   of DownloadMethod.hg:
     cd downloadDir:
       doCmd("hg checkout " & branch)


### PR DESCRIPTION
Doing the same as [download.nim#L38](https://github.com/nim-lang/nimble/blob/master/src/nimblepkg/download.nim#L38) it updates the submodules recursively at the moment of checkout. It fixes https://github.com/nim-lang/nimble/issues/675.

Avoiding to use the `--init` argument since in [SO](https://stackoverflow.com/questions/10168449/git-update-submodules-recursively) they claim it can conflict with some older versions of git with already initialized submodules. Since nimble already clones with `--recursive` this shouldn't be a problem.