### PR TITLE
nimscript{wrapper,api}: don't copy generated script to package directory

### DIFF
--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -38,6 +38,7 @@ var
   success = false
   retVal = true
   projectFile = ""
+  scriptFile = ""
   outFile = ""
 
 proc requires*(deps: varargs[string]) =
@@ -52,7 +53,9 @@ proc getParams() =
     let
       param = paramStr(i)
     if param[0] != '-':
-      if projectFile.len == 0:
+      if scriptFile.len == 0:
+        scriptFile = param
+      elif projectFile.len == 0:
         projectFile = param
       elif outFile.len == 0:
         outFile = param

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -38,7 +38,7 @@ proc writeExecutionOutput(data: string) =
 
 proc execNimscript(
   nimsFile, projectDir, actionName: string, options: Options, isHook: bool,
-  nimbleFile = ""
+  nimbleFile: string
 ): tuple[output: string, exitCode: int, stdout: string] =
   let
     outFile = getNimbleTempDir() & ".out"
@@ -49,7 +49,7 @@ proc execNimscript(
       (getTempDir() / "nimblecache").quoteShell,
       projectDir.quoteShell,
       nimsFile.quoteShell,
-      if nimbleFile.len > 0: nimbleFile.quoteShell else: "",
+      nimbleFile.quoteShell,
       outFile.quoteShell,
       actionName
     ]

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -66,19 +66,19 @@ proc execNimscript(
 
   displayDebug("Executing " & cmd)
 
-  var poptions = {poEvalCommand}
+  var processOpts = {poEvalCommand}
   if needsLiveOutput(actionName, options, isHook):
-    poptions.incl poParentStreams
+    processOpts.incl poParentStreams
   else:
-    poptions.incl poStdErrToStdOut
+    processOpts.incl poStdErrToStdOut
   let scriptRunner = startProcess(
     cmd,
     workingDir = projectDir,
-    options = poptions
+    options = processOpts
   )
   defer: close scriptRunner
   result.exitCode = waitForExit(scriptRunner)
-  if poParentStreams notin poptions:
+  if poParentStreams notin processOpts:
     # We want to capture any possible errors when parsing a .nimble
     # file's metadata. See #710.
     result.stdout = scriptRunner.outputStream.readAll()


### PR DESCRIPTION
This allows nimble to process read-only package directories.

Pretty much a draft for now since I don't have any way to test for this implementation shortcomings.

In short, instead of copying the generated script to the package dir, I run it directly in the nimble cache with paths pointing to the package dir as well as some magic to fool the script into thinking that it's running inside the package dir.

/cc @genotrance