### PR TITLE
tasks: add tests for PR #912

### DIFF
--- a/tests/tasks/empty/tasks.nimble
+++ b/tests/tasks/empty/tasks.nimble
@@ -1,0 +1,13 @@
+# Package
+
+version       = "0.1.0"
+author        = "David Anes <kraptor>"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["run"]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"

--- a/tests/tasks/max/tasks.nimble
+++ b/tests/tasks/max/tasks.nimble
@@ -1,0 +1,23 @@
+# Package
+
+version       = "0.1.0"
+author        = "David Anes <kraptor>"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["run"]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+
+task task1, "Description1":
+    echo "blah"
+
+task very_long_task, "This is a task with a long name":
+    echo "blah"
+
+task aaa, "A task with a small name":
+    echo "blah"

--- a/tests/tasks/min/tasks.nimble
+++ b/tests/tasks/min/tasks.nimble
@@ -1,0 +1,17 @@
+# Package
+
+version       = "0.1.0"
+author        = "David Anes <kraptor>"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["run"]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+
+task a, "Description for a":
+    echo "blah blah"

--- a/tests/tasks/nodesc/tasks.nimble
+++ b/tests/tasks/nodesc/tasks.nimble
@@ -1,0 +1,17 @@
+# Package
+
+version       = "0.1.0"
+author        = "David Anes <kraptor>"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["run"]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+
+task nodesc, "":
+    echo "A task with no description"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -1283,3 +1283,29 @@ suite "issues":
       let lines = output.strip.processOutput()
       check exitCode != QuitSuccess
       check inLines(lines, "Nothing to build")
+
+suite "nimble tasks":
+  test "can list tasks even with no tasks defined in nimble file":
+    cd "tasks/empty":
+      let (_, exitCode) = execNimble("tasks")
+      check exitCode == QuitSuccess
+
+  test "tasks with no descriptions are correctly displayed":
+    cd "tasks/nodesc":
+      let (output, exitCode) = execNimble("tasks")
+      check output.contains("nodesc")
+      check exitCode == QuitSuccess
+
+  test "task descriptions are correctly aligned to longer name":
+    cd "tasks/max":
+      let (output, exitCode) = execNimble("tasks")
+      check output.contains("task1           Description1")
+      check output.contains("very_long_task  This is a task with a long name")
+      check output.contains("aaa             A task with a small name")
+      check exitCode == QuitSuccess
+
+  test "task descriptions are correctly aligned to minimum (10 chars)":
+    cd "tasks/min":
+      let (output, exitCode) = execNimble("tasks")
+      check output.contains("a         Description for a")
+      check exitCode == QuitSuccess


### PR DESCRIPTION
As requested by @dom96, I added a few to tests to check output of `nimble tasks`.

The tests cover:
* If there are no tasks defined
* If there are tasks with long names
* If the minimum alignment is respected for very short names