### PR TITLE
Fix nimble because `paramCount` & `paramStr` for nimscript are now defined in os.nim

### DIFF
--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -6,7 +6,10 @@
 import system except getCommand, setCommand, switch, `--`
 import strformat, strutils, tables
 
-when not defined(nimscript):
+when (NimMajor, NimMinor) < (1, 3):
+  when not defined(nimscript):
+    import os
+else:
   import os
 
 var


### PR DESCRIPTION
Required for https://github.com/nim-lang/Nim/pull/12860