### PR TITLE
`nimble test` keeps git status clean; prevents accidental checking in of binaries etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# ignore files wo extension (posix binaries)
+*
+!*.*
+!*/
+
+
 # Any path
 *.swp
 *~
@@ -6,15 +12,6 @@ nimcache/
 # Absolute paths
 /src/babel
 /src/nimble
-
-# executables from test and build
-/nimble
-src/nimblepkg/cli
-src/nimblepkg/packageinfo
-src/nimblepkg/packageparser
-src/nimblepkg/reversedeps
-src/nimblepkg/version
-src/nimblepkg/download
 
 # Windows executables
 *.exe
@@ -31,4 +28,13 @@ src/nimblepkg/download
 *.orig
 
 # Test procedure artifacts
-nimble_*.nims
+/buildTests
+
+# executables from test and build (already gitignored but keeping for documentation)
+# /nimble
+# src/nimblepkg/cli
+# src/nimblepkg/packageinfo
+# src/nimblepkg/packageparser
+# src/nimblepkg/reversedeps
+# src/nimblepkg/version
+# src/nimblepkg/download

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -3,6 +3,12 @@
 # tester
 /nimble-test
 /issue799/issue799
+/issue308515/v1/binname.out
+/issue308515/v2/binname.out
+/localdeps/nimbledeps/
+/multi/
+/packagea/
+
 
 # occurs on multiple levels
 nimbleDir/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,24 +1,11 @@
-tester
+# ideally this shouldn't even be needed and all generated files would go under ../buildTests/
+
+# tester
 /nimble-test
-/buildDir
-/binaryPackage/v1/binaryPackage
-/binaryPackage/v2/binaryPackage
-/develop/dependent/src/dependent
-/issue27/issue27
-/issue206/issue/issue206bin
-/issue289/issue289
-/issue428/nimbleDir/
-/nimbleDir/
-/packageStructure/c/c
-/packageStructure/y/y
-/testCommand/testOverride/myTester
-/testCommand/testsFail/tests/a
-/testCommand/testsFail/tests/b
-/testCommand/testsPass/tests/one
-/testCommand/testsPass/tests/three
-/testCommand/testsPass/tests/two
-/nimscript/nimscript
-/packageStructure/validBinary/y
-/testCommand/testsFail/tests/t2
-/passNimFlags/passNimFlags
 /issue799/issue799
+
+# occurs on multiple levels
+nimbleDir/
+
+# generated nims files
+*_*.nims

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,0 +1,4 @@
+# this also doesn't work (even in nims): --outdir:"$nimcache/buildTests"
+import os
+let buildDir = currentSourcePath().parentDir.parentDir / "buildTests"
+switch("outdir", buildDir)

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -9,6 +9,7 @@ import osproc, unittest, strutils, os, sequtils, sugar, strformat
 let rootDir = getCurrentDir().parentDir()
 let nimblePath = rootDir / "src" / addFileExt("nimble", ExeExt)
 let installDir = rootDir / "tests" / "nimbleDir"
+let buildTests = rootDir / "buildTests"
 const path = "../src/nimble"
 const stringNotFound = -1
 
@@ -962,8 +963,9 @@ suite "issues":
     cd "issue727":
       var (output, exitCode) = execNimbleYes("c", "src/abc")
       check exitCode == QuitSuccess
-      check fileExists("src/abc".addFileExt(ExeExt))
+      check fileExists(buildTests / "abc".addFileExt(ExeExt))
       check not fileExists("src/def".addFileExt(ExeExt))
+      check not fileExists(buildTests / "def".addFileExt(ExeExt))
 
       (output, exitCode) = execNimbleYes("uninstall", "-i", "timezones")
       check exitCode == QuitSuccess


### PR DESCRIPTION
* git status should always be clean when running tests. after this PR (say, from a fresh nimble clone), `nimble test`  should keep `git status` clean
* this prevents accidental checking in of binaries etc
* speaking of which, I `git rm tests/nimbleVersionDefine/src/nimbleVersionDefine` in this PR
* try as much as possible to build test artifacts under a single dir (can be improved in future PR's)
* simplify & more robust/DRY gitignore logic in particular for genarated nims binaries and binaries without extensions




