### PR TITLE
Add `develop --global` option

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -293,8 +293,8 @@ packages for which the develop command is executed.
 manipulated. It is useful for creating a free develop file which is not 
 associated with any project intended for inclusion in some other develop file.
 * `-g, --global` - Creates an old style link file in the special `links`
-directory. It is read by Nim to be able to use global develop mode packages but
-it is ignored by Nimble.
+directory. It is read by Nim to be able to use global develop mode packages.
+Nimble uses it as a global develop file if a local one does not exist.
 
 The options for manipulation of the develop files could be given only when
 executing `develop` command from some package's directory unless

--- a/readme.markdown
+++ b/readme.markdown
@@ -292,6 +292,9 @@ packages for which the develop command is executed.
 * `--develop-file` - Changes the name of the develop file which to be
 manipulated. It is useful for creating a free develop file which is not 
 associated with any project intended for inclusion in some other develop file.
+* `-g, --global` - Creates an old style link file in the special `links`
+directory. It is read by Nim to be able to use global develop mode packages but
+it is ignored by Nimble.
 
 The options for manipulation of the develop files could be given only when
 executing `develop` command from some package's directory unless

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1292,7 +1292,7 @@ proc updateSyncFile(dependentPkg: PackageInfo, options: Options)
 
 proc updatePathsFile(pkgInfo: PackageInfo, options: Options) =
   let paths = pkgInfo.getDependenciesPaths(options)
-  var pathsFileContent: string
+  var pathsFileContent = "--noNimblePath\n"
   for path in paths:
     pathsFileContent &= &"--path:{path.escape}\n"
   var action = if fileExists(nimblePathsFileName): "updated" else: "generated"

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1151,7 +1151,7 @@ proc saveLinkFile(pkgInfo: PackageInfo, options: Options) =
 
   pkgLinkDir.createDir
   writeFile(pkgLinkFilePath, pkgLinkFileContent)
-  displaySuccess(&"Package link file saved to \"{pkgLinkFilePath}\".")
+  displaySuccess(pkgLinkFileSavedMsg(pkgLinkFilePath))
 
 proc developFromDir(pkgInfo: PackageInfo, options: var Options) =
   assert options.action.typ == actionDevelop,

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1141,8 +1141,8 @@ proc developAllDependencies(pkgInfo: PackageInfo, options: var Options)
 proc saveLinkFile(pkgInfo: PackageInfo, options: Options) =
   let
     pkgName = pkgInfo.basicInfo.name
-    pkgLinkDir = options.getPkgsLinksDir / pkgName & "-#head"
-    pkgLinkFilePath = pkgLinkDir / pkgName & ".nimble-link"
+    pkgLinkDir = options.getPkgsLinksDir / pkgName.getLinkFileDir
+    pkgLinkFilePath = pkgLinkDir / pkgName.getLinkFileName
     pkgLinkFileContent = pkgInfo.myPath & "\n" & pkgInfo.getNimbleFileDir
 
   if pkgLinkDir.dirExists and not options.prompt(
@@ -1449,10 +1449,9 @@ proc check(options: Options) =
   try:
     let currentDir = getCurrentDir()
     let pkgInfo = getPkgInfo(currentDir, options, true)
-    if currentDir.developFileExists:
-      validateDevelopFile(pkgInfo, options)
-      let dependencies = pkgInfo.processAllDependencies(options).toSeq
-      validateDevelopDependenciesVersionRanges(pkgInfo, dependencies, options)
+    validateDevelopFile(pkgInfo, options)
+    let dependencies = pkgInfo.processAllDependencies(options).toSeq
+    validateDevelopDependenciesVersionRanges(pkgInfo, dependencies, options)
     displaySuccess(&"The package \"{pkgInfo.basicInfo.name}\" is valid.")
   except CatchableError as error:
     displayError(error)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1138,6 +1138,21 @@ proc listTasks(options: Options) =
 
 proc developAllDependencies(pkgInfo: PackageInfo, options: var Options)
 
+proc saveLinkFile(pkgInfo: PackageInfo, options: Options) =
+  let
+    pkgName = pkgInfo.basicInfo.name
+    pkgLinkDir = options.getPkgsLinksDir / pkgName & "-#head"
+    pkgLinkFilePath = pkgLinkDir / pkgName & ".nimble-link"
+    pkgLinkFileContent = pkgInfo.myPath & "\n" & pkgInfo.getNimbleFileDir
+
+  if pkgLinkDir.dirExists and not options.prompt(
+    &"The link file for {pkgName} already exists. Overwrite?"):
+    return
+
+  pkgLinkDir.createDir
+  writeFile(pkgLinkFilePath, pkgLinkFileContent)
+  displaySuccess(&"Package link file saved to \"{pkgLinkFilePath}\".")
+
 proc developFromDir(pkgInfo: PackageInfo, options: var Options) =
   assert options.action.typ == actionDevelop,
     "This procedure should be called only when executing develop sub-command."
@@ -1172,6 +1187,9 @@ proc developFromDir(pkgInfo: PackageInfo, options: var Options) =
     else:
       # Dependencies need to be processed before the creation of the pkg dir.
       discard processAllDependencies(pkgInfo, options)
+
+  if options.action.global:
+    saveLinkFile(pkgInfo, options)
 
   displaySuccess(pkgSetupInDevModeMsg(pkgInfo.basicInfo.name, dir))
 

--- a/src/nimblepkg/common.nim
+++ b/src/nimblepkg/common.nim
@@ -24,6 +24,7 @@ type
 const
   nimbleVersion* = "0.14.0"
   nimblePackagesDirName* = "pkgs2"
+  nimblePackagesLinksDirName* ="links"
   nimbleBinariesDirName* = "bin"
 
 proc newNimbleError*[ErrorType](msg: string, hint = "",

--- a/src/nimblepkg/common.nim
+++ b/src/nimblepkg/common.nim
@@ -78,3 +78,9 @@ template cdNewDir*(dir: string, body: untyped) =
   createNewDir dir
   cd dir:
     body
+
+proc getLinkFileDir*(pkgName: string): string =
+  pkgName & "-#head"
+
+proc getLinkFileName*(pkgName: string): string =
+  pkgName & ".nimble-link"

--- a/src/nimblepkg/displaymessages.nim
+++ b/src/nimblepkg/displaymessages.nim
@@ -157,3 +157,6 @@ proc pkgAlreadyExistsInTheCacheMsg*(pkgInfo: PackageInfo): string =
 proc skipDownloadingInAlreadyExistingDirectoryMsg*(dir, name: string): string =
   &"The download directory \"{dir}\" already exists.\n" &
   &"Skipping the download of \"{name}\"."
+
+proc pkgLinkFileSavedMsg*(path: string): string =
+  &"Package link file \"{path}\" is saved."

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -133,8 +133,9 @@ Commands:
                                   specified and executed in package's directory.
          [-g, --global]           Creates an old style link file in the special
                                   `links` directory. It is read by Nim to be
-                                  able to use global develop mode packages but
-                                  it is ignored by Nimble.
+                                  able to use global develop mode packages.
+                                  Nimble uses it as a global develop file if a
+                                  local one does not exist.
   check                           Verifies the validity of a package in the
                                   current working directory.
   init         [pkgname]          Initializes a new Nimble project in the

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -74,6 +74,7 @@ type
         ## Whether to put in develop mode also the dependencies of the packages
         ## listed in the develop command.
       developFile*: string
+      global*: bool
     of actionSearch:
       search*: seq[string] # Search string.
     of actionInit, actionDump:
@@ -108,7 +109,7 @@ Commands:
                                   executed in package's directory.
          [--with-dependencies]    Puts in develop mode also the dependencies
                                   of the packages in the list or of the current
-                                  directory package if the list is
+                                  directory package if the list is empty.
          [--develop-file]         Specifies the name of the develop file which
                                   to be manipulated. If not present creates it.
          [-p, --path path]        Specifies the path whether the packages should
@@ -130,6 +131,10 @@ Commands:
          [-e, --exclude file]     Excludes a develop file from a specified
                                   develop file or from `nimble.develop` if not
                                   specified and executed in package's directory.
+         [-g, --global]           Creates an old style link file in the special
+                                  `links` directory. It is read by Nim to be
+                                  able to use global develop mode packages but
+                                  it is ignored by Nimble.
   check                           Verifies the validity of a package in the
                                   current working directory.
   init         [pkgname]          Initializes a new Nimble project in the
@@ -310,6 +315,9 @@ proc getNimbleDir*(options: Options): string =
 
 proc getPkgsDir*(options: Options): string =
   options.getNimbleDir() / nimblePackagesDirName
+
+proc getPkgsLinksDir*(options: Options): string =
+  options.getNimbleDir() / nimblePackagesLinksDirName
 
 proc getBinDir*(options: Options): string =
   options.getNimbleDir() / nimbleBinariesDirName
@@ -559,6 +567,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
         raise nimbleError(multiplePathOptionsGivenMsg)
     of "with-dependencies":
       result.action.withDependencies = true
+    of "global":
+      result.action.global = true
     of "develop-file":
       if result.action.developFile.len == 0:
         result.action.developFile = val.normalizedPath


### PR DESCRIPTION
An option for creating the old-style Nimble link files is added. Those files are created by `nimble develop` when called with the `--global` option. They are placed in a special `links` directory and they are read by Nim in order to have some kind of develop mode functionality when compiling stand-alone files which are not part of a Nimble package. Nimble itself treats them as a global develop file used only when no local one is found.

Related to nim-lang/nimble#948