### PR TITLE
patch version can be a multi-digit number

### DIFF
--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -57,7 +57,7 @@ template cd*(dir: string, body: untyped) =
 proc getNimrodVersion*(options: Options): Version =
   let vOutput = doCmdEx(getNimBin(options).quoteShell & " -v").output
   var matches: array[0..MaxSubpatterns, string]
-  if vOutput.find(peg"'Version'\s{(\d+\.)+\d}", matches) == -1:
+  if vOutput.find(peg"'Version'\s{(\d+\.)+\d+}", matches) == -1:
     raise newException(NimbleError, "Couldn't find Nim version.")
   newVersion(matches[0])
 


### PR DESCRIPTION
This is crucial for Nim 1.0.10 release, because currently 1.0.10 doesn't satisfy `>= 1.0.4` requirement.

cc @genotrance