### PR TITLE
Change the name of the "pkgs" directory to "pkgs2"

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -816,9 +816,9 @@ Library packages are likely the most popular form of Nimble packages. They are
 meant to be used by other library or binary packages.
 
 When Nimble installs a library, it will copy all of its files
-into ``$nimbleDir/pkgs/pkgname-ver``. It's up to the package creator to make sure
-that the package directory layout is correct, this is so that users of the
-package can correctly import the package.
+into ``$nimbleDir/pkgs2/pkgname-ver-checksum``. It's up to the package creator
+to make sure that the package directory layout is correct, this is so that users
+of the package can correctly import the package.
 
 It is suggested that the layout be as follows. The directory layout is
 determined by the nature of your package, that is, whether your package exposes
@@ -868,9 +868,9 @@ bin = @["main"]
 ```
 
 In this case when ``nimble install`` is invoked, Nimble will build the ``main.nim``
-file, copy it into ``$nimbleDir/pkgs/pkgname-ver/`` and subsequently create a
-symlink to the binary in ``$nimbleDir/bin/``. On Windows, a stub .cmd file is
-created instead.
+file, copy it into ``$nimbleDir/pkgs2/pkgname-ver-checksum/`` and subsequently
+create a symlink to the binary in ``$nimbleDir/bin/``. On Windows, a stub .cmd
+file is created instead.
 
 The binary can be named differently than the source file with the ``namedBin``
 table:
@@ -1096,7 +1096,7 @@ Nimble includes a ``publish`` command which does this for you automatically.
 ## Nimble's folder structure and packages
 
 Nimble stores all installed packages and metadata in ``$HOME/.nimble`` by default.
-Libraries are stored in ``$nimbleDir/pkgs``, and compiled binaries are linked in
+Libraries are stored in ``$nimbleDir/pkgs2``, and compiled binaries are linked in
 ``$nimbleDir/bin``. The Nim compiler is aware of Nimble and will automatically
 find modules so you can ``import modulename`` and have that working without
 additional setup.
@@ -1146,13 +1146,13 @@ For example, if your Nimble directory is located at `/some/custom/path/nimble`,
 this should work:
 
 ```
-nim c --nimblePath:/some/custom/path/nimble/pkgs main.nim
+nim c --nimblePath:/some/custom/path/nimble/pkgs2 main.nim
 ```
 
 In the case of package local dependencies with ``nimbledeps``:
 
 ```
-nim c --nimblePath:nimbledeps/pkgs main.nim
+nim c --nimblePath:nimbledeps/pkgs2 main.nim
 ```
 
 Some code editors rely on `nim check` to check for errors under the hood (e.g.
@@ -1162,12 +1162,12 @@ In this case, you will have to use the Nim compiler's configuration file capabil
 Simply add the following line to the `nim.cfg` located in any directory listed
 in the [documentation](https://nim-lang.org/docs/nimc.html#compiler-usage-configuration-files).
 ```
-nimblePath = "/some/custom/path/nimble/pkgs"
+nimblePath = "/some/custom/path/nimble/pkgs2"
 ```
 
 For project local dependencies:
 ```
-nimblePath = "$project/nimbledeps/pkgs"
+nimblePath = "$project/nimbledeps/pkgs2"
 ```
 
 ## Troubleshooting

--- a/src/nimblepkg/common.nim
+++ b/src/nimblepkg/common.nim
@@ -23,7 +23,7 @@ type
 
 const
   nimbleVersion* = "0.13.1"
-  nimblePackagesDirName* = "pkgs"
+  nimblePackagesDirName* = "pkgs2"
   nimbleBinariesDirName* = "bin"
 
 proc newNimbleError*[ErrorType](msg: string, hint = "",

--- a/src/nimblepkg/nimbledatafile.nim
+++ b/src/nimblepkg/nimbledatafile.nim
@@ -14,7 +14,7 @@ type
     ndjkRevDepPath = "path"
 
 const
-  nimbleDataFileName* = "nimbledata.json"
+  nimbleDataFileName* = "nimbledata2.json"
   nimbleDataFileVersion = 1
 
 var isNimbleDataFileLoaded = false
@@ -55,10 +55,6 @@ proc loadNimbleData*(options: var Options) =
 
   if fileExists(fileName):
     options.nimbleData = parseFile(fileName)
-    if not options.nimbleData.hasKey($ndjkVersion):
-      raise nimbleError(
-         "You are working with an old version of Nimble cache repository.\n",
-        &"Please delete your \"{options.getNimbleDir()}\" directory.")
     removeDeadDevelopReverseDeps(options)
     displayInfo(&"Nimble data file \"{fileName}\" has been loaded.",
                 LowPriority)

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -95,7 +95,7 @@ proc fromJson(obj: JSonNode): Package =
     result.tags = @[]
     for t in obj["tags"]:
       result.tags.add(t.str)
-    result.description = obj.requiredField("description")
+    result.description = obj.optionalField("description")
     result.web = obj.optionalField("web")
 {.warning[ProveInit]: on.}
 

--- a/tests/tuninstall.nim
+++ b/tests/tuninstall.nim
@@ -92,6 +92,6 @@ suite "uninstall":
 
     check execNimbleYes("uninstall", "PackageA@0.2", "issue27b").exitCode ==
         QuitSuccess
-    check(not dirExists(installDir / "pkgs" / "PackageA-0.2.0"))
+    check(not dirExists(pkgsDir / "PackageA-0.2.0"))
 
     check execNimbleYes("uninstall", "nimscript").exitCode == QuitSuccess


### PR DESCRIPTION
The names of the "nimbledata.json" file and "pkgs" directory are changed correspondingly to "nimbledata2.json" and "pkgs2" in order to avoid the need of removing the Nimble cache when changing between the new and old Nimble versions.