### PR TITLE
Iterative dependency resolver

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -182,25 +182,6 @@ proc removePackage(pkgInfo: PackageInfo, options: Options) =
   reinstallSymlinksForOlderVersion(pkgDestDir, options)
   options.nimbleData.removeRevDep(pkgInfo)
 
-proc packageExists(pkgInfo: PackageInfo, options: Options):
-    Option[PackageInfo] =
-  ## Checks whether a package `pkgInfo` already exists in the Nimble cache. If a
-  ## package already exists returns the `PackageInfo` of the package in the
-  ## cache otherwise returns `none`. Raises a `NimbleError` in the case the
-  ## package exists in the cache but it is not valid.
-  let pkgDestDir = pkgInfo.getPkgDest(options)
-  if not fileExists(pkgDestDir / packageMetaDataFileName):
-    return none[PackageInfo]()
-  else:
-    var oldPkgInfo = initPackageInfo()
-    try:
-      oldPkgInfo = pkgDestDir.getPkgInfo(options)
-    except CatchableError as error:
-      raise nimbleError(&"The package inside \"{pkgDestDir}\" is invalid.",
-                        details = error)
-    fillMetaData(oldPkgInfo, pkgDestDir, true)
-    return some(oldPkgInfo)
-
 proc installFromDir(dir: string, options: Options,
                     paths: seq[string], url: string, pkgInfo: var PackageInfo) =
   ## Returns where package has been installed to, together with paths
@@ -1607,7 +1588,6 @@ proc lock(options: Options) =
   let doesLockFileExist = displayLockOperationStart(currentDir)
   validateDevModeDepsWorkingCopiesBeforeLock(pkgInfo, options)
 
-  pkgInfo.lockedDeps.clear()
   let
     packageList = getInstalledPkgsMin(options.getPkgsDir(), options)
     developDeps = processDevelopDependencies(pkgInfo, options)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -601,7 +601,7 @@ proc installIteration(pkgList: seq[PackageInfo],
         let
           resolvedDep =
             (name: dep.name.removeTrailingGitString,
-            ver: dep.ver).resolveAlias(options)
+            ver: dep.ver)
           resolvedName =
             if pkgList.findPkg(resolvedDep, depPackage):
               depPackage.basicInfo.name

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -370,10 +370,10 @@ proc downloadLockedDependency(name: string, dep: LockFileDep, options: Options):
     downloadDir: downloadDir,
     vcsRevision: vcsRevision)
 
-proc installLockedDependency(pkgInfo: PackageInfo, downloadInfo: DownloadInfo,
+proc installLockedDependency(parentInfo: PackageInfo, downloadInfo: DownloadInfo,
                              paths: seq[string], options: Options): PackageInfo =
   ## Installs an already downloaded dependency of the package `pkgInfo`.
-  var newlyInstalledPkgInfo = pkgInfo
+  var newlyInstalledPkgInfo = getPkgInfo(downloadInfo.downloadDir, options)
   installFromDir(
     downloadInfo.downloadDir,
     options,
@@ -385,7 +385,7 @@ proc installLockedDependency(pkgInfo: PackageInfo, downloadInfo: DownloadInfo,
   downloadInfo.downloadDir.removeDir
 
   for depDepName in downloadInfo.dependency.dependencies:
-    let depDep = pkgInfo.lockedDeps[depDepName]
+    let depDep = parentInfo.lockedDeps[depDepName]
     let revDep = (name: depDepName, version: depDep.version,
                   checksum: depDep.checksums.sha1)
     options.nimbleData.addRevDep(revDep, newlyInstalledPkgInfo)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -648,6 +648,8 @@ proc installIteration(pkgList: seq[PackageInfo],
 
       for dep in dependencies[packageName]:
         addRevDep(options.nimbleData, installInfo[dep].package.basicInfo, installInfo[packageName].package)
+    else:
+      displayInfo(pkgDepsAlreadySatisfiedMsg((name: packageName, ver: installInfo[packageName].version.toVersionRange)))
 
     result.add installInfo[packageName].package
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -296,16 +296,6 @@ proc getDependencyDir(name: string, dep: LockFileDep, options: Options):
   ## Returns the installation directory for a dependency from the lock file.
   options.getPkgsDir() /  &"{name}-{dep.version}-{dep.checksums.sha1}"
 
-proc developWithDependencies(options: Options): bool =
-  ## Determines whether the current executed action is a develop sub-command
-  ## with `--with-dependencies` flag.
-  options.action.typ == actionDevelop and options.action.withDependencies
-
-proc raiseCannotCloneInExistingDirException(downloadDir: string) =
-  let msg = "Cannot clone into '$1': directory exists." % downloadDir
-  const hint = "Remove the directory, or run this command somewhere else."
-  raise nimbleError(msg, hint)
-
 type
   DownloadInfo = ref object
     ## Information for a downloaded dependency needed for installation.
@@ -315,6 +305,16 @@ type
     version: VersionRange
     downloadDir: string
     vcsRevision: Sha1Hash
+
+proc developWithDependencies(options: Options): bool =
+  ## Determines whether the current executed action is a develop sub-command
+  ## with `--with-dependencies` flag.
+  options.action.typ == actionDevelop and options.action.withDependencies
+
+proc raiseCannotCloneInExistingDirException(downloadDir: string) =
+  let msg = "Cannot clone into '$1': directory exists." % downloadDir
+  const hint = "Remove the directory, or run this command somewhere else."
+  raise nimbleError(msg, hint)
 
 proc downloadLockedDependency(name: string, dep: LockFileDep, options: Options):
     DownloadInfo =
@@ -1738,7 +1738,7 @@ proc sync(options: Options) =
   if not options.action.listOnly:
     # On `sync` we also want to update Nimble cache with the dependencies'
     # versions from the lock file.
-    discard processAllDependencies(pkgInfo, options)
+    discard processLockedDependencies(pkgInfo, options)
     if fileExists(nimblePathsFileName):
       updatePathsFile(pkgInfo, options)
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -448,6 +448,7 @@ proc installIteration(packages: seq[PkgTuple],
     toProcess: seq[string]
 
   for package in packages:
+    if package.name.len == 0: continue
     let constraintTuple = ("user", package.ver)
     if package.name == "nimrod" or package.name == "nim":
       let nimVer = getNimrodVersion(options)
@@ -664,6 +665,8 @@ proc install(packages: seq[PkgTuple],
     result = installIteration(pkgInfo.requires, options, doPrompt, fromLockFile)
     if not options.depsOnly:
       installFromDir(getCurrentDir(), options, result.map(it => it.getRealDir()).toHashSet(), "", pkgInfo)
+      for dep in result:
+        addRevDep(options.nimbleData, dep.basicInfo, pkgInfo)
       result.add(pkgInfo)
   else:
     result = installIteration(packages, options, doPrompt, fromLockFile)

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -340,7 +340,9 @@ proc findPkg*(pkglist: seq[PackageInfo], dep: PkgTuple,
       # is not being considered for them.
       r = pkg
       return true
-    elif withinRange(pkg, dep.ver):
+    elif withinRange(pkg, dep.ver) or
+      (dep.ver.kind == verSpecial and dep.ver.spe in pkg.metaData.specialVersions):
+
       let isNewer = r.basicInfo.version < pkg.basicInfo.version
       if not result or isNewer:
         r = pkg

--- a/src/nimblepkg/topologicalsort.nim
+++ b/src/nimblepkg/topologicalsort.nim
@@ -2,7 +2,7 @@
 # BSD License. Look at license.txt for more info.
 
 import sequtils, tables, strformat, algorithm, sets
-import common, packageinfotypes, packageinfo, options, cli
+import packageinfotypes, options, cli
 
 proc buildLockFileDeps*(packages: seq[PackageInfo], depGraph: Table[string, seq[string]], options: Options):
     LockFileDeps =

--- a/src/nimblepkg/topologicalsort.nim
+++ b/src/nimblepkg/topologicalsort.nim
@@ -33,7 +33,7 @@ proc buildDependencyGraph*(packages: seq[PackageInfo], options: Options):
       vcsRevision: pkgInfo.metaData.vcsRevision,
       url: pkgInfo.metaData.url,
       downloadMethod: pkgInfo.metaData.downloadMethod,
-      dependencies: getDependencies(packages, pkgInfo, options),
+      #dependencies: getDependencies(packages, pkgInfo, options),
       checksums: Checksums(sha1: pkgInfo.basicInfo.checksum))
 
 proc topologicalSort*(graph: LockFileDeps):

--- a/src/nimblepkg/topologicalsort.nim
+++ b/src/nimblepkg/topologicalsort.nim
@@ -20,7 +20,7 @@ proc getDependencies(packages: seq[PackageInfo], package: PackageInfo,
       found = findPkg(packages, resolvedDep, depPkgInfo)
       if not found:
         raise nimbleError(
-           "Cannot build the dependency graph.\n" & 
+           "Cannot build the dependency graph.\n" &
           &"Missing package \"{dep.name}\".")
     result.add depPkgInfo.basicInfo.name
 

--- a/src/nimblepkg/topologicalsort.nim
+++ b/src/nimblepkg/topologicalsort.nim
@@ -13,7 +13,7 @@ proc buildLockFileDeps*(packages: seq[PackageInfo], depGraph: Table[string, seq[
       vcsRevision: pkgInfo.metaData.vcsRevision,
       url: pkgInfo.metaData.url,
       downloadMethod: pkgInfo.metaData.downloadMethod,
-      dependencies: depGraph.getOrDefault(pkgInfo.basicInfo.name),
+      dependencies: depGraph.getOrDefault(pkgInfo.basicInfo.name).sorted,
       checksums: Checksums(sha1: pkgInfo.basicInfo.checksum))
 
 proc topologicalSort*(graph: OrderedTable[string, seq[string]]):

--- a/src/nimblepkg/version.nim
+++ b/src/nimblepkg/version.nim
@@ -172,12 +172,17 @@ proc refine*(input_a, input_b: VersionRange): VersionRange =
     b = input_b
   if a.kind > b.kind: swap(a, b)
 
-  if b.kind == verEq or b.kind == verSpecial:
-    # Eq & Special are handled elsewhere
+  if b.kind == verSpecial:
+    # Special are handled elsewhere
     # Ignore them during refining
     return a
   if b.kind == verAny:
     return a
+
+  if b.kind == verEq:
+    if not b.ver.withinRange(a):
+      raise newException(NimbleError, "Can't refine range")
+    return b
 
   result = case a.kind
     of verEqLater, verLater:

--- a/tests/tdevelopfeature.nim
+++ b/tests/tdevelopfeature.nim
@@ -566,8 +566,8 @@ suite "develop feature":
         let (output, exitCode) = execNimble("run", "-n")
         check exitCode == QuitFailure
         var lines = output.processOutput
-        check lines.inLinesOrdered(failedToLoadFileMsg(pkg1DevFileAbsPath))
-        check lines.inLinesOrdered(pkgFoundMoreThanOnceMsg("pkg3",
+        check lines.inLines(failedToLoadFileMsg(pkg1DevFileAbsPath))
+        check lines.inLines(pkgFoundMoreThanOnceMsg("pkg3",
           [(pkg3AbsPath.Path, pkg1DevFileAbsPath.Path),
            (pkg32AbsPath.Path, pkg2DevFileAbsPath.Path)].toHashSet))
 
@@ -622,9 +622,9 @@ suite "develop feature":
         let (output, exitCode) = execNimble("run", "-n")
         check exitCode == QuitSuccess
         var lines = output.processOutput
-        check lines.inLinesOrdered(
+        check lines.inLines(
           pkgDepsAlreadySatisfiedMsg(("pkg2", anyVersion)))
-        check lines.inLinesOrdered(
+        check lines.inLines(
           pkgDepsAlreadySatisfiedMsg(("pkg3", anyVersion)))
 
   test "do not filter used included develop dependencies":
@@ -673,11 +673,11 @@ suite "develop feature":
         let (output, exitCode) = execNimble("run", "-n")
         check exitCode == QuitSuccess
         var lines = output.processOutput
-        check lines.inLinesOrdered(
+        check lines.inLines(
           pkgDepsAlreadySatisfiedMsg(("pkg2", anyVersion)))
-        check lines.inLinesOrdered(
+        check lines.inLines(
           pkgDepsAlreadySatisfiedMsg(("pkg3", anyVersion)))
-        check lines.inLinesOrdered(
+        check lines.inLines(
           pkgDepsAlreadySatisfiedMsg(("pkg3", anyVersion)))
 
   test "version clash with not used included develop dependencies":
@@ -799,7 +799,7 @@ suite "develop feature":
           freeDevFile1Path = (".." / freeDevFile1Name).Path
           freeDevFile2Path = (".." / freeDevFile2Name).Path
 
-        check lines.inLinesOrdered(pkgFoundMoreThanOnceMsg("pkg3",
+        check lines.inLines(pkgFoundMoreThanOnceMsg("pkg3",
           [(pkg3Path, freeDevFile1Path),
            (pkg32Path, freeDevFile2Path)].toHashSet))
 

--- a/tests/tmultipkgs.nim
+++ b/tests/tmultipkgs.nim
@@ -7,9 +7,9 @@ import unittest, os
 import testscommon
 
 from nimblepkg/common import nimblePackagesDirName
-from nimblepkg/version import `$`
+from nimblepkg/version import newVRAny
 from nimblepkg/sha1hashes import `$`
-from nimblepkg/displaymessages import pkgAlreadyExistsInTheCacheMsg
+from nimblepkg/displaymessages import pkgDepsAlreadySatisfiedMsg
 from nimblepkg/tools import getNameVersionChecksum
 
 template installAlpha =
@@ -33,7 +33,7 @@ suite "multi":
       let (name, version, checksum) = getNameVersionChecksum(dir)
       if name != "alpha": continue
       check lines.inLinesOrdered(
-        pkgAlreadyExistsInTheCacheMsg(name, $version, $checksum))
+        pkgDepsAlreadySatisfiedMsg((name: name, ver: newVRAny())))
       break
     check lines.inLinesOrdered("beta installed successfully")
 

--- a/tests/tmultipkgs.nim
+++ b/tests/tmultipkgs.nim
@@ -8,7 +8,6 @@ import testscommon
 
 from nimblepkg/common import nimblePackagesDirName
 from nimblepkg/version import newVRAny
-from nimblepkg/sha1hashes import `$`
 from nimblepkg/displaymessages import pkgDepsAlreadySatisfiedMsg
 from nimblepkg/tools import getNameVersionChecksum
 
@@ -30,7 +29,7 @@ suite "multi":
     check exitCode == QuitSuccess
     var lines = output.processOutput
     for _,  dir in walkDir(installDir / nimblePackagesDirName):
-      let (name, version, checksum) = getNameVersionChecksum(dir)
+      let (name, _, _) = getNameVersionChecksum(dir)
       if name != "alpha": continue
       check lines.inLinesOrdered(
         pkgDepsAlreadySatisfiedMsg((name: name, ver: newVRAny())))

--- a/tests/tuninstall.nim
+++ b/tests/tuninstall.nim
@@ -23,8 +23,8 @@ suite "uninstall":
     let args = ["install", pkgBin2Url]
     check execNimbleYes(args).exitCode == QuitSuccess
 
-  proc cannotSatisfyMsg(v1, v2: string): string =
-     &"Cannot satisfy the dependency on PackageA {v1} and PackageA {v2}"
+  proc cannotSatisfyMsg(package: string): string =
+     &"Cannot satisfy the dependencies on " & package
 
   test "can reject same version dependencies":
     cleanDir(installDir)
@@ -33,8 +33,7 @@ suite "uninstall":
     # stderr output being generated and flushed without first flushing stdout
     let ls = outp.strip.processOutput()
     check exitCode != QuitSuccess
-    check ls.inLines(cannotSatisfyMsg("0.2.0", "0.5.0")) or
-          ls.inLines(cannotSatisfyMsg("0.5.0", "0.2.0"))
+    check ls.inLines(cannotSatisfyMsg("PackageA"))
 
   proc setupIssue27Packages() =
     # Install b


### PR DESCRIPTION
This PR switch nimble from a recursive dependency solver to an iterative one. This allows the algorithm to be a lot smarter, since it has a global view of dependency tree. Ex:
<details>
<summary>Example with already installed dependencies</summary>
<pre>
[~/nim-libp2p] $ nimble install -d
   Checking nimcrypto required by: user (>= 0.4.1)
   Checking https://github.com/ba0f3/dnsclient.nim required by: user (0.1.0)
   Checking bearssl required by: user (>= 0.1.4)
   Checking chronicles required by: user (>= 0.10.2)
   Checking chronos required by: user (>= 3.0.6)
   Checking metrics required by: user (any version)
   Checking secp256k1 required by: user (any version)
   Checking stew required by: user (#head), chronos (any version), secp256k1 (any version)
   Checking websock required by: user (any version)
   Checking unittest2 required by: bearssl (any version), chronos (#head)
   Checking testutils required by: chronicles (any version)
   Checking json_serialization required by: chronicles (any version)
   Checking httputils required by: chronos (any version), websock (>= 0.2.0)
   Checking asynctest required by: websock (>= 0.3.0 & < 0.4.0)
   Checking zlib required by: websock (any version)
   Checking unittest2 required by: bearssl (any version), chronos (#head), testutils (#head)
   Checking serialization required by: json_serialization (any version)
   Checking faststreams required by: serialization (any version)
     Info:  Dependency on unittest2@0.0.3 already satisfied
     Info:  Dependency on dnsclient@0.1.0 already satisfied
     Info:  Dependency on stew@0.1.0 already satisfied
     Info:  Dependency on testutils@0.4.2 already satisfied
     Info:  Dependency on nimcrypto@0.5.4 already satisfied
     Info:  Dependency on bearssl@0.1.5 already satisfied
     Info:  Dependency on asynctest@0.3.0 already satisfied
     Info:  Dependency on zlib@0.1.0 already satisfied
     Info:  Dependency on httputils@0.3.0 already satisfied
     Info:  Dependency on secp256k1@0.5.1 already satisfied
     Info:  Dependency on chronos@3.0.10 already satisfied
     Info:  Dependency on faststreams@0.3.0 already satisfied
     Info:  Dependency on metrics@0.0.1 already satisfied
     Info:  Dependency on serialization@0.1.0 already satisfied
     Info:  Dependency on json_serialization@0.1.0 already satisfied
     Info:  Dependency on chronicles@0.10.2 already satisfied
     Info:  Dependency on websock@0.1.0 already satisfied
</pre>
</details>

<details>
<summary>Example with no dependency installed</summary>
<pre>
$ nimble install libp2p
   Checking libp2p required by: user (any version)
Downloading https://github.com/status-im/nim-libp2p using git
   Checking nimcrypto required by: libp2p (>= 0.4.1)
Downloading https://github.com/cheatfate/nimcrypto using git
   Checking https://github.com/ba0f3/dnsclient.nim required by: libp2p (0.1.0)
Downloading https://github.com/ba0f3/dnsclient.nim using git
   Checking bearssl required by: libp2p (>= 0.1.4)
Downloading https://github.com/status-im/nim-bearssl using git
   Checking chronicles required by: libp2p (>= 0.10.2)
Downloading https://github.com/status-im/nim-chronicles using git
   Checking chronos required by: libp2p (>= 3.0.6)
Downloading https://github.com/status-im/nim-chronos using git
   Checking metrics required by: libp2p (any version)
Downloading https://github.com/status-im/nim-metrics using git
   Checking secp256k1 required by: libp2p (any version)
Downloading https://github.com/status-im/nim-secp256k1 using git
   Checking stew required by: libp2p (#head), chronos (any version), secp256k1 (any version)
Downloading https://github.com/status-im/nim-stew using git
   Checking websock required by: libp2p (any version)
Downloading https://github.com/status-im/nim-websock using git
   Checking unittest2 required by: bearssl (any version)
Downloading https://github.com/status-im/nim-unittest2 using git
   Checking testutils required by: chronicles (any version)
Downloading https://github.com/status-im/nim-testutils using git
   Checking json_serialization required by: chronicles (any version)
Downloading https://github.com/status-im/nim-json-serialization using git
   Checking httputils required by: chronos (any version), websock (>= 0.2.0)
Downloading https://github.com/status-im/nim-http-utils using git
   Checking https://github.com/status-im/nim-unittest2 required by: chronos (#head), testutils (#head)
Downloading https://github.com/status-im/nim-unittest2 using git
   Checking asynctest required by: websock (>= 0.3.0 & < 0.4.0)
Downloading https://github.com/markspanbroek/asynctest using git
   Checking zlib required by: websock (any version)
Downloading https://github.com/status-im/nim-zlib using git
   Checking serialization required by: json_serialization (any version)
Downloading https://github.com/status-im/nim-serialization using git
   Checking unittest2 required by: bearssl (any version), chronos (#head), testutils (#head), serialization (any version)
Downloading https://github.com/status-im/nim-unittest2 using git
   Checking faststreams required by: serialization (any version)
Downloading https://github.com/status-im/nim-faststreams using git
 Installing unittest2@0.0.3
  Success:  unittest2 installed successfully.
 Installing dnsclient@0.1.0
   Building dnsclient/dnsclient using c backend
  Success:  dnsclient installed successfully.
 Installing stew@0.1.0
  Success:  stew installed successfully.
 Installing testutils@0.4.2
   Building testutils/ntu using c backend
  Success:  testutils installed successfully.
 Installing nimcrypto@0.5.4
  Success:  nimcrypto installed successfully.
 Installing bearssl@0.1.5
  Success:  bearssl installed successfully.
 Installing asynctest@0.3.0
  Success:  asynctest installed successfully.
 Installing zlib@0.1.0
  Success:  zlib installed successfully.
 Installing httputils@0.3.0
  Success:  httputils installed successfully.
 Installing secp256k1@0.5.1
  Success:  secp256k1 installed successfully.
 Installing chronos@3.0.10
  Success:  chronos installed successfully.
 Installing faststreams@0.3.0
  Success:  faststreams installed successfully.
 Installing metrics@0.0.1
  Success:  metrics installed successfully.
 Installing serialization@0.1.0
  Success:  serialization installed successfully.
 Installing json_serialization@0.1.0
  Success:  json_serialization installed successfully.
 Installing chronicles@0.10.2
  Success:  chronicles installed successfully.
 Installing websock@0.1.0
  Success:  websock installed successfully.
 Installing libp2p@0.0.2
  Success:  libp2p installed successfully.
</pre>
</details>

<details>
<summary>As a reminder, current nimble output to install libp2p</summary>
<pre>
  Verifying dependencies for libp2p@0.0.2
 Installing nimcrypto@>= 0.4.1
Downloading https://github.com/cheatfate/nimcrypto using git
  Verifying dependencies for nimcrypto@0.5.4
 Installing nimcrypto@0.5.4
   Success: nimcrypto installed successfully.
 Installing https://github.com/ba0f3/dnsclient.nim@0.1.0
Downloading https://github.com/ba0f3/dnsclient.nim using git
  Verifying dependencies for dnsclient@0.1.0
 Installing dnsclient@0.1.0
   Building dnsclient/dnsclient using c backend
   Success: dnsclient installed successfully.
 Installing bearssl@>= 0.1.4
Downloading https://github.com/status-im/nim-bearssl using git
  Verifying dependencies for bearssl@0.1.5
 Installing unittest2@any version
Downloading https://github.com/status-im/nim-unittest2 using git
  Verifying dependencies for unittest2@0.0.3
 Installing unittest2@0.0.3
   Success: unittest2 installed successfully.
 Installing bearssl@0.1.5
   Success: bearssl installed successfully.
 Installing chronicles@>= 0.10.2
Downloading https://github.com/status-im/nim-chronicles using git
  Verifying dependencies for chronicles@0.10.2
 Installing testutils@any version
Downloading https://github.com/status-im/nim-testutils using git
  Verifying dependencies for testutils@0.4.2
 Installing https://github.com/status-im/nim-unittest2.git@#head
Downloading https://github.com/status-im/nim-unittest2.git using git
  Verifying dependencies for unittest2@#head
 Installing unittest2@#head
   Success: unittest2 installed successfully.
 Installing testutils@0.4.2
   Building testutils/ntu using c backend
   Success: testutils installed successfully.
 Installing json_serialization@any version
Downloading https://github.com/status-im/nim-json-serialization using git
  Verifying dependencies for json_serialization@0.1.0
 Installing serialization@any version
Downloading https://github.com/status-im/nim-serialization using git
  Verifying dependencies for serialization@0.1.0
 Installing faststreams@any version
Downloading https://github.com/status-im/nim-faststreams using git
  Verifying dependencies for faststreams@0.3.0
 Installing stew@any version
Downloading https://github.com/status-im/nim-stew using git
  Verifying dependencies for stew@0.1.0
 Installing stew@0.1.0
   Success: stew installed successfully.
      Info: Dependency on testutils@any version already satisfied
  Verifying dependencies for testutils@0.4.2
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
 Installing chronos@any version
Downloading https://github.com/status-im/nim-chronos using git
  Verifying dependencies for chronos@3.0.10
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on bearssl@any version already satisfied
  Verifying dependencies for bearssl@0.1.5
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
 Installing httputils@any version
Downloading https://github.com/status-im/nim-http-utils using git
  Verifying dependencies for httputils@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
 Installing httputils@0.3.0
   Success: httputils installed successfully.
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
 Installing chronos@3.0.10
   Success: chronos installed successfully.
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
 Installing faststreams@0.3.0
   Success: faststreams installed successfully.
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
 Installing serialization@0.1.0
   Success: serialization installed successfully.
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
 Installing json_serialization@0.1.0
   Success: json_serialization installed successfully.
 Installing chronicles@0.10.2
   Success: chronicles installed successfully.
      Info: Dependency on chronos@>= 3.0.6 already satisfied
  Verifying dependencies for chronos@3.0.10
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on bearssl@any version already satisfied
  Verifying dependencies for bearssl@0.1.5
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on httputils@any version already satisfied
  Verifying dependencies for httputils@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
 Installing metrics@any version
Downloading https://github.com/status-im/nim-metrics using git
  Verifying dependencies for metrics@0.0.1
      Info: Dependency on chronos@>= 2.6.0 already satisfied
  Verifying dependencies for chronos@3.0.10
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on bearssl@any version already satisfied
  Verifying dependencies for bearssl@0.1.5
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on httputils@any version already satisfied
  Verifying dependencies for httputils@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
 Installing metrics@0.0.1
   Success: metrics installed successfully.
 Installing secp256k1@any version
Downloading https://github.com/status-im/nim-secp256k1 using git
  Verifying dependencies for secp256k1@0.5.1
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on nimcrypto@any version already satisfied
  Verifying dependencies for nimcrypto@0.5.4
 Installing secp256k1@0.5.1
   Success: secp256k1 installed successfully.
 Installing stew@#head
Downloading https://github.com/status-im/nim-stew using git
  Verifying dependencies for stew@#head
 Installing stew@#head
   Success: stew installed successfully.
 Installing websock@any version
Downloading https://github.com/status-im/nim-websock using git
  Verifying dependencies for websock@0.1.0
      Info: Dependency on chronos@>= 3.0.0 already satisfied
  Verifying dependencies for chronos@3.0.10
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on bearssl@any version already satisfied
  Verifying dependencies for bearssl@0.1.5
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on httputils@any version already satisfied
  Verifying dependencies for httputils@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
      Info: Dependency on httputils@>= 0.2.0 already satisfied
  Verifying dependencies for httputils@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on chronicles@>= 0.10.2 already satisfied
  Verifying dependencies for chronicles@0.10.2
      Info: Dependency on testutils@any version already satisfied
  Verifying dependencies for testutils@0.4.2
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
      Info: Dependency on json_serialization@any version already satisfied
  Verifying dependencies for json_serialization@0.1.0
      Info: Dependency on serialization@any version already satisfied
  Verifying dependencies for serialization@0.1.0
      Info: Dependency on faststreams@any version already satisfied
  Verifying dependencies for faststreams@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on testutils@any version already satisfied
  Verifying dependencies for testutils@0.4.2
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
      Info: Dependency on chronos@any version already satisfied
  Verifying dependencies for chronos@3.0.10
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on bearssl@any version already satisfied
  Verifying dependencies for bearssl@0.1.5
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on httputils@any version already satisfied
  Verifying dependencies for httputils@0.3.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on https://github.com/status-im/nim-unittest2.git@#head already satisfied
  Verifying dependencies for unittest2@#head
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on stew@any version already satisfied
  Verifying dependencies for stew@0.1.0
      Info: Dependency on stew@>= 0.1.0 already satisfied
  Verifying dependencies for stew@0.1.0
 Installing asynctest@>= 0.3.0 & < 0.4.0
Downloading https://github.com/markspanbroek/asynctest using git
  Verifying dependencies for asynctest@0.3.0
 Installing asynctest@0.3.0
   Success: asynctest installed successfully.
      Info: Dependency on nimcrypto@any version already satisfied
  Verifying dependencies for nimcrypto@0.5.4
      Info: Dependency on bearssl@any version already satisfied
  Verifying dependencies for bearssl@0.1.5
      Info: Dependency on unittest2@any version already satisfied
  Verifying dependencies for unittest2@0.0.3
 Installing zlib@any version
Downloading https://github.com/status-im/nim-zlib using git
  Verifying dependencies for zlib@0.1.0
      Info: Dependency on stew@>= 0.1.0 already satisfied
  Verifying dependencies for stew@0.1.0
 Installing zlib@0.1.0
   Success: zlib installed successfully.
 Installing websock@0.1.0
   Success: websock installed successfully.
 Installing libp2p@0.0.2
   Success: libp2p installed successfully.
</pre>
</details>

The current iterative algorithm is fairly simple, but effective. We start by building the dependency graph:
- We build a list of things to install, and for each thing to install, we create a list of constraints (eg `stew required by: user (#head)`
- We'll then process them one at a time, adding it's dependencies as constraints where required. If a package is missing, we'll download it (but not install it yet) to check it's dependencies. (eg, when processing chronos, we notice that it also requires `stew`, so we add it to stew constaints `stew required by: user (#head), chronos (any version)`)
- If we processed a package, but a later package adds an constraint incompatible with the version we chose during the processing, we simply add the incompatible version back to the list of things to process.
- If two packages have incompatible constraints, we'll fail:
```sh
$ ../nimble/nimble install stew@#head stew@0.0.0
   Checking stew required by: user (#head), user (0.0.0)
Downloading https://github.com/status-im/nim-stew using git
       Tip: 3 messages have been suppressed, use --verbose to show them.
/home/tavon/Status/nimble/src/nimble.nim(1938) nimble
/home/tavon/Status/nimble/src/nimble.nim(1857) doAction
/home/tavon/Status/nimble/src/nimble.nim(696) install
/home/tavon/Status/nimble/src/nimble.nim(576) installIteration

    Error:  Cannot satisfy the dependencies on stew
```

When we've finished building the dep graph, we'll install every missing package (after their deps).

This is still WiP. I originally based my work on 0.13.1, and when porting it to master a lot of things broke. Currently fixing remaining issues.


The major thing missing from this algorithm is what python calls "[backtracking](https://pip.pypa.io/en/stable/topics/dependency-resolution/#backtracking) ".
 eg, if two have:
- A@4.0: requires C@1.0
- B@3.0: requires C@1.0
- B@4.0: requires C@2.0

`nimble install A@>2.0 B@>2.0` will not work, because the latest version of A & B are not compatible. But we could find out that using B@3.0 would solve the issue.
With the current nimble file format, that would imply downloading a lot of versions to find a compatible one, like python does, which is not ideal.
If a user stumble onto this, he can "manually" backtrack by asking for an older version of B manually.