### PR TITLE
cli: flush stdout before reading interactive input

### DIFF
--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -217,6 +217,8 @@ proc promptListInteractive(question: string, args: openarray[string]): string =
       cursorUp(stdout)
     resetAttributes(stdout)
 
+    # Ensure that the screen is updated before input
+    flushFile(stdout)
     # Begin key input
     while true:
       case getch():


### PR DESCRIPTION
This ensure that the screen content is up-to-date before any input is
received.

On certain systems, emitting control characters does not cause the
libc to flush stdout immediately, causing a "lag" feeling. This small
patch should handle those cases.