### PR TITLE
Fix #953

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -603,14 +603,14 @@ proc processLockedDependencies(pkgInfo: PackageInfo, options: Options):
       result.incl installDependency(pkgInfo, downloadResult, options)
 
 proc getDownloadInfo*(pv: PkgTuple, options: Options,
-                      doPrompt: bool, clean = false): (DownloadMethod, string,
+                      doPrompt: bool, ignorePackageCache = false): (DownloadMethod, string,
                                         Table[string, string]) =
   if pv.name.isURL:
     let (url, metadata) = getUrlData(pv.name)
     return (checkUrlType(url), url, metadata)
   else:
     var pkg = initPackage()
-    if getPackage(pv.name, options, pkg, clean):
+    if getPackage(pv.name, options, pkg, ignorePackageCache):
       let (url, metadata) = getUrlData(pkg.url)
       return (pkg.downloadMethod, url, metadata)
     else:
@@ -624,7 +624,7 @@ proc getDownloadInfo*(pv: PkgTuple, options: Options,
         # Once we've refreshed, try again, but don't prompt if not found
         # (as we've already refreshed and a failure means it really
         # isn't there)
-        # Also set `clean` to true so that it ignores current gPackageJson cache
+        # Also ignore the package cache so the old info isn't used
         return getDownloadInfo(pv, options, false, true)
       else:
         raise nimbleError(pkgNotFoundMsg(pv))

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -603,14 +603,14 @@ proc processLockedDependencies(pkgInfo: PackageInfo, options: Options):
       result.incl installDependency(pkgInfo, downloadResult, options)
 
 proc getDownloadInfo*(pv: PkgTuple, options: Options,
-                      doPrompt: bool): (DownloadMethod, string,
+                      doPrompt: bool, clean = false): (DownloadMethod, string,
                                         Table[string, string]) =
   if pv.name.isURL:
     let (url, metadata) = getUrlData(pv.name)
     return (checkUrlType(url), url, metadata)
   else:
     var pkg = initPackage()
-    if getPackage(pv.name, options, pkg):
+    if getPackage(pv.name, options, pkg, clean):
       let (url, metadata) = getUrlData(pkg.url)
       return (pkg.downloadMethod, url, metadata)
     else:
@@ -624,7 +624,8 @@ proc getDownloadInfo*(pv: PkgTuple, options: Options,
         # Once we've refreshed, try again, but don't prompt if not found
         # (as we've already refreshed and a failure means it really
         # isn't there)
-        return getDownloadInfo(pv, options, false)
+        # Also set `clean` to true so that it ignores current gPackageJson cache
+        return getDownloadInfo(pv, options, false, true)
       else:
         raise nimbleError(pkgNotFoundMsg(pv))
 

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -185,9 +185,9 @@ proc fetchList*(list: PackageList, options: Options) =
 # Cache after first call
 var
   gPackageJson: Table[string, JsonNode]
-proc readPackageList(name: string, options: Options, clean = false): JsonNode =
+proc readPackageList(name: string, options: Options, ignorePackageCache = false): JsonNode =
   # If packages.json is not present ask the user if they want to download it.
-  if (not clean) and gPackageJson.hasKey(name):
+  if (not ignorePackageCache) and gPackageJson.hasKey(name):
     return gPackageJson[name]
 
   if needsRefresh(options):
@@ -204,7 +204,7 @@ proc readPackageList(name: string, options: Options, clean = false): JsonNode =
                                  name.toLowerAscii() & ".json")
   return gPackageJson[name]
 
-proc getPackage*(pkg: string, options: Options, resPkg: var Package, clean = false): bool
+proc getPackage*(pkg: string, options: Options, resPkg: var Package, ignorePackageCache = false): bool
 proc resolveAlias(pkg: Package, options: Options): Package =
   result = pkg
   # Resolve alias.
@@ -215,7 +215,7 @@ proc resolveAlias(pkg: Package, options: Options): Package =
       raise nimbleError("Alias for package not found: " &
                          pkg.alias)
 
-proc getPackage*(pkg: string, options: Options, resPkg: var Package, clean = false): bool =
+proc getPackage*(pkg: string, options: Options, resPkg: var Package, ignorePackageCache = false): bool =
   ## Searches any packages.json files defined in ``options.config.packageLists``
   ## Saves the found package into ``resPkg``.
   ##
@@ -226,7 +226,7 @@ proc getPackage*(pkg: string, options: Options, resPkg: var Package, clean = fal
   ## Aliases are handled and resolved.
   for name, list in options.config.packageLists:
     display("Reading", "$1 package list" % name, priority = LowPriority)
-    let packages = readPackageList(name, options, clean)
+    let packages = readPackageList(name, options, ignorePackageCache)
     for p in packages:
       if normalize(p["name"].str) == normalize(pkg):
         resPkg = p.fromJson()

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -185,9 +185,9 @@ proc fetchList*(list: PackageList, options: Options) =
 # Cache after first call
 var
   gPackageJson: Table[string, JsonNode]
-proc readPackageList(name: string, options: Options): JsonNode =
+proc readPackageList(name: string, options: Options, clean = false): JsonNode =
   # If packages.json is not present ask the user if they want to download it.
-  if gPackageJson.hasKey(name):
+  if (not clean) and gPackageJson.hasKey(name):
     return gPackageJson[name]
 
   if needsRefresh(options):
@@ -204,7 +204,7 @@ proc readPackageList(name: string, options: Options): JsonNode =
                                  name.toLowerAscii() & ".json")
   return gPackageJson[name]
 
-proc getPackage*(pkg: string, options: Options, resPkg: var Package): bool
+proc getPackage*(pkg: string, options: Options, resPkg: var Package, clean = false): bool
 proc resolveAlias(pkg: Package, options: Options): Package =
   result = pkg
   # Resolve alias.
@@ -215,7 +215,7 @@ proc resolveAlias(pkg: Package, options: Options): Package =
       raise nimbleError("Alias for package not found: " &
                          pkg.alias)
 
-proc getPackage*(pkg: string, options: Options, resPkg: var Package): bool =
+proc getPackage*(pkg: string, options: Options, resPkg: var Package, clean = false): bool =
   ## Searches any packages.json files defined in ``options.config.packageLists``
   ## Saves the found package into ``resPkg``.
   ##
@@ -226,7 +226,7 @@ proc getPackage*(pkg: string, options: Options, resPkg: var Package): bool =
   ## Aliases are handled and resolved.
   for name, list in options.config.packageLists:
     display("Reading", "$1 package list" % name, priority = LowPriority)
-    let packages = readPackageList(name, options)
+    let packages = readPackageList(name, options, clean)
     for p in packages:
       if normalize(p["name"].str) == normalize(pkg):
         resPkg = p.fromJson()

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -411,6 +411,7 @@ suite "issues":
     let lines = output.strip.processOutput()
     # Test that it needed to refresh packages and that it installed
     check:
+      exitCode == QuitSuccess
       inLines(lines, "check internet for updated packages")
       inLines(lines, "fusion installed successfully")
 

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -401,3 +401,18 @@ suite "issues":
         else:
           "libissue941.so"
       check output.contains(expectedBinaryName)
+
+  test "issue #953 (Use refreshed package list)":
+    # Remove all packages from the json file so it needs to be refreshed
+    writeFile(installDir / "packages_official.json", "[]")
+    removeDir(installDir / "pkgs2")
+
+    let (output, exitCode) = execNimble("install", "-y", "fusion")
+    let lines = output.strip.processOutput()
+    # Test that it needed to refresh packages and that it installed
+    check:
+      inLines(lines, "check internet for updated packages")
+      inLines(lines, "fusion installed successfully")
+
+    # Clean up package file
+    check execNimble(["refresh"]).exitCode == QuitSuccess


### PR DESCRIPTION
Fixes [issue](https://github.com/nim-lang/nimble/issues/953) where nimble didn't search refreshed package list when trying to install a package

Current behavior
 
![image](https://user-images.githubusercontent.com/19339842/143988094-b48f28a9-5222-4009-b39b-06a61ae0da76.png)

Behavior after PR

![image](https://user-images.githubusercontent.com/19339842/143988364-f6f205a8-b0b3-40a8-80d0-143799cbbcc7.png)

Is the way I did it in the PR good or should I instead implement a proc which clears `gPackageJson` table?
