### PR TITLE
Fix multiple downloads and installs of the same package (#678)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,12 @@ tests/testCommand/testsFail/tests/t2
 *.ilk
 *.pdb
 
+# Editors and IDEs project files and folders
+.vscode
+
+# VCS artifacts
+*.orig
+
+# Test procedure artifacts
+tests/nimble-test/
+nimble_*.nims

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -3,6 +3,8 @@
 
 # Nimble changelog
 
+- Fixed multiple downloads and installs of the same package (#678).
+
 ## 0.10.2 - 03/06/2019
 
 This is a small release which avoids object variant changes that are now

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -156,7 +156,8 @@ proc processDeps(pkginfo: PackageInfo, options: Options): seq[PackageInfo] =
           "dependencies for $1@$2" % [pkginfo.name, pkginfo.specialVersion],
           priority = HighPriority)
 
-  var pkgList = getInstalledPkgsMin(options.getPkgsDir(), options)
+  var pkgList {.global.}: seq[tuple[pkginfo: PackageInfo, meta: MetaData]] = @[]
+  once: pkgList = getInstalledPkgsMin(options.getPkgsDir(), options)
   var reverseDeps: seq[tuple[name, version: string]] = @[]
   for dep in pkginfo.requires:
     if dep.name == "nimrod" or dep.name == "nim":

--- a/tests/issue678/issue678.nimble
+++ b/tests/issue678/issue678.nimble
@@ -1,0 +1,12 @@
+# Package
+
+version     = "0.1.0"
+author      = "Ivan Bobev"
+description = "Package for ensuring that issue #678 is resolved."
+license     = "MIT"
+
+# Dependencies
+
+requires "nim >= 0.19.6"
+# to reproduce dependency 2 must be before 1
+requires "issue678_dependency_2", "issue678_dependency_1"

--- a/tests/issue678/packages.json
+++ b/tests/issue678/packages.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "issue678_dependency_1",
+    "url": "https://github.com/bobeff/issue678?subdir=dependency_1",
+    "method": "git",
+    "tags": [ "test" ], 
+    "description":
+      "Both first and second level dependency of the issue678 package.",
+    "license": "MIT"
+  },
+  {
+    "name": "issue678_dependency_2",
+    "url": "https://github.com/bobeff/issue678?subdir=dependency_2",
+    "method": "git",
+    "tags": [ "test" ],
+    "description": "First level dependency of the issue678 package.",
+    "license": "MIT"
+  }
+]


### PR DESCRIPTION
This is a new pull request for #678. I decided to implement the unit test in the standard way with an additional remote repository. As for the local dependencies feature it can be implemented in the future as separate issue, when it is being decided how exactly it have to behave. For now, it is not clear to me which is the right way to do it. The refactoring stuff eventually will be applied with a separate pull request for #680.

> I can give you access to https://github.com/nimble-test/ if you're up for doing it this way.

Yes, please give me access to it, to be able to transfer the ownership of the [issue678 test repository](https://github.com/bobeff/issue678) to you.