### PR TITLE
Remove ~/.nimble from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 
 cache:
   directories:
-    - "$HOME/.nimble/bin"
     - "$HOME/.choosenim"
 
 install:


### PR DESCRIPTION
Fix CI failure reported here - https://github.com/nim-lang/nimble/pull/771#issuecomment-584724908

cc @atstp