### PR TITLE
cli(help): Document `nimble dump [--ini, --json]`

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -128,6 +128,7 @@ Commands:
                                   external tools. The argument can be a
                                   .nimble file, a project directory or
                                   the name of an installed package.
+               [--ini, --json]    Selects the output format (the default is --ini).
 
 Nimble Options:
   -h, --help                      Print this help message.


### PR DESCRIPTION
Is the `--json` switch considered stable enough to document? Feel free to suggest changes to the wording.

`nimble dump --json` was added in 9a3c569f6c4e (#810), but was
not shown when running `nimble --help`.

This commit also documents the fact that the `--ini` option exists, and
that INI is the default output format.