### PR TITLE
Added AGPL-3.0 to license list

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -802,6 +802,7 @@ This should ideally be a valid SPDX identifier. See https://spdx.org/licenses/.
     "LGPL-2.1",
     "LGPL-3.0",
     "EPL-2.0",
+    "AGPL-3.0",
     # This is what npm calls "UNLICENSED" (which is too similar to "Unlicense")
     "Proprietary",
     "Other"


### PR DESCRIPTION
The GNU Affero GPLv3 (AGPL-3.0) is a copyleft license approved by both the [FSF](https://www.gnu.org/licenses/license-list.en.html#AGPLv3.0) and the [OSI](https://opensource.org/licenses/AGPL-3.0). It is used by many popular programs* and is quite different from the other licenses in the list, so I think it deserves a spot.

* Such as ANKI, OpenEdX, CiviCRM, Launchpad, Mastodon, MediaGoblin, NextCloud, OnlyOffice, ownCloud, PeerTube, POV-Ray, R Studio and Signal