### PR TITLE
Handle flags correctly for `nimble run`

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -478,7 +478,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.action.compileOptions.add(getFlagString(kind, flag, val))
   of actionRun:
     result.showHelp = false
-    result.setRunOptions(flag, getFlagString(kind, flag, val), false)
+    if not isGlobalFlag:
+      result.setRunOptions(flag, getFlagString(kind, flag, val), false)
   of actionCustom:
     if not isGlobalFlag:
       if result.action.command.normalize == "test":
@@ -517,9 +518,11 @@ proc parseMisc(options: var Options) =
 
 proc handleUnknownFlags(options: var Options) =
   if options.action.typ == actionRun:
-    # actionRun uses flags that come before the command as compilation flags.
-    options.action.compileFlags =
+    # In addition to flags that come after the command before binary,
+    # actionRun also uses flags that come before the command as compilation flags.
+    options.action.compileFlags.insert(
       map(options.unknownFlags, x => getFlagString(x[0], x[1], x[2]))
+    )
     options.unknownFlags = @[]
   elif options.action.typ == actionCustom:
     # actionCustom uses flags that come before the command as compilation flags

--- a/tests/run/src/run.nim
+++ b/tests/run/src/run.nim
@@ -2,3 +2,5 @@ import os
 
 when isMainModule:
   echo("Testing `nimble run`: ", commandLineParams())
+  when defined(sayWhee):
+    echo "Whee!"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -804,7 +804,7 @@ suite "nimble run":
         """Testing `nimble run`: @["\"", "\'", "\t", "arg with spaces"]"""
       )
 
-  test "Compile flags before executable name":
+  test "Nimble options before executable name":
     cd "run":
       let (output, exitCode) = execNimble(
         "run", # Run command invokation
@@ -818,7 +818,7 @@ suite "nimble run":
       echo output
       check output.contains("""Testing `nimble run`: @["--test"]""")
 
-  test "Compile flags before --":
+  test "Nimble options before --":
     cd "run":
       let (output, exitCode) = execNimble(
         "run", # Run command invokation
@@ -831,6 +831,72 @@ suite "nimble run":
                             [$DirSep, "run".changeFileExt(ExeExt)])
       echo output
       check output.contains("""Testing `nimble run`: @["--test"]""")
+
+  test "Compilation flags before run command":
+    cd "run":
+      let (output, exitCode) = execNimble(
+        "-d:sayWhee", # Compile flag to define a conditional symbol
+        "run", # Run command invokation
+        "--debug", # Flag to enable debug verbosity in Nimble
+        "--", # Separator for arguments
+        "--test" # First argument passed to the executed command
+      )
+      check exitCode == QuitSuccess
+      check output.contains("tests$1run$1$2 --test" %
+                            [$DirSep, "run".changeFileExt(ExeExt)])
+      echo output
+      check output.contains("""Testing `nimble run`: @["--test"]""")
+      check output.contains("""Whee!""")
+
+  test "Compilation flags before executable name":
+    cd "run":
+      let (output, exitCode) = execNimble(
+        "--debug", # Flag to enable debug verbosity in Nimble
+        "run", # Run command invokation
+        "-d:sayWhee", # Compile flag to define a conditional symbol
+        "run", # The executable to run
+        "--test" # First argument passed to the executed command
+      )
+      check exitCode == QuitSuccess
+      check output.contains("tests$1run$1$2 --test" %
+                            [$DirSep, "run".changeFileExt(ExeExt)])
+      echo output
+      check output.contains("""Testing `nimble run`: @["--test"]""")
+      check output.contains("""Whee!""")
+
+  test "Compilation flags before --":
+    cd "run":
+      let (output, exitCode) = execNimble(
+        "run", # Run command invokation
+        "-d:sayWhee", # Compile flag to define a conditional symbol
+        "--debug", # Flag to enable debug verbosity in Nimble
+        "--", # Separator for arguments
+        "--test" # First argument passed to the executed command
+      )
+      check exitCode == QuitSuccess
+      check output.contains("tests$1run$1$2 --test" %
+                            [$DirSep, "run".changeFileExt(ExeExt)])
+      echo output
+      check output.contains("""Testing `nimble run`: @["--test"]""")
+      check output.contains("""Whee!""")
+
+  test "Order of compilation flags before and after run command":
+    cd "run":
+      let (output, exitCode) = execNimble(
+        "-d:compileFlagBeforeRunCommand", # Compile flag to define a conditional symbol
+        "run", # Run command invokation
+        "-d:sayWhee", # Compile flag to define a conditional symbol
+        "--debug", # Flag to enable debug verbosity in Nimble
+        "--", # Separator for arguments
+        "--test" # First argument passed to the executed command
+      )
+      check exitCode == QuitSuccess
+      check output.contains("-d:compileFlagBeforeRunCommand -d:sayWhee")
+      check output.contains("tests$1run$1$2 --test" %
+                            [$DirSep, "run".changeFileExt(ExeExt)])
+      echo output
+      check output.contains("""Testing `nimble run`: @["--test"]""")
+      check output.contains("""Whee!""")
 
 suite "project local deps mode":
   beforeSuite()


### PR DESCRIPTION
1. check for `isGlobalFlag` before `setRunOptions`. Flags like `--debug` should not be treated as `run` options.
2. in `handleUnknownFlags`, add unknown flags to `compileFlags` instead of overwriting `compileFlags`. This enables compilation flags after the `run` command to be correctly passed.

Fixes #923.