### PR TITLE
Update packageparser.nim

### DIFF
--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -291,6 +291,8 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           else:
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
+        of "":
+          discard
         else:
           raise newException(NimbleError, "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -281,9 +281,6 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for i in ev.value.multiSplit:
               result.postHooks.incl(i.normalize)
           else:
-            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line
-            # and comment line read by the 'parsecfg' module. An exception
-            # should not be thrown; it should be skipped.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
         of "deps", "dependencies":
@@ -292,16 +289,11 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
           else:
-            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line
-            # and comment line read by the 'parsecfg' module. An exception
-            # should not be thrown; it should be skipped.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
         else:
-          # Skip the blank line and comment line in the header of the file.
           if currentSection != "":
-            raise newException(NimbleError, "Invalid section: " &
-                               currentSection)
+            raise newException(NimbleError, "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,
             "Invalid package info, should not contain --" & ev.value)
       of cfgError:

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -280,7 +280,7 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           of "afterhooks":
             for i in ev.value.multiSplit:
               result.postHooks.incl(i.normalize)
-          else:
+          else: # Blank lines and comment lines in 'parsecfg' are ignored when read.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
         of "deps", "dependencies":
@@ -291,7 +291,6 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           else:
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
-        of "": discard
         else:
           raise newException(NimbleError, "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -280,8 +280,9 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           of "afterhooks":
             for i in ev.value.multiSplit:
               result.postHooks.incl(i.normalize)
-          else:
-            raise newException(NimbleError, "Invalid field: " & ev.key)
+          else: # Blank lines and comment lines in 'parsecfg' are ignored when read.
+            if not startsWith(ev.key.normalize, "cfgBlankAndCommentLine"):
+              raise newException(NimbleError, "Invalid field: " & ev.key)
         of "deps", "dependencies":
           case ev.key.normalize
           of "requires":

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -281,8 +281,8 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for i in ev.value.multiSplit:
               result.postHooks.incl(i.normalize)
           else:
-            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line 
-            # and comment line read by the 'parsecfg' module. An exception 
+            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line
+            # and comment line read by the 'parsecfg' module. An exception
             # should not be thrown; it should be skipped.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
@@ -292,8 +292,8 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
           else:
-            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line 
-            # and comment line read by the 'parsecfg' module. An exception 
+            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line
+            # and comment line read by the 'parsecfg' module. An exception
             # should not be thrown; it should be skipped.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -291,10 +291,11 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           else:
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
-        of "":
-          discard
         else:
-          raise newException(NimbleError, "Invalid section: " & currentSection)
+          if not (currentSection == "" and 
+                  startsWith(ev.key, "cfgBlankAndCommentLine")):
+            raise newException(NimbleError, "Invalid section: " &
+                               currentSection)
       of cfgOption: raise newException(NimbleError,
             "Invalid package info, should not contain --" & ev.value)
       of cfgError:

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -280,7 +280,10 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           of "afterhooks":
             for i in ev.value.multiSplit:
               result.postHooks.incl(i.normalize)
-          else: # Blank lines and comment lines in 'parsecfg' are ignored when read.
+          else:
+            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line 
+            # and comment line read by the 'parsecfg' module. An exception 
+            # should not be thrown; it should be skipped.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
         of "deps", "dependencies":
@@ -289,9 +292,15 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
           else:
+            # 'key' starting with 'cfgBlankAndCommentLine' is the blank line 
+            # and comment line read by the 'parsecfg' module. An exception 
+            # should not be thrown; it should be skipped.
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
-        else: raise newException(NimbleError,
+        else:
+          # Skip the blank line and comment line in the header of the file.
+          if currentSection != "":
+            raise newException(NimbleError,
               "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,
             "Invalid package info, should not contain --" & ev.value)

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -281,7 +281,7 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for i in ev.value.multiSplit:
               result.postHooks.incl(i.normalize)
           else: # Blank lines and comment lines in 'parsecfg' are ignored when read.
-            if not startsWith(ev.key.normalize, "cfgBlankAndCommentLine"):
+            if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
         of "deps", "dependencies":
           case ev.key.normalize

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -291,9 +291,9 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           else:
             if not startsWith(ev.key, "cfgBlankAndCommentLine"):
               raise newException(NimbleError, "Invalid field: " & ev.key)
+        of "": discard
         else:
-          if currentSection != "":
-            raise newException(NimbleError, "Invalid section: " & currentSection)
+          raise newException(NimbleError, "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,
             "Invalid package info, should not contain --" & ev.value)
       of cfgError:

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -289,7 +289,8 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
             for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
           else:
-            raise newException(NimbleError, "Invalid field: " & ev.key)
+            if not startsWith(ev.key, "cfgBlankAndCommentLine"):
+              raise newException(NimbleError, "Invalid field: " & ev.key)
         else: raise newException(NimbleError,
               "Invalid section: " & currentSection)
       of cfgOption: raise newException(NimbleError,

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -300,8 +300,8 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
         else:
           # Skip the blank line and comment line in the header of the file.
           if currentSection != "":
-            raise newException(NimbleError,
-              "Invalid section: " & currentSection)
+            raise newException(NimbleError, "Invalid section: " &
+                               currentSection)
       of cfgOption: raise newException(NimbleError,
             "Invalid package info, should not contain --" & ev.value)
       of cfgError:


### PR DESCRIPTION
Blank lines and comment lines in 'parsecfg' are ignored when read.
I'm going to add the ability to keep blank lines and comment lines to 'parsecfg'.

 'key' starting with 'cfgBlankAndCommentLine' is the blank line and comment line read by the 'parsecfg' module. An exception should not be thrown; it should be skipped.

[parsecfg # 16402](https://github.com/nim-lang/Nim/pull/16402)