### PR TITLE
Fix #633 - pass CLI to tasks

### DIFF
--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -40,9 +40,17 @@ proc execNimscript(nimsFile, projectDir, actionName: string, options: Options):
     if not isScriptResultCopied:
       nimsFileCopied.removeFile()
 
-  let
+  var
     cmd = ("nim e --hints:off --verbosity:0 -p:" & (getTempDir() / "nimblecache").quoteShell &
       " " & nimsFileCopied.quoteShell & " " & outFile.quoteShell & " " & actionName).strip()
+
+  if options.action.typ == actionCustom and actionName != "printPkgInfo":
+    for i in options.action.arguments:
+      cmd &= " " & i.quoteShell()
+    for key, val in options.action.flags.pairs():
+      cmd &= " $#$#" % [if key.len == 1: "-" else: "--", key]
+      if val.len != 0:
+        cmd &= ":" & val.quoteShell()
 
   displayDebug("Executing " & cmd)
 

--- a/tests/issue633/issue633.nimble
+++ b/tests/issue633/issue633.nimble
@@ -1,0 +1,16 @@
+# Package
+
+version     = "0.1.0"
+author      = "GT"
+description = "Package for ensuring that issue #633 is resolved."
+license     = "MIT"
+
+# Dependencies
+
+requires "nim >= 0.19.6"
+# to reproduce dependency 2 must be before 1
+
+task testTask, "Test":
+  for i in 0 .. paramCount():
+    if paramStr(i) == "--testTask":
+      echo "Got it"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -860,3 +860,8 @@ test "do not install single dependency multiple times (#678)":
       let (output, exitCode) = execNimble("install", "-y")
       check exitCode == QuitSuccess
       check output.find("issue678_dependency_1@0.1.0 already exists") == -1
+
+test "Passing command line arguments to a task (#633)":
+  cd "issue633":
+    var (output, exitCode) = execNimble("testTask --testTask")
+    check output.contains("Got it")


### PR DESCRIPTION
Args and flags are now forwarded to the tasks in this PR but considering nimble now uses `nim e`, we have to pass a bunch of other flags to the compiler which results in a long list of stuff that task writers have to skip.

From the original issue:
```
nimble dmdm --abc
  Executing task dmdm in /home/binhong/wings/wings.nimble
7
/home/binhong/.choosenim/toolchains/nim-0.20.2/bin/nim
e
--hints:off
--verbosity:0
-p:/tmp/nimblecache
/home/binhong/wings/wings_21085.nims
/tmp/nimble_21085.out
dmdm
```

Any suggestions to simplify or clean this up will be helpful.