### PR TITLE
Fix #460 - findNimbleFile 'not found' error more specific

### DIFF
--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -312,7 +312,7 @@ proc findNimbleFile*(dir: string; error: bool): string =
   elif hits == 0:
     if error:
       raise newException(NimbleError,
-          "Specified directory ($1) does not contain a .nimble file." % dir)
+          "Specified directory ($1) does not contain a (*).nimble file." % dir)
     else:
       display("Warning:", "No .nimble or .nimble-link file found for " &
               dir, Warning, HighPriority)

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -312,7 +312,7 @@ proc findNimbleFile*(dir: string; error: bool): string =
   elif hits == 0:
     if error:
       raise newException(NimbleError,
-          "Specified directory ($1) does not contain a (*).nimble file." % dir)
+          "Could not find a file with a .nimble extension inside the specified directory: $1" % dir)
     else:
       display("Warning:", "No .nimble or .nimble-link file found for " &
               dir, Warning, HighPriority)


### PR DESCRIPTION
Not found error updated to `Specified directory ($1) does not contain a (*).nimble file.` from `Specified directory ($1) does not contain a .nimble file.`.
That _probably_ specifies more explicitly that 'SOMETHING.nimble' is required, thus help to not get confused with scenarios like `.nimble` file not being acceptable.
Not sure whether it is an actually useful change. 

Besides that, errors nearby like `Only one .nimble file should be present in` could have probably being updated too, but it wasn't mentioned in #460, so didn't try to update it in this PR