### PR TITLE
Add Github Actions CI using choosenim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
           - 1.0.10
           - 1.2.8
           - 1.4.0
-          - git:8a004e2
           - nightly:https://github.com/nim-lang/nightlies/releases/tag/2020-11-11-devel-bbe49a14ae827b6474d692042406716a3b3dd71f
     name: ${{ matrix.os }} - ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,19 @@ jobs:
           - windows-latest
           - macos-latest
           - ubuntu-latest
-        target:
+        nimversion:
           - 0.20.2
           - 1.0.10
           - 1.2.8
           - 1.4.0
           - nightly:https://github.com/nim-lang/nightlies/releases/tag/2020-11-11-devel-bbe49a14ae827b6474d692042406716a3b3dd71f
-    name: ${{ matrix.os }} - ${{ matrix.target }}
+    name: ${{ matrix.os }} - ${{ matrix.nimversion }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: iffy/install-nim@v3
+        with:
+          version: ${{ matrix.nimversion }}
       - run: nim --version
       - name: Run nim c -r tester
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+          - ubuntu-latest
+        target:
+          - 0.20.2
+          - 1.0.10
+          - 1.2.8
+          - 1.4.0
+          - git:8a004e2
+          - nightly:https://github.com/nim-lang/nightlies/releases/tag/2020-11-11-devel-bbe49a14ae827b6474d692042406716a3b3dd71f
+    name: ${{ matrix.os }} - ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: iffy/install-nim@v3
+      - run: nim --version
+      - name: Run nim c -r tester
+        run: |
+          cd tests
+          nim c -r tester
+      - run: ./src/nimble install -y


### PR DESCRIPTION
This is yet another alternative for switching from Travis to Github Actions.  It supersedes #871 and #868 with the following differences:

- It uses choosenim to test Nim versions 0.20.2, 1.0.10, 1.2.8 and 1.4.0 (so as choosenim improves, so does this)
- It also tests with Nim built from Git SHA 8a004e2
- It also tests with this nightly https://github.com/nim-lang/nightlies/releases/tag/2020-11-11-devel-bbe49a14ae827b6474d692042406716a3b3dd71f
- @genotrance requested "I would prefer one place where all this is solved, not yet another copy of code that has to be maintained in each repo." This does that by using the Github Action [iffy/install-nim@v3](https://github.com/iffy/install-nim) instead of including a script file.

You can see the build run for this PR here: https://github.com/iffy/nimble/actions/runs/370324359

I apologize for making 3 PRs for this issue, but they haven't followed a sequential pattern of development.