### PR TITLE
Support multiple Nimble dirs

### DIFF
--- a/src/nimblepkg/displaymessages.nim
+++ b/src/nimblepkg/displaymessages.nim
@@ -37,6 +37,9 @@ const
   ignoringCompilationFlagsMsg* =
     "Ignoring compilation flags for installed package."
 
+  uninstallRevDepsNimbleDirsMsg* =
+    "Option 'inclDeps' cannot be used with multiple Nimble directories."
+
   updatingTheLockFileMsg* = "Updating the lock file..."
   generatingTheLockFileMsg* = "Generating the lock file..."
   lockFileIsUpdatedMsg* = "The lock file is updated."
@@ -55,6 +58,9 @@ proc pkgInstalledMsg*(pkgName: string): string =
   &"{pkgName} installed successfully."
 
 proc pkgNotFoundMsg*(pkg: PkgTuple): string = &"Package {pkg} not found."
+
+proc pkgNotFoundInNimbleDirMsg*(nimbleDir: string): string =
+  &"Package not found in \"{nimbleDir}\"."
 
 proc pkgDepsAlreadySatisfiedMsg*(dep: PkgTuple): string =
   &"Dependency on {dep} already satisfied"

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -303,6 +303,11 @@ proc getInstalledPkgsMin*(libsDir: string, options: Options): seq[PackageInfo] =
         let pkg = getInstalledPackageMin(path, nimbleFile)
         result.add pkg
 
+proc getInstalledPkgsMin*(options: Options): seq[PackageInfo] =
+  result = @[]
+  for nimbleDir in options.nimbleDirs:
+    result.add(getInstalledPkgsMin(nimbleDir.getPkgsDir(), options))
+
 proc withinRange*(pkgInfo: PackageInfo, verRange: VersionRange): bool =
   ## Determines whether the specified package's version is within the specified
   ## range. As the ordinary version is always added to the special versions set

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -503,10 +503,6 @@ proc toFullInfo*(pkg: PackageInfo, options: Options): PackageInfo =
            "A package must not be simultaneously installed and linked."
 
     if result.isInstalled:
-      assert result.metaData.vcsRevision == notSetSha1Hash,
-            "Should not have a VCS revision read from package directory for " &
-            "installed packages."
-
       # For installed packages use already read meta data.
       result.metaData = pkg.metaData
   else:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -40,6 +40,7 @@
 
 # occurs on multiple levels
 nimbleDir/
+nimbleDir2/
 
 # generated nims files
 *_*.nims

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -28,8 +28,10 @@ let
   pkgsDir* = installDir / nimblePackagesDirName
 
 proc execNimble*(args: varargs[string]): ProcessOutput =
+  let defaultNimbleDir = getHomeDir() / ".nimble"
   var quotedArgs = @args
   quotedArgs.insert("--nimbleDir:" & installDir)
+  quotedArgs.insert("--excludeNimbleDir:" & defaultNimbleDir)
   quotedArgs.insert(nimblePath)
   quotedArgs = quotedArgs.map((x: string) => x.quoteShell)
 

--- a/tests/tmisctests.nim
+++ b/tests/tmisctests.nim
@@ -107,6 +107,15 @@ suite "misc tests":
       linesWithWarningsCount += checkOutput(output)
     check linesWithWarningsCount == 0
 
+  test "can find deps in fallback Nimble directory":
+    cleanDir(installDir)
+    cleanDir(&"{installDir}2")
+    check execNimbleYes("install", &"{pkgAUrl}@0.2").exitCode == QuitSuccess
+    let (output, exitCode) = execNimbleYes(
+      &"--nimbleDir:{installDir}2", "install", pkgBUrl)
+    check exitCode == QuitSuccess
+    check output.contains("Dependency on PackageA@0.2 already satisfied")
+
   test "can update":
     check execNimble("update").exitCode == QuitSuccess
 


### PR DESCRIPTION
This PR closes issue #956. It is more complex than PR #965 (`--destDir`) but hypothetically solves wider range of use cases.

**Important:** only the main Nimble dir can be modified, the others are read-only (this is necessary for packaging in Linux distributions).

Some regressions:
* `uninstall --inclDeps` can no longer be used with `--nimbleDir` - use `--excludeNimbleDir` to leave only one Nimble dir (workaround applied in test suite)
* `assert result.metaData.vcsRevision == notSetSha1Hash` removed because it no longer works for some reason

Some edge cases are probably not covered.