### PR TITLE
refs #803 add: `nimble dump --json` command

### DIFF
--- a/nimble.zsh-completion
+++ b/nimble.zsh-completion
@@ -4,7 +4,7 @@ _nimble() {
   local line
 
   _arguments -C \
-    '1: :(install init publish uninstall build c cc js doc doc2 refresh search list tasks path dump dumpJson develop)' \
+    '1: :(install init publish uninstall build c cc js doc doc2 refresh search list tasks path dump develop)' \
     '*::options:->options' \
     '(--version)--version[show version]' \
     '(--help)--help[show help]' \
@@ -28,7 +28,7 @@ _nimble() {
     install)
       _nimble_installable_packages
     ;;
-    uninstall|path|dump|dumpJson)
+    uninstall|path|dump)
       _nimble_installed_packages
     ;;
     init|publish|build|refresh|search|tasks)

--- a/nimble.zsh-completion
+++ b/nimble.zsh-completion
@@ -4,7 +4,7 @@ _nimble() {
   local line
 
   _arguments -C \
-    '1: :(install init publish uninstall build c cc js doc doc2 refresh search list tasks path dump develop)' \
+    '1: :(install init publish uninstall build c cc js doc doc2 refresh search list tasks path dump dumpJson develop)' \
     '*::options:->options' \
     '(--version)--version[show version]' \
     '(--help)--help[show help]' \
@@ -28,7 +28,7 @@ _nimble() {
     install)
       _nimble_installable_packages
     ;;
-    uninstall|path|dump)
+    uninstall|path|dump|dumpJson)
       _nimble_installed_packages
     ;;
     init|publish|build|refresh|search|tasks)

--- a/readme.markdown
+++ b/readme.markdown
@@ -24,6 +24,7 @@ Interested in learning **how to create a package**? Skip directly to that sectio
   - [nimble publish](#nimble-publish)
   - [nimble tasks](#nimble-tasks)
   - [nimble dump](#nimble-dump)
+  - [nimble dumpJson](#nimble-dumpJson)
 - [Configuration](#configuration)
 - [Creating Packages](#creating-packages)
   - [Project structure](#project-structure)
@@ -336,6 +337,10 @@ nimscript .nimble files.
 Outputs information about the package in the current working directory in
 an ini-compatible format. Useful for tools wishing to read metadata about
 Nimble packages who do not want to use the NimScript evaluator.
+
+### nimble dumpJson
+
+Same as `nimble dump` but in json format.
 
 ## Configuration
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -337,7 +337,8 @@ Outputs information about the package in the current working directory in
 an ini-compatible format. Useful for tools wishing to read metadata about
 Nimble packages who do not want to use the NimScript evaluator.
 
-Use `nimble --json dump` to output in json format.
+The format can be specified with `--json` or `--ini` (and defaults to `--ini`).
+Use `nimble dump pkg` to dump information about provided `pkg` instad.
 
 ## Configuration
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -24,7 +24,6 @@ Interested in learning **how to create a package**? Skip directly to that sectio
   - [nimble publish](#nimble-publish)
   - [nimble tasks](#nimble-tasks)
   - [nimble dump](#nimble-dump)
-  - [nimble dumpJson](#nimble-dumpJson)
 - [Configuration](#configuration)
 - [Creating Packages](#creating-packages)
   - [Project structure](#project-structure)
@@ -338,9 +337,7 @@ Outputs information about the package in the current working directory in
 an ini-compatible format. Useful for tools wishing to read metadata about
 Nimble packages who do not want to use the NimScript evaluator.
 
-### nimble dumpJson
-
-Same as `nimble dump` but in json format.
+Use `nimble --json dump` to output in json format.
 
 ## Configuration
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -713,11 +713,13 @@ proc getPackageByPattern(pattern: string, options: Options): PackageInfo =
 # import std/jsonutils
 proc `%`(a: Version): JsonNode = %a.string
 
-proc dump(options: Options, json: bool) =
+# proc dump(options: Options, json: bool) =
+proc dump(options: Options) =
   cli.setSuppressMessages(true)
   let p = getPackageByPattern(options.action.projName, options)
   var j: JsonNode
   var s: string
+  let json = options.dumpMode == kdumpJson
   if json: j = newJObject()
   template fn(key, val) =
     if json:
@@ -1222,9 +1224,7 @@ proc doAction(options: var Options) =
     var pkgInfo = getPkgInfo(getCurrentDir(), options)
     publish(pkgInfo, options)
   of actionDump:
-    dump(options, json = false)
-  of actionDumpJson:
-    dump(options, json = true)
+    dump(options)
   of actionTasks:
     listTasks(options)
   of actionDevelop:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -710,25 +710,57 @@ proc getPackageByPattern(pattern: string, options: Options): PackageInfo =
       )
     result = getPkgInfoFromFile(skeletonInfo.myPath, options)
 
-proc dump(options: Options) =
+# import std/jsonutils
+proc `%`(a: Version): JsonNode = %a.string
+
+proc dump(options: Options, json: bool) =
   cli.setSuppressMessages(true)
   let p = getPackageByPattern(options.action.projName, options)
-  echo "name: ", p.name.escape
-  echo "version: ", p.version.escape
-  echo "author: ", p.author.escape
-  echo "desc: ", p.description.escape
-  echo "license: ", p.license.escape
-  echo "skipDirs: ", p.skipDirs.join(", ").escape
-  echo "skipFiles: ", p.skipFiles.join(", ").escape
-  echo "skipExt: ", p.skipExt.join(", ").escape
-  echo "installDirs: ", p.installDirs.join(", ").escape
-  echo "installFiles: ", p.installFiles.join(", ").escape
-  echo "installExt: ", p.installExt.join(", ").escape
-  echo "requires: ", p.requires.join(", ").escape
-  echo "bin: ", p.bin.join(", ").escape
-  echo "binDir: ", p.binDir.escape
-  echo "srcDir: ", p.srcDir.escape
-  echo "backend: ", p.backend.escape
+  var j: JsonNode
+  var s: string
+  if json: j = newJObject()
+  template fn(key, val) =
+    if json:
+      when val is seq[PkgTuple]:
+        # jsonutils.toJson would work but is only available since 1.3.5, so we
+        # do it manually.
+        j[key] = newJArray()
+        for (name, ver) in val:
+          j[key].add %{
+            "name": % name,
+            # we serialize both: `ver` may be more convenient for tooling
+            # (no parsing needed); while verStr is more familiar.
+            "verStr": % $ver,
+            "ver": %* ver,
+          }
+      else:
+        j[key] = %*val
+    else:
+      if s.len > 0: s.add "\n"
+      s.add key & ": "
+      when val is string:
+        s.add val.escape
+      else:
+        s.add val.join(", ").escape
+  fn "name", p.name
+  fn "version", p.version
+  fn "author", p.author
+  fn "desc", p.description
+  fn "license", p.license
+  fn "skipDirs", p.skipDirs
+  fn "skipFiles", p.skipFiles
+  fn "skipExt", p.skipExt
+  fn "installDirs", p.installDirs
+  fn "installFiles", p.installFiles
+  fn "installExt", p.installExt
+  fn "requires", p.requires
+  fn "bin", p.bin
+  fn "binDir", p.binDir
+  fn "srcDir", p.srcDir
+  fn "backend", p.backend
+  if json:
+    s = j.pretty
+  echo s
 
 proc init(options: Options) =
   # Check whether the vcs is installed.
@@ -1190,7 +1222,9 @@ proc doAction(options: var Options) =
     var pkgInfo = getPkgInfo(getCurrentDir(), options)
     publish(pkgInfo, options)
   of actionDump:
-    dump(options)
+    dump(options, json = false)
+  of actionDumpJson:
+    dump(options, json = true)
   of actionTasks:
     listTasks(options)
   of actionDevelop:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -731,8 +731,8 @@ proc dump(options: Options) =
           j[key].add %{
             "name": % name,
             # we serialize both: `ver` may be more convenient for tooling
-            # (no parsing needed); while verStr is more familiar.
-            "verStr": % $ver,
+            # (no parsing needed); while `str` is more familiar.
+            "str": % $ver,
             "ver": %* ver,
           }
       else:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -32,7 +32,7 @@ type
     unknownFlags*: seq[(CmdLineKind, string, string)]
 
   ActionType* = enum
-    actionNil, actionRefresh, actionInit, actionDump, actionPublish,
+    actionNil, actionRefresh, actionInit, actionDump, actionDumpJson, actionPublish,
     actionInstall, actionSearch,
     actionList, actionBuild, actionPath, actionUninstall, actionCompile,
     actionDoc, actionCustom, actionTasks, actionDevelop, actionCheck,
@@ -49,7 +49,7 @@ type
       passNimFlags*: seq[string]
     of actionSearch:
       search*: seq[string] # Search string.
-    of actionInit, actionDump:
+    of actionInit, actionDump, actionDumpJson:
       projName*: string
       vcsOption*: string
     of actionCompile, actionDoc, actionBuild:
@@ -170,6 +170,8 @@ proc parseActionType*(action: string): ActionType =
     result = actionInit
   of "dump":
     result = actionDump
+  of "dumpjson":
+    result = actionDumpJson
   of "update", "refresh":
     result = actionRefresh
   of "search":
@@ -205,7 +207,7 @@ proc initAction*(options: var Options, key: string) =
   of actionInit:
     options.action.projName = ""
     options.action.vcsOption = ""
-  of actionDump:
+  of actionDump, actionDumpJson:
     options.action.projName = ""
     options.action.vcsOption = ""
     options.forcePrompts = forcePromptYes
@@ -290,7 +292,7 @@ proc parseArgument*(key: string, result: var Options) =
     result.action.optionalURL = key
   of actionSearch:
     result.action.search.add(key)
-  of actionInit, actionDump:
+  of actionInit, actionDump, actionDumpJson:
     if result.action.projName != "":
       raise newException(
         NimbleError, "Can only perform this action on one package at a time."


### PR DESCRIPTION
refs #803

## example

nimble dump --json cligen
```json
{
  "name": "cligen",
  "version": "0.9.46",
  "author": "Charles Blake",
  "desc": "Infer & generate command-line interace/option/argument parser",
  "license": "MIT/ISC",
  "skipDirs": [
    "test"
  ],
  "skipFiles": [],
  "skipExt": [],
  "installDirs": [
    "cligen"
  ],
  "installFiles": [
    "cligen.nim"
  ],
  "installExt": [],
  "requires": [
    {
      "name": "nim",
      "verStr": ">= 0.19.2",
      "ver": {
        "kind": "verEqLater",
        "ver": "0.19.2"
      }
    }
  ],
  "bin": [],
  "binDir": "",
  "srcDir": "",
  "backend": "c"
}
```


CI failure seems unrelated, is it time to retire 0.19.6 from travis? /cc @dom96 
```
Error: unhandled exception: C:\Users\travis\build\nim-lang\nimble\tests\tester.nim(23, 10) `execCmdEx("nim c ../src/nimble", {poStdErrToStdOut, poUsePath}).exitCode == 0`  [AssertionError]
Error: execution of an external program failed: 'C:\Users\travis\build\nim-lang\nimble\tests\tester.exe '
/c/Users/travis/.travis/functions: line 109: ./src/nimble: No such file or directory
gzip: warning: GZIP environment variable is deprecated; use an alias or script
uploading PR.810/cache--windows-1809-containers-dc9c8a84c165888cb42394129daee8603110d91b1aef291d81a8ea7579b8507b--compiler-gcc.tgz
cache uploaded
```