### PR TITLE
Fixes #710.

### DIFF
--- a/tests/invalidPackage/invalidPackage.nimble
+++ b/tests/invalidPackage/invalidPackage.nimble
@@ -1,0 +1,13 @@
+# Package
+
+version       = "0.1.0"
+author        = "Dominik Picheta"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+thisFieldDoesNotExist = "hello"
+
+# Dependencies
+
+requires "nim >= 0.20.0"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -86,6 +86,13 @@ test "depsOnly + flag order test":
   check(not output.contains("Success: packagebin2 installed successfully."))
   check exitCode == QuitSuccess
 
+test "nimscript evaluation error message":
+  cd "invalidPackage":
+    var (output, exitCode) = execNimble("check")
+    let lines = output.strip.processOutput()
+    check(lines[^2].endsWith("Error: undeclared identifier: 'thisFieldDoesNotExist'"))
+    check exitCode == QuitFailure
+
 test "caching of nims and ini detects changes":
   cd "caching":
     var (output, exitCode) = execNimble("dump")


### PR DESCRIPTION
Ended up having to enable live output for tasks but not when getting Nimble file metadata. That should give us the best of both worlds and the expense of some extra complexity.