### PR TITLE
Fixes #504

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: c
 env:
   - BRANCH=0.19.6
   - BRANCH=0.20.2
-  - BRANCH=#29b5c48edf90b6f8a8a55e39bc6091dc4c483736
+  - BRANCH=#44aadd50cfa647a759610a15967960632bf597ce
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ language: c
 
 env:
   - BRANCH=0.19.6
-  - BRANCH=0.20.0
-  - BRANCH=#ced0527ae334439a10e1719d1eccb727c19dc781
+  - BRANCH=0.20.2
+  - BRANCH=#29b5c48edf90b6f8a8a55e39bc6091dc4c483736
 
 cache:
   directories:
     - "$HOME/.choosenim/toolchains/nim-0.19.6"
-    - "$HOME/.choosenim/toolchains/nim-0.20.0"
+    - "$HOME/.choosenim/toolchains/nim-0.20.2"
 
 install:
   - export CHOOSENIM_CHOOSE_VERSION=$BRANCH

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -840,7 +840,8 @@ proc uninstall(options: Options) =
     raise newException(NimbleError,
         "Please specify the package(s) to uninstall.")
 
-  var pkgsToDelete: seq[PackageInfo] = @[]
+  var pkgsToDelete: HashSet[PackageInfo]
+  pkgsToDelete.init()
   # Do some verification.
   for pkgTup in options.action.packages:
     display("Looking", "for $1 ($2)" % [pkgTup.name, $pkgTup.ver],
@@ -858,36 +859,26 @@ proc uninstall(options: Options) =
         getAllRevDeps(options, pkg, pkgsToDelete)
       else:
         let
-          # Pkgs already processed for removal
-          namesOfPkgsToDelete = pkgsToDelete.mapIt(it.name)
-            
-          # revDeps which haven't already been processed for removal
-          revDeps = getRevDeps(options, pkg).filterIt(
-            it.name notin namesOfPkgsToDelete)
-
+          revDeps = getRevDeps(options, pkg)
         var reason = ""
-        if revDeps.len == 1:
-          reason = "$1 ($2) depends on it" % [revDeps[0].name, $revDeps[0].ver]
-        else:
-          for i in 0 ..< revDeps.len:
-            reason.add("$1 ($2)" % [revDeps[i].name, $revDeps[i].ver])
-            if i != revDeps.len-1:
-              reason.add ", "
-          reason.add " depend on it"
+        for revDep in revDeps:
+          if reason.len != 0: reason.add ", "
+          reason.add("$1 ($2)" % [revDep.name, revDep.version])
+        if reason.len != 0:
+          reason &= " depend" & (if revDeps.len == 1: "s" else: "") & " on it"
 
-        if revDeps.len > 0:
+        if len(revDeps - pkgsToDelete) > 0:
           display("Cannot", "uninstall $1 ($2) because $3" %
                   [pkgTup.name, pkg.specialVersion, reason], Warning, HighPriority)
         else:
-          pkgsToDelete.add pkg
+          pkgsToDelete.incl pkg
 
   if pkgsToDelete.len == 0:
     raise newException(NimbleError, "Failed uninstall - no packages selected")
 
   var pkgNames = ""
-  for i in 0 ..< pkgsToDelete.len:
-    if i != 0: pkgNames.add ", "
-    let pkg = pkgsToDelete[i]
+  for pkg in pkgsToDelete.items:
+    if pkgNames.len != 0: pkgNames.add ", "
     pkgNames.add("$1 ($2)" % [pkg.name, pkg.specialVersion])
 
   # Let's confirm that the user wants these packages removed.

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -851,7 +851,6 @@ proc uninstall(options: Options) =
       raise newException(NimbleError, "Package not found")
 
     display("Checking", "reverse dependencies", priority = HighPriority)
-    var errors: seq[string] = @[]
     for pkg in pkgList:
       # Check whether any packages depend on the ones the user is trying to
       # uninstall.
@@ -870,13 +869,14 @@ proc uninstall(options: Options) =
           reason.add " depend on it"
 
         if revDeps.len > 0:
-          errors.add("Cannot uninstall $1 ($2) because $3" %
-                     [pkgTup.name, pkg.specialVersion, reason])
+          display("Unable", "to uninstall $1 ($2) because $3" %
+                  [pkgTup.name, pkg.specialVersion, reason], Warning, HighPriority)
         else:
           pkgsToDelete.add pkg
 
-    if pkgsToDelete.len == 0:
-      raise newException(NimbleError, "\n  " & errors.join("\n  "))
+  if pkgsToDelete.len == 0:
+    display("Failed", "uninstall - no packages selected", Error, HighPriority)
+    return
 
   var pkgNames = ""
   for i in 0 ..< pkgsToDelete.len:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -857,7 +857,14 @@ proc uninstall(options: Options) =
       if options.uninstallRevDeps:
         getAllRevDeps(options, pkg, pkgsToDelete)
       else:
-        let revDeps = getRevDeps(options, pkg)
+        let
+          # Pkgs already processed for removal
+          namesOfPkgsToDelete = pkgsToDelete.mapIt(it.name)
+            
+          # revDeps which haven't already been processed for removal
+          revDeps = getRevDeps(options, pkg).filterIt(
+            it.name notin namesOfPkgsToDelete)
+
         var reason = ""
         if revDeps.len == 1:
           reason = "$1 ($2) depends on it" % [revDeps[0].name, $revDeps[0].ver]

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -882,8 +882,7 @@ proc uninstall(options: Options) =
           pkgsToDelete.add pkg
 
   if pkgsToDelete.len == 0:
-    display("Failed", "uninstall - no packages selected", Error, HighPriority)
-    return
+    raise newException(NimbleError, "Failed uninstall - no packages selected")
 
   var pkgNames = ""
   for i in 0 ..< pkgsToDelete.len:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -876,7 +876,7 @@ proc uninstall(options: Options) =
           reason.add " depend on it"
 
         if revDeps.len > 0:
-          display("Unable", "to uninstall $1 ($2) because $3" %
+          display("Cannot", "uninstall $1 ($2) because $3" %
                   [pkgTup.name, pkg.specialVersion, reason], Warning, HighPriority)
         else:
           pkgsToDelete.add pkg

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -3,7 +3,7 @@
 
 # Stdlib imports
 import system except TResult
-import parsecfg, json, streams, strutils, parseutils, os, sets, tables
+import hashes, parsecfg, json, streams, strutils, parseutils, os, sets, tables
 import httpclient
 
 # Local imports
@@ -541,6 +541,11 @@ proc getPkgDest*(pkgInfo: PackageInfo, options: Options): string =
 proc `==`*(pkg1: PackageInfo, pkg2: PackageInfo): bool =
   if pkg1.name == pkg2.name and pkg1.myPath == pkg2.myPath:
     return true
+
+proc hash*(x: PackageInfo): Hash =
+  var h: Hash = 0
+  h = h !& hash(x.myPath)
+  result = !$h
 
 when isMainModule:
   doAssert getNameVersion("/home/user/.nimble/libs/packagea-0.1") ==

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -828,7 +828,7 @@ test "init does not overwrite existing files (#581)":
   removeDir("issue581")
 
 test "remove skips packages with revDeps (#504)":
-  check execNimble("install", "nimboost", "nimfp", "-y").exitCode == QuitSuccess
+  check execNimble("install", "nimboost@0.5.5", "nimfp@0.4.4", "-y").exitCode == QuitSuccess
 
   var (output, exitCode) = execNimble("uninstall", "nimboost", "nimfp", "-n")
   var lines = output.strip.processOutput()

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -465,8 +465,7 @@ test "can uninstall":
 
     let ls = outp.strip.processOutput()
     check exitCode != QuitSuccess
-    check "Cannot uninstall issue27b (0.1.0) because issue27a (0.1.0) depends" &
-          " on it" in ls[ls.len-1]
+    check inLines(ls, "Cannot uninstall issue27b (0.1.0) because issue27a (0.1.0) depends")
 
     check execNimble("uninstall", "-y", "issue27").exitCode == QuitSuccess
     check execNimble("uninstall", "-y", "issue27a").exitCode == QuitSuccess
@@ -827,3 +826,17 @@ test "init does not overwrite existing files (#581)":
     check execNimbleYes("init").exitCode == QuitSuccess
     check readFile("src/issue581.nim") == Src
   removeDir("issue581")
+
+test "remove skips packages with revDeps (#504)":
+  check execNimble("install", "nimboost", "nimfp", "-y").exitCode == QuitSuccess
+
+  var (output, exitCode) = execNimble("uninstall", "nimboost", "nimfp", "-n")
+  var lines = output.strip.processOutput()
+  check inLines(lines, "Cannot uninstall nimboost")
+
+  (output, exitCode) = execNimble("uninstall", "nimfp", "nimboost", "-y")
+  lines = output.strip.processOutput()
+  check not inLines(lines, "Cannot uninstall nimboost")
+
+  check execNimble("path", "nimboost").exitCode != QuitSuccess
+  check execNimble("path", "nimfp").exitCode != QuitSuccess

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -836,7 +836,7 @@ test "remove skips packages with revDeps (#504)":
 
   (output, exitCode) = execNimble("uninstall", "nimfp", "nimboost", "-y")
   lines = output.strip.processOutput()
-  check not inLines(lines, "Cannot uninstall nimboost")
+  check (not inLines(lines, "Cannot uninstall nimboost"))
 
   check execNimble("path", "nimboost").exitCode != QuitSuccess
   check execNimble("path", "nimfp").exitCode != QuitSuccess


### PR DESCRIPTION
Fixes #504 - better behavior for multi-package removal

- Better error message when nimble cannot uninstall something due to a reverse dependency

> nimble remove nimboost nimfp

![image](https://user-images.githubusercontent.com/192231/61971509-da17c900-afa4-11e9-831a-9144d382abb1.png)

`nimboost` cannot be removed since `nimfp` depends on it but `nimfp` hasn't been processed yet.

- Uninstall if packages specified in the right order - i.e. reverse dependency was already processed for removal

> nimble remove nimfp nimboost

![image](https://user-images.githubusercontent.com/192231/61971701-51e5f380-afa5-11e9-8a81-8fe8f7a145bb.png)

`nimboost` can be removed since its reverse dependency `nimfp` was already processed and marked for removal.