### PR TITLE
fix for issue #799

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -456,11 +456,13 @@ proc installFromDir(dir: string, requestedVer: VersionRange, options: Options,
   # processDeps).
   saveNimbleData(options)
 
+  # update package path to point to installed directory rather than the temp directory
+  pkgInfo.myPath = dest
+
   # Return the dependencies of this package (mainly for paths).
   result.deps.add pkgInfo
   result.pkg = pkgInfo
   result.pkg.isInstalled = true
-  result.pkg.myPath = dest
 
   display("Success:", pkgInfo.name & " installed successfully.",
           Success, HighPriority)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -458,11 +458,11 @@ proc installFromDir(dir: string, requestedVer: VersionRange, options: Options,
 
   # update package path to point to installed directory rather than the temp directory
   pkgInfo.myPath = dest
+  pkgInfo.isInstalled = true
 
   # Return the dependencies of this package (mainly for paths).
   result.deps.add pkgInfo
   result.pkg = pkgInfo
-  result.pkg.isInstalled = true
 
   display("Success:", pkgInfo.name & " installed successfully.",
           Success, HighPriority)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -21,3 +21,4 @@ tester
 /packageStructure/validBinary/y
 /testCommand/testsFail/tests/t2
 /passNimFlags/passNimFlags
+/issue799/issue799

--- a/tests/issue799/issue799.nim
+++ b/tests/issue799/issue799.nim
@@ -1,0 +1,7 @@
+
+import nimblepkg/tools
+import nimblepkg/version
+
+when isMainModule:
+  let current_version = getNimrodVersion()
+  echo $current_version

--- a/tests/issue799/issue799.nimble
+++ b/tests/issue799/issue799.nimble
@@ -1,0 +1,13 @@
+# Package
+
+version     = "0.1.0"
+author      = "Author"
+description = "package to test issue #799"
+license     = "MIT"
+
+bin         = @["issue799"]
+
+# Dependencies
+requires "nim >= 0.16.0"
+
+requires "nimble#head"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1043,3 +1043,18 @@ test "compilation without warnings":
     check exitCode == QuitSuccess
     linesWithWarningsCount += checkOutput(output)
   check linesWithWarningsCount == 0
+
+
+suite "Package Installation":
+
+  # When building, any newly installed packages should be referenced via the path that they get permanently installed at.
+  test "issue799":
+    cd "issue799":
+      let (build_output, build_code) = execNimbleYes("--verbose", "build")
+      check build_code == 0
+      var build_results = processOutput(build_output)
+      build_results.keepItIf(unindent(it).startsWith("Executing"))
+      for build_line in build_results:
+        if build_line.contains("issue799"):
+          let pkg_installed_path = "--path:\"" & installDir / "pkgs" / "nimble-#head" & "\""
+          check build_line.contains(pkg_installed_path)


### PR DESCRIPTION
updates path to nimble package before assignment as result of package
installation, thus using the correct package path instead of the temporary path
the package was cloned into. (see issue #799 for more details)