### PR TITLE
Improve compilation messages

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,3 @@
+@if nimHasWarningObservableStores:
+  --warning[ObservableStores]: off
+@end

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -20,7 +20,7 @@ removeDir(installDir)
 createDir(installDir)
 
 # Always recompile.
-doAssert execCmdEx("nim c -d:danger " & path).exitCode == QuitSuccess
+doAssert execCmdEx("nim c -d:danger " & path).exitCode == QuitSuccess, path
 
 template cd*(dir: string, body: untyped) =
   ## Sets the current dir to ``dir``, executes ``body`` and restores the


### PR DESCRIPTION
* Show path when `nimble` is not found, for debugging.
* Suppress ObservableStores warning.