### PR TITLE
Fix a bug when including symbolic link files to the package's checksum.

### DIFF
--- a/src/nimblepkg/checksums.nim
+++ b/src/nimblepkg/checksums.nim
@@ -25,22 +25,36 @@ proc updateSha1Checksum(checksum: var Sha1State, fileName, filePath: string) =
     # directory from which no files are being installed.
     return
   checksum.update(fileName)
-  var file: File
-  try:
-    file = filePath.open(fmRead)
-  except IOError:
-    ## If the file cannot be open for reading do not count its content in the
-    ## checksum.
-    displayWarning(&"The file \"{filePath}\" cannot be open for reading.\n" &
-                    "Skipping it in the calculation of the checksum.")
-    return
-  defer: close(file)
-  const bufferSize = 8192
-  var buffer = newString(bufferSize)
-  while true:
-    var bytesRead = readChars(file, buffer)
-    if bytesRead == 0: break
-    checksum.update(buffer.toOpenArray(0, bytesRead - 1))
+  if symlinkExists(filePath):
+    # Check whether a file is a symbolic link and if so update the checksum with
+    # the path to the file that the link points to.
+    var linkPath: string
+    try:
+      linkPath = expandSymlink(filePath)
+    except OSError:
+      displayWarning(&"Cannot expand symbolic link \"{filePath}\".\n" &
+                      "Skipping it in the calculation of the checksum.")
+      return
+    checksum.update(linkPath)
+  else:
+    # Otherwise this is an ordinary file and we are adding its content to the
+    # checksum.
+    var file: File
+    try:
+      file = filePath.open(fmRead)
+    except IOError:
+      ## If the file cannot be open for reading do not count its content in the
+      ## checksum.
+      displayWarning(&"The file \"{filePath}\" cannot be open for reading.\n" &
+                      "Skipping it in the calculation of the checksum.")
+      return
+    defer: close(file)
+    const bufferSize = 8192
+    var buffer = newString(bufferSize)
+    while true:
+      var bytesRead = readChars(file, buffer)
+      if bytesRead == 0: break
+      checksum.update(buffer.toOpenArray(0, bytesRead - 1))
 
 proc calculateDirSha1Checksum*(dir: string): Sha1Hash =
   ## Recursively calculates the sha1 checksum of the contents of the directory

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -320,8 +320,7 @@ proc doDownloadTarball(url, downloadDir, version: string, queryRevision: bool):
     let (cmdOutput, cmdExitCode) = doCmdEx(listCmd)
     if cmdExitCode != QuitSuccess:
       raise nimbleError(tryDoCmdExErrorMessage(listCmd, cmdOutput, cmdExitCode))
-    let lines = cmdOutput.splitLines()
-    for line in lines:
+    for line in cmdOutput.splitLines():
       if line.contains(" -> "):
         let parts = line.split
         let linkPath = parts[^1]

--- a/src/nimblepkg/vcstools.nim
+++ b/src/nimblepkg/vcstools.nim
@@ -205,6 +205,10 @@ proc getPackageFileListWithoutVcs(dir: Path): seq[string] =
   ## its subdirectories.
   for file in walkDirRec($dir, yieldFilter = {pcFile, pcLinkToFile},
                          relative = true):
+    when defined(windows):
+      # On windows relative paths to files which are included in the calculation
+      # of the package checksum must be the same as on POSIX systems.
+      let file = file.replace('\\', '/')
     result.add file
 
 proc getPackageFileList*(dir: Path): seq[string] =
@@ -1061,7 +1065,6 @@ username = John Doe <john.doe@example.com>
       check not isValidSha1Hash($getVcsRevision(testNoVcsDir))
 
     test "getPackageFileList":
-      check getPackageFileList(testNoVcsDir) ==
-            @[testFile, testSubDirFile.normalizedPath]
+      check getPackageFileList(testNoVcsDir) == @[testFile, testSubDirFile]
 
     tearDownSuite(testNoVcsDir)

--- a/src/nimblepkg/vcstools.nim
+++ b/src/nimblepkg/vcstools.nim
@@ -203,7 +203,8 @@ proc getVcsRevision*(dir: Path): Sha1Hash =
 proc getPackageFileListWithoutVcs(dir: Path): seq[string] =
   ## Recursively walks the directory `dir` and returns a list of files in it and
   ## its subdirectories.
-  for file in walkDirRec($dir, relative = true):
+  for file in walkDirRec($dir, yieldFilter = {pcFile, pcLinkToFile},
+                         relative = true):
     result.add file
 
 proc getPackageFileList*(dir: Path): seq[string] =


### PR DESCRIPTION
When a file is a symbolic link to some other file the proper behavior when calculating the checksum of a package is to use the link path instead of the content of the pointed file.

When cloning a Git repository on Windows Git puts the link file path as the content of an ordinary file. When downloading tarball the symbolic link files cannot be properly established and Tar writes empty files instead. This leads to different packages checksums compared to the case when the package is downloaded via Git or downloaded on Linux either via Git or via tarball.

To fix the above problem we parsed the content of the tarball and extract the link paths from there. After that, we write a link file with the link path in it overriding the empty file extracted by Tar.

The `getPackageFileListWithoutVcs` procedure is fixed to return also the symbolic link files and to return files with `/` separator even on Windows (in order to achieve the same checksum).