### PR TITLE
Enable compile-time echos

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -251,9 +251,9 @@ proc buildFromDir(
       createDir(outputDir)
 
     try:
-      doCmd("\"" & getNimBin() & "\" $# --noNimblePath $# $# $# \"$#\"" %
+      doCmd("\"" & getNimBin() & "\" --hints=off $# --noNimblePath $# $# $# \"$#\"" %
             [pkgInfo.backend, nimblePkgVersion, join(args, " "), outputOpt,
-             realDir / bin.changeFileExt("nim")])
+             realDir / bin.changeFileExt("nim")], true)
       binariesBuilt.inc()
     except NimbleError:
       let currentExc = (ref NimbleError)(getCurrentException())


### PR DESCRIPTION
When using nimble to compile files, `echo`s in static blocks will be shown on stdout.