### PR TITLE
Menu select add arrow button support

### DIFF
--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -260,7 +260,7 @@ proc promptListInteractive(question: string, args: openarray[string]): string =
       of '\27':
         if getch() != '\91': continue
         case getch():
-        of char 65:
+        of char(65): # Up arrow
           current = (args.len + current - 1) mod args.len
           break
         of char 66:

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -257,6 +257,16 @@ proc promptListInteractive(question: string, args: openarray[string]): string =
       of '\3':
         showCursor(stdout)
         raise nimbleError("Keyboard interrupt")
+      of '\27':
+        if getch() != '\91': continue
+        case getch():
+        of char 65:
+          current = (args.len + current - 1) mod args.len
+          break
+        of char 66:
+          current = (current + 1) mod args.len
+          break
+        else: discard
       else: discard
 
   # Erase all lines of the selection

--- a/src/nimblepkg/cli.nim
+++ b/src/nimblepkg/cli.nim
@@ -263,7 +263,7 @@ proc promptListInteractive(question: string, args: openarray[string]): string =
         of char(65): # Up arrow
           current = (args.len + current - 1) mod args.len
           break
-        of char 66:
+        of char(66): # Down arrow
           current = (current + 1) mod args.len
           break
         else: discard


### PR DESCRIPTION
Support for up & down arrows for interactive prompt. It's a pet peeve, I try and hit up/down every time Nimble prompts this way. 

I didn't see any unit tests, but I tested it manually. Here's some manual test code: 

```nim

import unittest
import strutils, strformat

import nimblepkg/cli

test "test prompt":
  let token = promptCustom("Personal access token?", "").strip()
  echo "token: " & $token

test "test prompt":
  let resp1 = prompt(dontForcePrompt, "Non-forced prompt example?")
  echo "answer: " & $resp1

test "test overriden prompt":
  let resp2 = prompt(forcePromptYes, "forced prompt (e.g. overriden)")
  assert resp2 == true
  echo "answer: " & $resp2

test "test displays":
  let name = "fakePackage"
  displayWarning(&"Installed package {name} should be renamed  ")
  displayDebug(&"Installed package {name} should be renamed  ")
  displayDetails(&"Installed package {name} should be renamed  ")
  displayError(&"Installed package {name} should be renamed  ")
  displayInfo(&"Installed package {name} should be renamed  ")
  displayHint(&"Installed package {name} should be renamed  ")

test "test display raw":
  display("Msg", "Some message", Hint)
  display("Msg2", "Some message", priority=HighPriority, displayType=Success)
  display("Msg3", "Some message", priority=HighPriority, displayType=Error)

test "test display medium priority":
  setVerbosity(MediumPriority)
  display("Msg", "Some message", Hint)

test "test display colorize":
  setShowColor(false)
  display("Msg33", "Some message", Warning, HighPriority)
  setShowColor(true)
  display("Msg34", "Some message", Warning, HighPriority)

test "test multiline":
  displayInfo("Some message\nwith lots of\nlines")

test "test interactive prompt":
  let resp = promptList(dontForcePrompt, "Select options:", ["alpha", "beta", "gamma"])
  displayInfo(&"Got answer: {resp} ")

```

