### PR TITLE
SPDX compliance for the GNU family of licenses (choice for "or any later version" clause)

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -815,6 +815,14 @@ Please specify a valid SPDX identifier.""",
       "MIT"
     )
 
+  if pkgLicense in ["GPL-2.0", "GPL-3.0", "LGPL-2.1", "LGPL-3.0", "AGPL-3.0"]:
+    let orLater = options.promptList(
+      "\"Or any later version\" clause?", ["Yes", "No"])
+    if orLater == "Yes":
+      pkgLicense.add("-or-later")
+    else:
+      pkgLicense.add("-only")
+
   # Ask for Nim dependency
   let nimDepDef = getNimrodVersion(options)
   let pkgNimDep = promptCustom(options, "Lowest supported Nim version?",


### PR DESCRIPTION
When releasing a software under the GNU family of licenses (GPL, LGPL and AGPL) it is very common to have a clause which says that the program can be licensed under any later version of the license. Examples: GIMP (GPLv3+), LibreOffice (LGPLv3+).

On the other hand, some programs deliberately choose to apply only a specific version of the license. Examples: Linux kernel (GPLv2 only), Krita (GPLv3 only)

The [latest SPDX standard](https://spdx.org/licenses/) is aware of this and deprecated the bare GNU license identifiers like `GPL-3.0` (the ones which are currently set by nimble), forcing a clause specifier like `GPL-3.0-only` or `GPL-3.0-or-later`.

This commit shows the usual license list but if a license from the GNU family is picked, it will show an additional prompt for the "or any later version" clause and pick the valid SPDX identifier according to the user's choice.