### PR TITLE
improve error message, make link clickable

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -91,7 +91,7 @@ proc getTagsListRemote*(url: string, meth: DownloadMethod): seq[string] =
     var (output, exitCode) = doCmdEx("git ls-remote --tags " & url.quoteShell())
     if exitCode != QuitSuccess:
       raise newException(OSError, "Unable to query remote tags for " & url &
-          ". Git returned: " & output)
+          " Git returned: " & output)
     for i in output.splitLines():
       let refStart = i.find("refs/tags/")
       # git outputs warnings, empty lines, etc


### PR DESCRIPTION
before PR: error message contains a dot, which prevents making the link clickable in logs (eg github action logs)

after PR: I remove the dot so the link becomes clickable.

example: https://github.com/nim-lang/Nim/runs/2063531199
```
 PASS: norm c                                                       ( 6.54 sec)
  PASS: npeg c                                                       (17.42 sec)
  FAIL: numericalnim c
  Test "numericalnim" in category "nimble-packages-2"
  Failure: reInstallFailed
  nimble install --depsOnly -y
    Verifying dependencies for numericalnim@0.6.1
   Installing arraymancer@>= 0.5.0
  Downloading mratsim/Arraymancer using git
    Verifying dependencies for arraymancer@0.6.2
        Info: Dependency on nimblas@>= 0.2.2 already satisfied
    Verifying dependencies for nimblas@0.2.2
        Info: Dependency on nimlapack@>= 0.1.1 already satisfied
    Verifying dependencies for nimlapack@0.2.0
        Info: Dependency on nimcuda@>= 0.1.4 already satisfied
    Verifying dependencies for nimcuda@0.1.7
        Info: Dependency on nimcl@>= 0.1.3 already satisfied
    Verifying dependencies for nimcl@0.1.3
        Info: Dependency on opencl@>= 1.0 already satisfied
    Verifying dependencies for opencl@1.0
        Info: Dependency on clblast@any version already satisfied
    Verifying dependencies for clblast@0.0.1
        Info: Dependency on opencl@any version already satisfied
    Verifying dependencies for opencl@1.0
   Installing stb_image@any version
  Downloading gitlab.com/define-private-public/stb_image-Nim.git using git
  download.nim(93)         getTagsListRemote
  Error: unhandled exception: Unable to query remote tags for gitlab.com/define-private-public/stb_image-Nim.git. Git returned: fatal: unable to access 'gitlab.com/define-private-public/stb_image-Nim.git': The requested URL returned error: 502
   [OSError]
  
  PASS: optionsutils c                                               (10.26 sec)
```

