### PR TITLE
Fix Git sub-modules handling

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -15,15 +15,18 @@ type
     version: Version
     vcsRevision: Sha1Hash
 
+proc updateSubmodules(dir: string) =
+  discard tryDoCmdEx(
+    &"git -C {dir} submodule update --init --recursive --depth 1")
+
 proc doCheckout(meth: DownloadMethod, downloadDir, branch: string) =
   case meth
   of DownloadMethod.git:
     # Force is used here because local changes may appear straight after a clone
     # has happened. Like in the case of git on Windows where it messes up the
     # damn line endings.
-    discard tryDoCmdEx(&"git -C {downloadDir} checkout --force {branch}")
-    discard tryDoCmdEx(
-      &"git -C {downloadDir} submodule update --recursive --depth 1")
+    discard tryDoCmdEx(&"git -C {downloadDir} checkout --force {branch}") 
+    downloadDir.updateSubmodules
   of DownloadMethod.hg:
     discard tryDoCmdEx(&"hg --cwd {downloadDir} checkout {branch}")
 
@@ -147,6 +150,7 @@ proc cloneSpecificRevision(downloadMethod: DownloadMethod,
     discard tryDoCmdEx(
       &"git -C {downloadDir} fetch --depth 1 origin {vcsRevision}")
     discard tryDoCmdEx(&"git -C {downloadDir} reset --hard FETCH_HEAD")
+    downloadDir.updateSubmodules
   of DownloadMethod.hg:
     discard tryDoCmdEx(&"hg clone {url} -r {vcsRevision}")
 


### PR DESCRIPTION
Add init and update of Git sub-modules when cloning a specific revision. This is used by the `nimble sync` command when downloading locked dependencies. Without it required by some libraries, additional files will not be installed. This for example is the case with the `nim-bearssl` library.

Fixes  nim-lang/nimble#958