### PR TITLE
fix for https://github.com/nim-lang/Nim/pull/13642

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1044,7 +1044,7 @@ proc test(options: Options) =
   var pkgInfo = getPkgInfo(getCurrentDir(), options)
 
   var
-    files = toSeq(walkDir(getCurrentDir() / "tests"))
+    files = toSeq(walkDir(getCurrentDir() / "tests", checkDir = false))
     tests, failures: int
 
   if files.len < 1:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1043,8 +1043,10 @@ proc test(options: Options) =
   ## Subdirectories are not walked.
   var pkgInfo = getPkgInfo(getCurrentDir(), options)
 
+  var files: seq[string]
+  let testsDir = getCurrentDir() / "tests"
+  if testsDir.existsDir: files = toSeq(walkDir(testsDir))
   var
-    files = toSeq(walkDir(getCurrentDir() / "tests", checkDir = false))
     tests, failures: int
 
   if files.len < 1:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1043,8 +1043,8 @@ proc test(options: Options) =
   ## Subdirectories are not walked.
   var pkgInfo = getPkgInfo(getCurrentDir(), options)
 
-  var files: seq[string]
   let testsDir = getCurrentDir() / "tests"
+  var files: seq[typeof(walkDir(testsDir))]
   if testsDir.existsDir: files = toSeq(walkDir(testsDir))
   var
     tests, failures: int

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -517,7 +517,7 @@ proc iterInstallFiles*(realDir: string, pkgInfo: PackageInfo,
 
     iterFilesWithExt(realDir, pkgInfo, action)
   else:
-    for kind, file in walkDir(realDir):
+    for kind, file in walkDir(realDir, checkDir = false):
       if kind == pcDir:
         let skip = pkgInfo.checkInstallDir(realDir, file)
         if skip: continue

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -516,8 +516,10 @@ proc iterInstallFiles*(realDir: string, pkgInfo: PackageInfo,
       iterFilesInDir(src, action)
 
     iterFilesWithExt(realDir, pkgInfo, action)
-  else:
-    for kind, file in walkDir(realDir, checkDir = false):
+  elif existsDir(realDir):
+    # check `existsDir` for things like:
+    # "C:\\Users\\foo\\.nimble\\pkgs\\chroma-0.1.0\\src
+    for kind, file in walkDir(realDir):
       if kind == pcDir:
         let skip = pkgInfo.checkInstallDir(realDir, file)
         if skip: continue


### PR DESCRIPTION
* fix to unblock https://github.com/nim-lang/Nim/pull/13642
* the change in src/nimble.nim is done so that packages that put tests in wrong place (eg test instead of tests) don't cause nim CI to fail; after the packages identified in https://github.com/nim-lang/Nim/pull/13642#issuecomment-599168662 update their pacakges, the change in this file could be reverted to cause an error, for eg:
```
nimble test foo # error if no tests dir nor test task
nimble test --allowempty foo # no error if no tests dir nor test task
```
(refs https://github.com/nim-lang/nimble/issues/558 ; a warning is not enough, default should be error, but that's orthogonal to this PR)

/cc @dom96 the CI error seems mysterious and unrelated to this PR (and I'm also seeing it for another unrelated PR https://github.com/nim-lang/nimble/pull/781), do you know the source of this error?