### PR TITLE
Bump iffy/install-nim to v3.1 for increased logging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: iffy/install-nim@v3
+      - uses: iffy/install-nim@v3.1
         with:
           version: ${{ matrix.nimversion }}
       - run: nim --version


### PR DESCRIPTION
This adds additional logging to the GitHub actions that install from nightlies in an attempt to figure out what happened to cause https://github.com/iffy/install-nim/issues/8

I suspect the issue is transient (e.g. the request to the GitHub API failed for some reason)