### PR TITLE
Fix #757 - compile flags for test

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -14,10 +14,10 @@ bug fixes with some minor improvements:
   compiler output.
 - Custom tasks can now be passed compiler flags as well as run flags when run
   as `nimble <compflags> task <runflags>`. This includes the custom `test`
-  task if defined. Compile flags can be used to set `--define:xxx` values that
-  can be checked with `when defined(xxx)` and other compiler flags that are
-  applicable in nimscript mode. Run flags can be accessed per usual from
-  `commandLineParams: seq[string]`.
+  task if defined. Compile flags are forwarded to `nim e` that executes the
+  `.nimble` task and can be used to set `--define:xxx` and other compiler flags
+  that are applicable in Nimscript mode. Run flags can be accessed per usual
+  from `commandLineParams: seq[string]`.
 - The default `nimble test` task also allows passing compiler flags but given
   run flags are not really applicable for multiple test binaries, it allows
   specifying compile flags before or after the `test` task.

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -3,6 +3,39 @@
 
 # Nimble changelog
 
+## 0.11.6 - TBD
+
+This is a minor release containing just X commits. This release brings mostly
+bug fixes with some minor improvements:
+
+- `nimble dump` now provides `--json` output.
+- Calls to the Nim compiler now display `--hints:off` output by default.
+  The `--verbose` flag will print the full Nim command as well as regular
+  compiler output.
+- Custom tasks can now be passed compiler flags as well as run flags when run
+  as `nimble <compflags> task <runflags>`. This includes the custom `test`
+  task if defined. Compile flags can be used to set `--define:xxx` values that
+  can be checked with `when defined(xxx)` and other compiler flags that are
+  applicable in nimscript mode. Run flags can be accessed per usual from
+  `commandLineParams: seq[string]`.
+- The default `nimble test` task also allows passing compiler flags but given
+  run flags are not really applicable for multiple test binaries, it allows
+  specifying compile flags before or after the `test` task.
+- `nimble install` also allows passing compiler flags similar to the default
+  `nimble test` and no longer requires the `--passNim` flag.
+
+----
+
+Full changelog: https://github.com/nim-lang/nimble/compare/v0.11.4...master
+
+## 0.11.4 - 19/05/2020
+
+This is a minor release containing just 2 commits and a few minor bug fixes.
+
+----
+
+Full changelog: https://github.com/nim-lang/nimble/compare/v0.11.2...v0.11.4
+
 ## 0.11.2 - 02/05/2020
 
 This is a minor release containing just 15 commits. This release brings mostly

--- a/readme.markdown
+++ b/readme.markdown
@@ -182,9 +182,12 @@ The latter command will install a version which is greater than ``0.5``.
 
 If you don't specify a parameter and there is a ``package.nimble`` file in your
 current working directory then Nimble will install the package residing in
-the current working directory. This can be useful for developers who are testing
-locally their ``.nimble`` files before submitting them to the official package
+the current working directory. This can be useful for developers who are locally
+testing their ``.nimble`` files before submitting them to the official package
 list. See the [Creating Packages](#creating-packages) section for more info on this.
+
+Nim flags provided to `nimble install` will be forwarded to the compiler when
+building any binaries.
 
 #### Package URLs
 
@@ -238,6 +241,8 @@ their ``.nimble`` package. This command will build the package with default
 flags, i.e. a debug build which includes stack traces but no GDB debug
 information. The ``install`` command will build the package in release mode
 instead.
+
+Nim flags provided to `nimble build` will be forwarded to the compiler.
 
 ### nimble run
 
@@ -496,6 +501,13 @@ also return ``false`` from these blocks to stop further execution.
 The ``nimscriptapi.nim`` module specifies this and includes other definitions
 which are also useful. Take a look at it for more information.
 
+Tasks support two kinds of flags: `nimble <compflags> task <runflags>`. Compile flags
+are those specified before the task name and are forwarded to the Nim compiler. This
+enables setting `--define:xxx` values that can be checked with `when defined(xxx)`
+and other compiler flags that are applicable in nimscript mode. Run flags are those
+after the task name and are available as command line arguments to the task. They can
+be accessed per usual from `commandLineParams: seq[string]`.
+
 ### Project structure
 
 For a package named "foobar", the recommended project structure is the following:
@@ -577,7 +589,9 @@ your ``tests`` directory with the following contents:
 ```
 
 Nimble offers a pre-defined ``test`` task which compiles and runs all files
-in the ``tests`` directory beginning with 't' in their filename.
+in the ``tests`` directory beginning with 't' in their filename. Nim flags
+provided to `nimble test` will be forwarded to the compiler when building
+the tests.
 
 You may wish to override this ``test`` task in your ``.nimble`` file. This
 is particularly useful when you have a single test suite program. Just add

--- a/readme.markdown
+++ b/readme.markdown
@@ -501,12 +501,17 @@ also return ``false`` from these blocks to stop further execution.
 The ``nimscriptapi.nim`` module specifies this and includes other definitions
 which are also useful. Take a look at it for more information.
 
-Tasks support two kinds of flags: `nimble <compflags> task <runflags>`. Compile flags
-are those specified before the task name and are forwarded to the Nim compiler. This
-enables setting `--define:xxx` values that can be checked with `when defined(xxx)`
-and other compiler flags that are applicable in nimscript mode. Run flags are those
-after the task name and are available as command line arguments to the task. They can
+Tasks support two kinds of flags: `nimble <compflags> task <runflags>`. Compile
+flags are those specified before the task name and are forwarded to the Nim
+compiler that runs the `.nimble` task. This enables setting `--define:xxx`
+values that can be checked with `when defined(xxx)` in the task, and other
+compiler flags that are applicable in Nimscript mode. Run flags are those after
+the task name and are available as command line arguments to the task. They can
 be accessed per usual from `commandLineParams: seq[string]`.
+
+In order to forward compiler flags to `exec("nim ...")` calls executed within a
+custom task, the user needs to specify these flags as run flags which will then
+need to be manually accessed and forwarded in the task.
 
 ### Project structure
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1115,7 +1115,7 @@ proc test(options: Options) =
       optsCopy.action = Action(typ: actionCompile)
       optsCopy.action.file = file.path
       optsCopy.action.backend = pkgInfo.backend
-      optsCopy.getCompilationFlags() = @[]
+      optsCopy.getCompilationFlags() = options.getCompilationFlags()
       optsCopy.getCompilationFlags().add("-r")
       optsCopy.getCompilationFlags().add("--path:.")
       let

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1116,6 +1116,8 @@ proc test(options: Options) =
       optsCopy.action.file = file.path
       optsCopy.action.backend = pkgInfo.backend
       optsCopy.getCompilationFlags() = options.getCompilationFlags()
+      # treat run flags as compile for default test task
+      optsCopy.getCompilationFlags().add(options.action.custRunFlags)
       optsCopy.getCompilationFlags().add("-r")
       optsCopy.getCompilationFlags().add("--path:.")
       let

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -44,10 +44,14 @@ proc execNimscript(
 ): tuple[output: string, exitCode: int, stdout: string] =
   let
     outFile = getNimbleTempDir() & ".out"
+    isCustomTask = isCustomTask(actionName, options)
+    compFlags = if isCustomTask: join(options.getCompilationFlags(), " ")
+      else: ""
 
   var cmd = (
-    getNimBin() & " e $# --colors:on $# $# $# $#" % [
+    getNimBin() & " e $# --colors:on $# $# $# $# $#" % [
       "--hints:off --verbosity:0",
+      compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,
       outFile.quoteShell,
@@ -55,11 +59,10 @@ proc execNimscript(
     ]
   ).strip()
 
-  let isCustomTask = isCustomTask(actionName, options)
   if isCustomTask:
     for i in options.action.arguments:
       cmd &= " " & i.quoteShell()
-    cmd &= " " & join(options.getCompilationFlags(), " ")
+    cmd &= " " & join(options.action.custRunFlags, " ")
 
   displayDebug("Executing " & cmd)
 

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -4,7 +4,7 @@
 ## Implements the new configuration system for Nimble. Uses Nim as a
 ## scripting language.
 
-import hashes, json, os, strutils, tables, times, osproc, strtabs
+import hashes, json, os, strutils, tables, times, osproc
 
 import version, options, cli, tools
 
@@ -59,10 +59,7 @@ proc execNimscript(
   if isCustomTask:
     for i in options.action.arguments:
       cmd &= " " & i.quoteShell()
-    for key, val in options.action.flags.pairs():
-      cmd &= " $#$#" % [if key.len == 1: "-" else: "--", key]
-      if val.len != 0:
-        cmd &= ":" & val.quoteShell()
+    cmd &= " " & join(options.getCompilationFlags(), " ")
 
   displayDebug("Executing " & cmd)
 

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -391,11 +391,12 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     result.showHelp = false
     result.setRunOptions(flag, getFlagString(kind, flag, val), false)
   of actionCustom:
-    if result.action.command.normalize == "test" and
-      f == "continue" or f == "c":
-        result.continueTestsOnFailure = true
-    elif not isGlobalFlag:
-      # Set run flags for task
+    if not isGlobalFlag:
+      if result.action.command.normalize == "test":
+        if f == "continue" or f == "c":
+          result.continueTestsOnFailure = true
+
+      # Set run flags for custom task
       result.action.custRunFlags.add(getFlagString(kind, flag, val))
   else:
     wasFlagHandled = false

--- a/tests/testCommand/testOverride/pkga.nimble
+++ b/tests/testCommand/testOverride/pkga.nimble
@@ -6,4 +6,6 @@ license       = "BSD"
 skipFiles = @["myTester.nim"]
 
 task test, "Custom tester":
-  exec "nim c -r myTester.nim"
+  when defined(CUSTOM):
+    exec "nim c -r myTester.nim"
+    echo commandLineParams.contains("--runflag")

--- a/tests/testCommand/testsPass/testing123.nim
+++ b/tests/testCommand/testsPass/testing123.nim
@@ -1,4 +1,7 @@
 
 proc myFunc*() =
+  when defined(CUSTOM):
     echo "Executing my func"
+  else:
+    echo "Missing -d:CUSTOM"
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -538,7 +538,7 @@ suite "develop feature":
 suite "test command":
   test "Runs passing unit tests":
     cd "testCommand/testsPass":
-      let (outp, exitCode) = execNimble("test")
+      let (outp, exitCode) = execNimble("test", "-d:CUSTOM") # Pass flags to test #757
       check exitCode == QuitSuccess
       check outp.processOutput.inLines("First test")
       check outp.processOutput.inLines("Second test")

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -538,7 +538,8 @@ suite "develop feature":
 suite "test command":
   test "Runs passing unit tests":
     cd "testCommand/testsPass":
-      let (outp, exitCode) = execNimble("test", "-d:CUSTOM") # Pass flags to test #757
+      # Pass flags to test #726, #757
+      let (outp, exitCode) = execNimble("test", "-d:CUSTOM")
       check exitCode == QuitSuccess
       check outp.processOutput.inLines("First test")
       check outp.processOutput.inLines("Second test")
@@ -555,9 +556,10 @@ suite "test command":
 
   test "test command can be overriden":
     cd "testCommand/testOverride":
-      let (outp, exitCode) = execNimble("test")
+      let (outp, exitCode) = execNimble("-d:CUSTOM", "test", "--runflag")
       check exitCode == QuitSuccess
       check outp.processOutput.inLines("overriden")
+      check outp.processOutput.inLines("true")
 
   test "certain files are ignored":
     cd "testCommand/testsIgnore":


### PR DESCRIPTION
- `nimble test` forwards non-nimble flags to compiler
- `--passNim` is no longer required for `nimble install` but still supported
- Pass compile flags to nimscript
- Cleaned up help
- Change log