### PR TITLE
Add warning  message when cloning the HEAD.

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -205,7 +205,7 @@ proc doDownload(url: string, downloadDir: string, verRange: VersionRange,
                   onlyTip = not options.forceFullClone)
       else:
         # If no commits have been tagged on the repo we just clone HEAD.
-        display("Warning:", "No corresponding tag found with required version. We grab HEAD.", Warning, 
+        display("Warning:", "The package has no tagged releases, downloading HEAD instead.", Warning, 
                   priority = HighPriority)
         doClone(downMethod, url, downloadDir) # Grab HEAD.
     of DownloadMethod.hg:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -205,6 +205,8 @@ proc doDownload(url: string, downloadDir: string, verRange: VersionRange,
                   onlyTip = not options.forceFullClone)
       else:
         # If no commits have been tagged on the repo we just clone HEAD.
+        display("Warning:", "No corresponding tag found with required version. We grab HEAD.", Warning, 
+                  priority = HighPriority)
         doClone(downMethod, url, downloadDir) # Grab HEAD.
     of DownloadMethod.hg:
       doClone(downMethod, url, downloadDir, onlyTip = not options.forceFullClone)
@@ -216,6 +218,9 @@ proc doDownload(url: string, downloadDir: string, verRange: VersionRange,
           display("Switching", "to latest tagged version: " & latest.tag,
                   priority = MediumPriority)
           doCheckout(downMethod, downloadDir, latest.tag)
+      else:
+        display("Warning:", "No corresponding tag found with required version.", Warning, 
+                  priority = HighPriority)
 
 proc downloadPkg*(url: string, verRange: VersionRange,
                  downMethod: DownloadMethod,

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -219,7 +219,7 @@ proc doDownload(url: string, downloadDir: string, verRange: VersionRange,
                   priority = MediumPriority)
           doCheckout(downMethod, downloadDir, latest.tag)
       else:
-        display("Warning:", "No corresponding tag found with required version.", Warning, 
+        display("Warning:", "The package has no tagged releases, downloading HEAD instead.", Warning, 
                   priority = HighPriority)
 
 proc downloadPkg*(url: string, verRange: VersionRange,


### PR DESCRIPTION
In answer of this [issue](https://github.com/nim-lang/packages/issues/1051), it is important to indicate that the developer use a package without git release tag.

This message, I hope, can also generate more serious in development process and improve the quality. In the common world, a release version has a git tag.