### PR TITLE
Implement ability to pass compiler arguments with `nimble install -- …`

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -41,6 +41,7 @@ type
     of actionInstall, actionPath, actionUninstall, actionDevelop:
       packages*: seq[PkgTuple] # Optional only for actionInstall
                                # and actionDevelop.
+      passNimFlags*: seq[string]
     of actionSearch:
       search*: seq[string] # Search string.
     of actionInit, actionDump:
@@ -61,6 +62,7 @@ Usage: nimble COMMAND [opts]
 Commands:
   install      [pkgname, ...]     Installs a list of packages.
                [-d, --depsOnly]   Install only dependencies.
+               [-p, --passNim]    Forward specified flag to compiler.
   develop      [pkgname, ...]     Clones a list of packages for development.
                                   Symlinks the cloned packages or any package
                                   in the current working directory.
@@ -175,6 +177,7 @@ proc initAction*(options: var Options, key: string) =
   case options.action.typ
   of actionInstall, actionPath, actionDevelop, actionUninstall:
     options.action.packages = @[]
+    options.action.passNimFlags = @[]
   of actionCompile, actionDoc, actionBuild:
     options.action.compileOptions = @[]
     options.action.file = ""
@@ -303,6 +306,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       case f
       of "depsonly", "d":
         result.depsOnly = true
+      of "passnim", "p":
+        result.action.passNimFlags.add(val)
       else:
         wasFlagHandled = false
     of actionUninstall:

--- a/tests/passNimFlags/passNimFlags.nim
+++ b/tests/passNimFlags/passNimFlags.nim
@@ -1,0 +1,1 @@
+when not defined(passNimIsWorking): {.error: "-d:passNimIsWorking wasn't passed to the compiler"}

--- a/tests/passNimFlags/passNimFlags.nimble
+++ b/tests/passNimFlags/passNimFlags.nimble
@@ -1,0 +1,11 @@
+# Package
+
+version       = "0.1.0"
+author        = "SolitudeSF"
+description   = "Test nimble install flag forwarding"
+license       = "BSD"
+bin           = @["passNimFlags"]
+
+# Dependencies
+
+requires "nim >= 0.13.0"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -840,3 +840,7 @@ test "remove skips packages with revDeps (#504)":
 
   check execNimble("path", "nimboost").exitCode != QuitSuccess
   check execNimble("path", "nimfp").exitCode != QuitSuccess
+
+test "pass options to the compiler with `nimble install`":
+  cd "passNimFlags":
+    check execNimble("install", "--passNim:-d:passNimIsWorking").exitCode == QuitSuccess


### PR DESCRIPTION
Add `passNim/p` flag to `nimble install` for passing compiler flags. `nimble install --passNim:-d:danger`.

#599