### PR TITLE
Run can work without additional option if only one bin in .nimble

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -89,8 +89,8 @@ Commands:
   uninstall    [pkgname, ...]     Uninstalls a list of packages.
                [-i, --inclDeps]   Uninstall package and dependent package(s).
   build        [opts, ...] [bin]  Builds a package.
-  run          [opts, ...] bin    Builds and runs a package.
-                                  A binary name needs
+  run          [opts, ...] [bin]  Builds and runs a package.
+                                  If several binaries defined then binary name needs
                                   to be specified after any compilation options,
                                   any flags after the binary name are passed to
                                   the binary when it is run.

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -266,8 +266,8 @@ proc parseCommand*(key: string, result: var Options) =
   result.action = Action(typ: parseActionType(key))
   initAction(result, key)
 
-proc setRunOptions(result: var Options, key, val: string, okForRun: bool) =
-  if okForRun and result.action.runFile.isNone():
+proc setRunOptions(result: var Options, key, val: string, isArg: bool) =
+  if result.action.runFile.isNone() and (isArg or val == "--"):
     result.action.runFile = some(key)
   else:
     result.action.runFlags.add(val)
@@ -374,7 +374,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.action.compileOptions.add(getFlagString(kind, flag, val))
   of actionRun:
     result.showHelp = false
-    result.setRunOptions(flag, getFlagString(kind, flag, val), flag == "" and val == "")
+    result.setRunOptions(flag, getFlagString(kind, flag, val), false)
   of actionCustom:
     if result.action.command.normalize == "test":
       if f == "continue" or f == "c":

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -266,8 +266,8 @@ proc parseCommand*(key: string, result: var Options) =
   result.action = Action(typ: parseActionType(key))
   initAction(result, key)
 
-proc setRunOptions(result: var Options, key, val: string) =
-  if result.action.runFile.isNone():
+proc setRunOptions(result: var Options, key, val: string, okForRun: bool) =
+  if okForRun and result.action.runFile.isNone():
     result.action.runFile = some(key)
   else:
     result.action.runFlags.add(val)
@@ -303,7 +303,7 @@ proc parseArgument*(key: string, result: var Options) =
   of actionBuild:
     result.action.file = key
   of actionRun:
-    result.setRunOptions(key, key)
+    result.setRunOptions(key, key, true)
   of actionCustom:
     result.action.arguments.add(key)
   else:
@@ -374,7 +374,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.action.compileOptions.add(getFlagString(kind, flag, val))
   of actionRun:
     result.showHelp = false
-    result.setRunOptions(flag, getFlagString(kind, flag, val))
+    result.setRunOptions(flag, getFlagString(kind, flag, val), flag == "" and val == "")
   of actionCustom:
     if result.action.command.normalize == "test":
       if f == "continue" or f == "c":

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -90,10 +90,10 @@ Commands:
                [-i, --inclDeps]   Uninstall package and dependent package(s).
   build        [opts, ...] [bin]  Builds a package.
   run          [opts, ...] [bin]  Builds and runs a package.
-                                  If several binaries defined then binary name needs
-                                  to be specified after any compilation options,
-                                  any flags after the binary name are passed to
-                                  the binary when it is run.
+                                  If there are several binaries defined then binary
+                                  needs to be specified after any compilation
+                                  options, any flags after the binary or -- arg
+                                  are passed to the binary when it is run.
   c, cc, js    [opts, ...] f.nim  Builds a file inside a package. Passes options
                                   to the Nim compiler.
   test                            Compiles and executes tests

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -526,15 +526,23 @@ proc getCompilationFlags*(options: Options): seq[string] =
   var opt = options
   return opt.getCompilationFlags()
 
-proc getCompilationBinary*(options: Options): Option[string] =
+proc getCompilationBinary*(options: Options, pkgInfo: PackageInfo): Option[string] =
   case options.action.typ
   of actionBuild, actionDoc, actionCompile:
     let file = options.action.file.changeFileExt("")
     if file.len > 0:
       return some(file)
   of actionRun:
-    let runFile = options.action.runFile.changeFileExt(ExeExt)
+    let optRunFile = options.action.runFile
+    let runFile =
+      if optRunFile.len > 0:
+        optRunFile
+      elif pkgInfo.bin.len == 1:
+        pkgInfo.bin[0]
+      else:
+        ""
+
     if runFile.len > 0:
-      return some(runFile)
+      return some(runFile.changeFileExt(ExeExt))
   else:
     discard

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -950,6 +950,32 @@ suite "nimble run":
                             [$DirSep, "run".changeFileExt(ExeExt)])
       check output.contains("""Testing `nimble run`: @["--debug", "check"]""")
 
+  test "Parameters not passed to single executable":
+    cd "run":
+      var (output, exitCode) = execNimble(
+        "--debug", # Flag to enable debug verbosity in Nimble
+        "run", # Run command invokation
+        "--debug" # First argument passed to the executed command
+      )
+      check exitCode == QuitSuccess
+      check output.contains("tests$1run$1$2 --debug" %
+                            [$DirSep, "run".changeFileExt(ExeExt)])
+      check output.contains("""Testing `nimble run`: @["--debug"]""")
+
+  test "Parameters passed to single executable":
+    cd "run":
+      var (output, exitCode) = execNimble(
+        "--debug", # Flag to enable debug verbosity in Nimble
+        "run", # Run command invokation
+        "--", # Flag to set run file to "" before next argument
+        "--debug", # First argument passed to the executed command
+        "check" # Second argument passed to the executed command.
+      )
+      check exitCode == QuitSuccess
+      check output.contains("tests$1run$1$2 --debug check" %
+                            [$DirSep, "run".changeFileExt(ExeExt)])
+      check output.contains("""Testing `nimble run`: @["--debug", "check"]""")
+
 test "NimbleVersion is defined":
   cd "nimbleVersionDefine":
     var (output, exitCode) = execNimble("c", "-r", "src/nimbleVersionDefine.nim")


### PR DESCRIPTION
if you have only one bin in .nimble.

before:
  you have to specific executable every time: nimble run my_tool

after PR:
  you can just: nimble run

additional fix:
before:
  windows parsed empty option not correct => ".exe"

after PR:
  it will raise correct exception "Please specify a binary to run" if binary not defined in opts or config