### PR TITLE
Fix create directory behavior

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -963,6 +963,7 @@ proc init(options: Options) =
     raise nimbleError("Please install git or mercurial first")
 
   # Determine the package name.
+  let hasprojectname = options.action.projName != ""
   let pkgName =
     if options.action.projName != "":
       options.action.projName
@@ -974,7 +975,7 @@ proc init(options: Options) =
 
   # Determine the package root.
   let pkgRoot =
-    if pkgName == os.getCurrentDir().splitPath.tail:
+    if not hasprojectname:
       os.getCurrentDir()
     else:
       os.getCurrentDir() / pkgName

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -975,7 +975,7 @@ proc init(options: Options) =
 
   # Determine the package root.
   let pkgRoot =
-    if not hasprojectname:
+    if not hasProjectName:
       os.getCurrentDir()
     else:
       os.getCurrentDir() / pkgName

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -963,7 +963,7 @@ proc init(options: Options) =
     raise nimbleError("Please install git or mercurial first")
 
   # Determine the package name.
-  let hasprojectname = options.action.projName != ""
+  let hasProjectName = options.action.projName != ""
   let pkgName =
     if options.action.projName != "":
       options.action.projName

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -5,6 +5,7 @@ import testscommon
 
 # suits imports
 
+import tinitcommand
 import tcheckcommand
 import tcleancommand
 import tdevelopfeature

--- a/tests/tinitcommand.nim
+++ b/tests/tinitcommand.nim
@@ -6,8 +6,7 @@ from nimblepkg/common import cd
 suite "init":
   ## https://github.com/nim-lang/nimble/pull/983
   test "init within directory that is invalid package name will not create new directory":
-    cleanDir(installDir)
-    let tempdir = installDir / "a-b"
+    let tempdir = getTempDir() / "a-b"
     createDir(tempdir)
     cd(tempdir):
       let args = ["init"]

--- a/tests/tinitcommand.nim
+++ b/tests/tinitcommand.nim
@@ -1,0 +1,17 @@
+import unittest, os
+import testscommon
+
+from nimblepkg/common import cd
+
+suite "init":
+  ## https://github.com/nim-lang/nimble/pull/983
+  test "init within directory that is invalid package name will not create new directory":
+    cleanDir(installDir)
+    let tempdir = installDir / "a-b"
+    createDir(tempdir)
+    cd(tempdir):
+      let args = ["init"]
+      let (output, exitCode) = execNimbleYes(args)
+      check exitCode == QuitSuccess
+      check not dirExists("a_b")
+      check fileExists("a_b.nimble")

--- a/tests/tinitcommand.nim
+++ b/tests/tinitcommand.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import unittest, os
 import testscommon
 
@@ -11,6 +13,7 @@ suite "init":
     cd(tempdir):
       let args = ["init"]
       let (output, exitCode) = execNimbleYes(args)
+      discard output
       check exitCode == QuitSuccess
       check not dirExists("a_b")
       check fileExists("a_b.nimble")


### PR DESCRIPTION
Before this fix, `nimble init` will create a new directory if current directory name is `a-b`, because the inferred package name is `a_b`.

This fixed the behavior to align with what was in #503, so `nimble init` will never create a new directory.