### PR TITLE
change `nimbleDir` to xdg specification

### DIFF
--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -18,7 +18,14 @@ type
     path*: string
 
 proc initConfig(): Config =
-  result.nimbleDir = getHomeDir() / ".nimble"
+  when defined(windows):
+    let cache = getEnv("LOCALAPPDATA")
+  elif defined(osx):
+    let cache = getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches")
+  else:
+    let cache = getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")
+
+  result.nimbleDir = cache / "nimble"
 
   result.httpProxy = initUri()
 


### PR DESCRIPTION
**note**: in `devel` branch there are [getCacheDir](https://nim-lang.github.io/Nim/os.html#getCacheDir%2Cstring) `proc`, but in `1.4.8` there is not

and at next `nim` release we can just do:
```nim
result.nimbleDir = getCacheDir("nimble")
```