### PR TITLE
Option to provide JSON output from search and list commands

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -15,6 +15,7 @@ type
     uninstallRevDeps*: bool
     queryVersions*: bool
     queryInstalled*: bool
+    jsonOutput*:bool
     nimbleDir*: string
     verbosity*: cli.Priority
     action*: Action
@@ -101,8 +102,10 @@ Commands:
                                   can be optionally specified.
   search       pkg/tag            Searches for a specified package. Search is
                                   performed by tag and by name.
+               [--json]           Format output as JSON.
                [--ver]            Query remote server for package version.
   list                            Lists all packages.
+               [--json]           Format output as JSON.
                [--ver]            Query remote server for package version.
                [-i, --installed]  Lists all installed packages.
   tasks                           Lists the tasks specified in the Nimble
@@ -120,6 +123,8 @@ Options:
   -v, --version                   Print version information.
   -y, --accept                    Accept all interactive prompts.
   -n, --reject                    Reject all interactive prompts.
+      --json                      Produce JSON formatted output when
+                                  searching or listing packages
       --ver                       Query remote server for package version
                                   information when searching or listing packages
       --nimbleDir:dirname         Set the Nimble directory.
@@ -339,6 +344,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.queryInstalled = true
     of "ver":
       result.queryVersions = true
+    of "json":
+      result.jsonOutput = true
     else:
       wasFlagHandled = false
   of actionInstall:

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -425,6 +425,18 @@ proc echoPackage*(pkg: Package) =
     if pkg.web.len > 0:
       echo("  website:     " & pkg.web)
 
+func toJson*(pkg: Package, queryVersions = false): JsonNode =
+  result = %*{
+    "name": %pkg.name,
+    "url": %pkg.url,
+    "method": %pkg.downloadMethod,
+    "tags": %pkg.tags,
+    "description": %pkg.description,
+    "license": %pkg.license,
+  }
+  if pkg.web.len > 0:
+    result["web"] = %pkg.web
+
 proc getDownloadDirName*(pkg: Package, verRange: VersionRange): string =
   result = pkg.name
   let verSimple = getSimpleString(verRange)


### PR DESCRIPTION
JSON output is helpful for transforming Nimble metadata into other kinds of packaging.

Ref https://github.com/NixOS/nixpkgs/pull/67878