### PR TITLE
Capitalize the "D" in srcDir to avoid errors when using styleChecks

### DIFF
--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -17,7 +17,7 @@ var
   author*: string      ## The package's author.
   description*: string ## The package's description.
   license*: string     ## The package's license.
-  srcdir*: string      ## The package's source directory.
+  srcDir*: string      ## The package's source directory.
   binDir*: string      ## The package's binary directory.
   backend*: string     ## The package's backend.
 
@@ -101,7 +101,7 @@ proc printPkgInfo(): string =
   printIfLen author
   printIfLen description
   printIfLen license
-  printIfLen srcdir
+  printIfLen srcDir
   printIfLen binDir
   printIfLen backend
 


### PR DESCRIPTION
Fixes #740

When using a config.nims containing `--styleCheck:error`, `srcDir` will no longer throw an error. Originally, nimscriptapi.nim defined the variable as `srcdir`, without the capitalized D. As nimble generates a nimble file containing `srcDir` (with the capital D), the compiler would error out.

I know this is a small change, but since everywhere else refers to the variable as `srcDir`, I think it's a good change.