### PR TITLE
Remove escaping of author name and package description in `nimble init`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ nimcache/
 /nimble
 /tests/nimscript/nimscript
 /tests/issue27/issue27
+src/nimblepkg/cli
+src/nimblepkg/packageinfo
+src/nimblepkg/packageparser
+src/nimblepkg/reversedeps
+src/nimblepkg/version
+tests/nimble-test/
+tests/packageStructure/validBinary/y
+tests/testCommand/testsFail/tests/t2
 
 # Windows executables
 *.exe
@@ -20,3 +28,4 @@ nimcache/
 # VCC compiler and linker artifacts
 *.ilk
 *.pdb
+

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -732,20 +732,20 @@ proc init(options: Options) =
   display("Using", "$# for new package name" % [pkgName.escape()],
     priority = HighPriority)
 
-  # Ask for package author
+  # Determine author by running an external command
+  proc getAuthorWithCmd(cmd: string): string =
+    let (name, exitCode) = doCmdEx(cmd)
+    if exitCode == QuitSuccess and name.len > 0:
+      result = name.strip()
+      display("Using", "$# for new package author" % [result],
+        priority = HighPriority)
+
+  # Determine package author via git/hg or asking
   proc getAuthor(): string =
     if findExe("git") != "":
-      let (name, exitCode) = doCmdEx("git config --global user.name")
-      if exitCode == QuitSuccess and name.len > 0:
-        result = name.strip()
-        display("Using", "$# for new package author" % [result.escape()],
-          priority = HighPriority)
+      result = getAuthorWithCmd("git config --global user.name")
     elif findExe("hg") != "":
-      let (name, exitCode) = doCmdEx("hg config ui.username")
-      if exitCode == QuitSuccess and name.len > 0:
-        result = name.strip()
-        display("Using", "$# for new package author" % [result.escape()],
-          priority = HighPriority)
+      result = getAuthorWithCmd("hg config ui.username")
     if result.len == 0:
       result = promptCustom(options, "Your name?", "Anonymous")
   let pkgAuthor = getAuthor()

--- a/src/nimblepkg/init.nim
+++ b/src/nimblepkg/init.nim
@@ -175,7 +175,7 @@ $#
 
 requires "nim >= $#"
 """ % [
-      info.pkgVersion.escape(), info.pkgAuthor.escape(), info.pkgDesc.escape(),
+      info.pkgVersion.escape(), info.pkgAuthor, info.pkgDesc.escape(),
       info.pkgLicense.escape(), info.pkgSrcDir.escape(), nimbleFileOptions,
       pkgBackend, info.pkgNimDep
     ]

--- a/src/nimblepkg/init.nim
+++ b/src/nimblepkg/init.nim
@@ -175,7 +175,7 @@ $#
 
 requires "nim >= $#"
 """ % [
-      info.pkgVersion.escape(), info.pkgAuthor, info.pkgDesc.escape(),
+      info.pkgVersion.escape(), info.pkgAuthor, info.pkgDesc,
       info.pkgLicense.escape(), info.pkgSrcDir.escape(), nimbleFileOptions,
       pkgBackend, info.pkgNimDep
     ]


### PR DESCRIPTION
...since it replaces characters used in many names and languages with escape sequences.

Slightly refactor the code for determining author name, to make it easier to add other version control systems in future (right now it's just git and hg).

Also, add some binary test artifacts to .gitignore so they don't accidentally get committed in future.

Fixes issue #410.