### PR TITLE
Fix issue678 test repository links

### DIFF
--- a/tests/issue678/packages.json
+++ b/tests/issue678/packages.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "issue678_dependency_1",
-    "url": "https://github.com/bobeff/issue678?subdir=dependency_1",
+    "url": "https://github.com/nimble-test/issue678?subdir=dependency_1",
     "method": "git",
     "tags": [ "test" ], 
     "description":
@@ -10,7 +10,7 @@
   },
   {
     "name": "issue678_dependency_2",
-    "url": "https://github.com/bobeff/issue678?subdir=dependency_2",
+    "url": "https://github.com/nimble-test/issue678?subdir=dependency_2",
     "method": "git",
     "tags": [ "test" ],
     "description": "First level dependency of the issue678 package.",


### PR DESCRIPTION
After the ownership of the [issue678](https://github.com/bobeff/issue678) test repository was transferred to the [nimble-test](https://github.com/nimble-test) account, the links to the repository required for performing the test had to be updated in order to avoid possible confusion, despite the fact that GitHub does automatic link redirection for transferred repositories.
