### PR TITLE
Add --noRebuild option for install

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -68,6 +68,7 @@ type
       passNimFlags*: seq[string]
       devActions*: seq[DevelopAction]
       path*: string
+      noRebuild*: bool
       withDependencies*: bool
         ## Whether to put in develop mode also the dependencies of the packages
         ## listed in the develop command.
@@ -99,6 +100,7 @@ Commands:
   install      [pkgname, ...]     Installs a list of packages.
                [-d, --depsOnly]   Install only dependencies.
                [-p, --passNim]    Forward specified flag to compiler.
+               [--noRebuild]      Don't rebuild binaries if they're up-to-date.
   develop      [pkgname, ...]     Clones a list of packages for development.
                                   Adds them to a develop file if specified or
                                   to `nimble.develop` if not specified and
@@ -499,6 +501,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     case f
     of "depsonly", "d":
       result.depsOnly = true
+    of "norebuild":
+      result.action.noRebuild = true
     of "passnim", "p":
       result.action.passNimFlags.add(val)
     else:


### PR DESCRIPTION
Needs testing to make sure it works as expected.

This PR allows to separate build and installation, this is needed for installing nim packages using source-based system package managers like portage.