### PR TITLE
Consider given version range in `nimble path`

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -857,7 +857,7 @@ proc listPaths(options: Options) =
     var installed: seq[VersionAndPath] = @[]
     # There may be several, list all available ones and sort by version.
     for pkg in pkgs:
-      if name == pkg.basicInfo.name:
+      if name == pkg.basicInfo.name and withinRange(pkg.basicInfo.version, version):
         installed.add((pkg.basicInfo.version, pkg.getRealDir))
 
     if installed.len > 0:


### PR DESCRIPTION
Previously, versions passed to `nimble path` such as `nimble path pack@0.1.0` were accepted, but ignored. Now, this version restriction is respected.