### PR TITLE
Remove Nimble beta qualifier

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # Nimble
 
-Nimble is a *beta*-grade *package manager* for the [Nim programming
+Nimble is the default *package manager* for the [Nim programming
 language](https://nim-lang.org).
 
 Interested in learning **how to create a package**? Skip directly to that section


### PR DESCRIPTION
It seems to me that Nimble is not beta software at this point. It's widely used, fairly stable, and mostly does what is needed. Especially with the addition of lock files, I don't believe the beta qualifier fits. It's certainly not worse than the Python or Go-lang package managers, and arguably better in many ways. 

The reason for changing this is that it gives a bit of a "Nim's package manger is beta? Should I really be sure about this language... ".