### PR TITLE
Add GITHUB_TOKEN to avoid rate limits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,11 @@ jobs:
           - nightly:https://github.com/nim-lang/nightlies/releases/tag/2021-02-06-devel-39230422d02bd41b02378211e8613f702e5b945c
     name: ${{ matrix.os }} - ${{ matrix.nimversion }}
     runs-on: ${{ matrix.os }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
-      - uses: iffy/install-nim@v3.1
+      - uses: iffy/install-nim@v3.2.0
         with:
           version: ${{ matrix.nimversion }}
       - run: nim --version


### PR DESCRIPTION
Fixes https://github.com/iffy/install-nim/issues/8

If you'd like to review what changed between v3.1 and v3.2.0 of install-nim, here's the diff: https://github.com/iffy/install-nim/compare/v3.1...v3.2.0