### PR TITLE
Allow locking nim version in nimble.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ src/nimblepkg/version
 # Test procedure artifacts
 *.nims
 /buildTests
+/tests/nimdep/nimble.lock

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1629,7 +1629,6 @@ proc lock(options: Options) =
 
   # We need to process free dependencies for all tasks.
   # Then we can store each task as a seperate sub graph.
-  var requirements = pkgInfo.requires
   var deps = pkgInfo.processFreeDependencies(pkgInfo.requires, options)
   var fullDeps = deps # Deps shared by base and tasks
 

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -357,6 +357,9 @@ proc useLockedNimIfNeeded(pkgInfo: PackageInfo, options: var Options) =
                             "If you are using develop mode nim make sure to compile it.")
 
         options.nim = nim
+        let separator = when defined(windows): ";" else: ":"
+
+        putEnv("PATH", nimDep.getRealDir() / "bin" & separator & getEnv("PATH"))
         display("Info:", "using $1 for compilation" % options.nim, priority = HighPriority)
 
 proc installFromDir(dir: string, requestedVer: VersionRange, options: Options,
@@ -2128,6 +2131,7 @@ proc doAction(options: var Options) =
       discard pkgInfo.processAllDependencies(optsCopy)
       # If valid task defined in nimscript, run it
       var execResult: ExecutionResult[bool]
+      useLockedNimIfNeeded(pkgInfo, optsCopy)
       if execCustom(nimbleFile, optsCopy, execResult):
         if execResult.hasTaskRequestedCommand():
           var options = execResult.getOptionsForCommand(optsCopy)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1656,7 +1656,7 @@ proc lock(options: Options) =
     # Reset the deps to what they were before hand.
     # Stops dependencies in this task overflowing into the next
     fullDeps.incl newDeps
-
+  options.checkSatisfied(fullDeps)
   let fullInfo = fullDeps.toSeq().map(pkg => pkg.toFullInfo(options))
   pkgInfo.validateDevelopDependenciesVersionRanges(fullInfo, options)
   var graph = buildDependencyGraph(fullInfo, options)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1644,7 +1644,10 @@ proc lock(options: Options) =
   # Add each individual tasks as partial sub graphs
   for task, requires in pkgInfo.taskRequires:
     let newDeps = pkgInfo.processFreeDependencies(requires, options)
+    {.push warning[ProveInit]: off.}
+    # Don't know why this isn't considered proved
     let fullInfo = newDeps.toSeq().map(pkg => pkg.toFullInfo(options))
+    {.push warning[ProveInit]: on.}
     pkgInfo.validateDevelopDependenciesVersionRanges(fullInfo, options)
     # Add in the dependencies that are in this task but not in base
     taskDepNames[task] = initHashSet[string]()
@@ -1655,6 +1658,7 @@ proc lock(options: Options) =
     # Reset the deps to what they were before hand.
     # Stops dependencies in this task overflowing into the next
     fullDeps.incl newDeps
+  # Now build graph for all dependencies
   options.checkSatisfied(fullDeps)
   let fullInfo = fullDeps.toSeq().map(pkg => pkg.toFullInfo(options))
   pkgInfo.validateDevelopDependenciesVersionRanges(fullInfo, options)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -344,7 +344,7 @@ proc allDependencies(pkgInfo: PackageInfo, options: Options): HashSet[PackageInf
     result.incl pkgInfo.processFreeDependencies(requires, options)
 
 proc useLockedNimIfNeeded(pkgInfo: PackageInfo, options: var Options) =
-  if pkgInfo.lockedDeps.len > 0:
+  if pkgInfo.lockedDeps.len > 0 and not options.useSystemNim:
     var deps = pkgInfo.processLockedDependencies(options, true)
     if deps.len != 0:
       # process the first entry (hash.pop is triggering warnings)

--- a/src/nimblepkg/developfile.nim
+++ b/src/nimblepkg/developfile.nim
@@ -854,7 +854,7 @@ proc workingCopyNeeds*(dependencyPkg, dependentPkg: PackageInfo,
   ## if any.
 
   let
-    lockFileVcsRev = dependentPkg.lockedDeps.getOrDefault(
+    lockFileVcsRev = dependentPkg.lockedDeps[""].getOrDefault(
       dependencyPkg.basicInfo.name, notSetLockFileDep).vcsRevision
     syncFile = getSyncFile(dependentPkg)
     syncFileVcsRev = syncFile.getDepVcsRevision(dependencyPkg.basicInfo.name)

--- a/src/nimblepkg/developfile.nim
+++ b/src/nimblepkg/developfile.nim
@@ -854,7 +854,7 @@ proc workingCopyNeeds*(dependencyPkg, dependentPkg: PackageInfo,
   ## if any.
 
   let
-    lockFileVcsRev = dependentPkg.lockedDeps[""].getOrDefault(
+    lockFileVcsRev = dependentPkg.lockedDeps.getOrDefault("").getOrDefault(
       dependencyPkg.basicInfo.name, notSetLockFileDep).vcsRevision
     syncFile = getSyncFile(dependentPkg)
     syncFileVcsRev = syncFile.getDepVcsRevision(dependencyPkg.basicInfo.name)

--- a/src/nimblepkg/lockfile.nim
+++ b/src/nimblepkg/lockfile.nim
@@ -48,7 +48,6 @@ proc readLockFile*(filePath: string): AllLockFileDeps =
   result[noTask] = data[$lfjkPackages].to(LockFileDeps)
   if $lfjkTasks in data:
     for task, deps in data[$lfjkTasks]:
-      echo "Reading in ", task
       result[task] = deps.to(LockFileDeps)
   {.warning[ProveInit]: on.}
   {.warning[UnsafeDefault]: on.}

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -42,6 +42,7 @@ var
   project = ""
   success = false
   retVal = true
+  nimblePathsEnv = "__NIMBLE_PATHS"
 
 proc requires*(deps: varargs[string]) =
   ## Call this to set the list of requirements of your Nimble
@@ -201,7 +202,7 @@ template task*(name: untyped; description: string; body: untyped): untyped =
   proc `name Task`*() = body
 
   nimbleTasks.add (astToStr(name), description)
-  
+
   if actionName.len == 0 or actionName == "help":
     success = true
   elif actionName == astToStr(name).normalize:
@@ -238,3 +239,11 @@ proc getPkgDir*(): string =
   result = projectFile.rsplit(seps={'/', '\\', ':'}, maxsplit=1)[0]
 
 proc thisDir*(): string = getPkgDir()
+
+proc getPaths*(): seq[string] =
+  ## Returns the paths to the dependencies
+  return getEnv(nimblePathsEnv).split("|")
+
+proc getPathsClause*(): string =
+  ## Returns the paths to the dependencies as consumed by the nim compiler.
+  return getPaths().mapIt("--path:" & it.quoteShell).join(" ")

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -45,6 +45,7 @@ type
     localdeps*: bool # True if project local deps mode
     developLocaldeps*: bool # True if local deps + nimble develop pkg1 ...
     disableSslCertCheck*: bool
+    disableLockFile*: bool
     enableTarballs*: bool # Enable downloading of packages as tarballs from GitHub.
     task*: string # Name of the task that is getting ran
     package*: string
@@ -229,6 +230,7 @@ Nimble Options:
       --noColor                   Don't colorise output.
       --noSSLCheck                Don't check SSL certificates.
       --lock-file                 Override the lock file name.
+      --noLockFile                Ignore the lock file if present.
       --use-system-nim            Use system nim and ignore nim from the lock
                                   file if any
 
@@ -532,6 +534,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
   of "nim": result.nim = val
   of "localdeps", "l": result.localdeps = true
   of "nosslcheck": result.disableSslCertCheck = true
+  of "nolockfile": result.disableLockFile = true
   of "tarballs", "t": result.enableTarballs = true
   of "package", "p": result.package = val
   of "lock-file": result.lockFileName = val

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -28,6 +28,7 @@ type
     pkgInfoCache*: TableRef[string, PackageInfo]
     showHelp*: bool
     lockFileName*: string
+    useSystemNim*: bool
     showVersion*: bool
     offline*: bool
     noColor*: bool
@@ -112,7 +113,7 @@ Usage: nimble [nimbleopts] COMMAND [cmdopts]
 Commands:
   install      [pkgname, ...]     Installs a list of packages.
                [-d, --depsOnly]   Only install dependencies. Leave out pkgname
-                                  to install deps for a local nimble package. 
+                                  to install deps for a local nimble package.
                [-p, --passNim]    Forward specified flag to compiler.
                [--noRebuild]      Don't rebuild binaries if they're up-to-date.
   develop      [pkgname, ...]     Clones a list of packages for development.
@@ -228,6 +229,8 @@ Nimble Options:
       --noColor                   Don't colorise output.
       --noSSLCheck                Don't check SSL certificates.
       --lock-file                 Override the lock file name.
+      --use-system-nim            Use system nim and ignore nim from the lock
+                                  file if any
 
 For more information read the Github readme:
   https://github.com/nim-lang/nimble#readme
@@ -532,6 +535,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
   of "tarballs", "t": result.enableTarballs = true
   of "package", "p": result.package = val
   of "lock-file": result.lockFileName = val
+  of "use-system-nim": result.useSystemNim = true
   else: isGlobalFlag = false
 
   var wasFlagHandled = true

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -435,6 +435,20 @@ proc setNimBin*(options: var Options) =
       raise nimbleError(
         "Unable to find `nim` binary - add to $PATH or use `--nim`")
 
+proc getNimbleFileDir*(pkgInfo: PackageInfo): string =
+  pkgInfo.myPath.splitFile.dir
+
+proc getNimBin*(pkgInfo: PackageInfo, options: Options): string =
+  if pkgInfo.basicInfo.name == "nim":
+    let binaryPath =  when defined(windows):
+        "bin\nim.exe"
+      else:
+        "bin/nim"
+    result = pkgInfo.getNimbleFileDir() / binaryPath
+    display("Info:", "compiling nim package using $1" % result, priority = HighPriority)
+  else:
+    result = options.nim
+
 proc getNimBin*(options: Options): string =
   return options.nim
 

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -537,6 +537,18 @@ iterator lockedDepsFor*(pkgInfo: PackageInfo, options: Options): (string, LockFi
       for name, dep in deps:
         yield (name, dep)
 
+proc hasLockedDeps*(pkgInfo: PackageInfo): bool =
+  ## Returns true if pkgInfo has any locked deps (including any tasks)
+  # Check if any tasks have locked deps
+  for deps in pkgInfo.lockedDeps.values:
+    if deps.len > 0:
+      return true
+
+proc hasPackage*(deps: AllLockFileDeps, pkgName: string): bool =
+  for deps in deps.values:
+    if pkgName in deps:
+      return true
+
 proc `==`*(pkg1: PackageInfo, pkg2: PackageInfo): bool =
   pkg1.myPath == pkg2.myPath
 

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -360,8 +360,6 @@ proc findAllPkgs*(pkglist: seq[PackageInfo], dep: PkgTuple): seq[PackageInfo] =
     if withinRange(pkg, dep.ver):
       result.add pkg
 
-proc getNimbleFileDir*(pkgInfo: PackageInfo): string =
-  pkgInfo.myPath.splitFile.dir
 
 proc getRealDir*(pkgInfo: PackageInfo): string =
   ## Returns the directory containing the package source files.
@@ -559,6 +557,9 @@ proc hash*(x: PackageInfo): Hash =
 
 proc getNameAndVersion*(pkgInfo: PackageInfo): string =
   &"{pkgInfo.basicInfo.name}@{pkgInfo.basicInfo.version}"
+
+proc isNim*(name: string): bool =
+  result = name == "nim" or name == "nimrod" or name == "compiler"
 
 when isMainModule:
   import unittest

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -346,6 +346,17 @@ proc findPkg*(pkglist: seq[PackageInfo], dep: PkgTuple,
         r = pkg
         result = true
 
+proc resolveURL*(pkglist: seq[PackageInfo], str: string): string =
+  ## Resolves a URL into a package name from a package list.
+  ## Just returns **str** if its not a url
+  # We can't just check if it starts with "http" since thats a valid package name
+  if str.startsWith("http://") or str.startsWith("https://"):
+    for pkg in pkglist:
+      if cmpIgnoreStyle(pkg.metaData.url, str) == 0:
+           return pkg.basicInfo.name
+  else:
+    return str
+
 proc findAllPkgs*(pkglist: seq[PackageInfo], dep: PkgTuple): seq[PackageInfo] =
   ## Searches ``pkglist`` for packages of which version is within the range
   ## of ``dep.ver``. This is similar to ``findPkg`` but returns multiple

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -37,7 +37,8 @@ proc initPackageInfo*(options: Options, filePath: string): PackageInfo =
   result.myPath = filePath
   result.basicInfo.name = fileName
   result.backend = "c"
-  result.lockedDeps = options.lockFile(fileDir).getLockedDependencies()
+  if not options.disableLockFile:
+    result.lockedDeps = options.lockFile(fileDir).getLockedDependencies()
 
 proc toValidPackageName*(name: string): string =
   for c in name:

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -346,17 +346,6 @@ proc findPkg*(pkglist: seq[PackageInfo], dep: PkgTuple,
         r = pkg
         result = true
 
-proc resolveURL*(pkglist: seq[PackageInfo], str: string): string =
-  ## Resolves a URL into a package name from a package list.
-  ## Just returns **str** if its not a url
-  # We can't just check if it starts with "http" since thats a valid package name
-  if str.startsWith("http://") or str.startsWith("https://"):
-    for pkg in pkglist:
-      if cmpIgnoreStyle(pkg.metaData.url, str) == 0:
-           return pkg.basicInfo.name
-  else:
-    return str
-
 proc findAllPkgs*(pkglist: seq[PackageInfo], dep: PkgTuple): seq[PackageInfo] =
   ## Searches ``pkglist`` for packages of which version is within the range
   ## of ``dep.ver``. This is similar to ``findPkg`` but returns multiple
@@ -536,6 +525,8 @@ proc fullRequirements*(pkgInfo: PackageInfo): seq[PkgTuple] =
   for requirements in pkgInfo.taskRequires.values:
     result &= requirements
 
+proc name*(pkgInfo: PackageInfo): string {.inline.} =
+  pkgInfo.basicInfo.name
 
 proc `==`*(pkg1: PackageInfo, pkg2: PackageInfo): bool =
   pkg1.myPath == pkg2.myPath

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -22,6 +22,8 @@ type
   LockFileDeps* = OrderedTable[string, LockFileDep]
 
   AllLockFileDeps* = Table[string, LockFileDeps]
+    ## Base deps is stored with empty string key ""
+    ## Other tasks have task name as key
 
   PackageMetaData* = object
     url*: string
@@ -83,3 +85,5 @@ type
     alias*: string ## A name of another package, that this package aliases.
 
   PackageDependenciesInfo* = tuple[deps: HashSet[PackageInfo], pkg: PackageInfo]
+
+const noTask* = "" # Means that noTask is being ran. Use this as key for base dependencies

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -21,6 +21,8 @@ type
 
   LockFileDeps* = OrderedTable[string, LockFileDep]
 
+  AllLockFileDeps* = Table[string, LockFileDeps]
+
   PackageMetaData* = object
     url*: string
     downloadMethod*: DownloadMethod
@@ -62,7 +64,7 @@ type
     backend*: string
     foreignDeps*: seq[string]
     basicInfo*: PackageBasicInfo
-    lockedDeps*: LockFileDeps
+    lockedDeps*: AllLockFileDeps
     metaData*: PackageMetaData
     isLink*: bool
 

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -184,7 +184,9 @@ proc validatePackageInfo(pkgInfo: PackageInfo, options: Options) =
       raise validationError("'" & pkgInfo.backend &
           "' is an invalid backend.", false)
 
-  validatePackageStructure(pkginfo, options)
+  # nim is used for building the project, thus no need to validate its structure.
+  if not pkgInfo.basicInfo.name.isNim:
+    validatePackageStructure(pkginfo, options)
 
 proc nimScriptHint*(pkgInfo: PackageInfo) =
   if not pkgInfo.isNimScript:
@@ -323,7 +325,7 @@ proc inferInstallRules(pkgInfo: var PackageInfo, options: Options) =
   # installed.)
   let installInstructions =
     pkgInfo.installDirs.len + pkgInfo.installExt.len + pkgInfo.installFiles.len
-  if installInstructions == 0 and pkgInfo.bin.len > 0:
+  if installInstructions == 0 and pkgInfo.bin.len > 0 and pkgInfo.basicInfo.name != "nim":
     pkgInfo.skipExt.add("nim")
 
   # When a package doesn't specify a `srcDir` it's fair to assume that

--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -62,11 +62,6 @@ proc tryDoCmdEx*(cmd: string): string {.discardable.} =
     raise nimbleError(tryDoCmdExErrorMessage(cmd, output, exitCode))
   return output
 
-proc getNimBin*: string =
-  result = "nim"
-  if findExe("nim") != "": result = findExe("nim")
-  elif findExe("nimrod") != "": result = findExe("nimrod")
-
 proc getNimrodVersion*(options: Options): Version =
   let vOutput = doCmdEx(getNimBin(options).quoteShell & " -v").output
   var matches: array[0..MaxSubpatterns, string]

--- a/src/nimblepkg/topologicalsort.nim
+++ b/src/nimblepkg/topologicalsort.nim
@@ -11,7 +11,7 @@ proc getDependencies(packages: seq[PackageInfo], package: PackageInfo,
   ## package. It is needed because some of the names of the packages in the
   ## `requires` clause of a package could be URLs.
   for dep in package.requires:
-    if dep.name == "nim":
+    if dep.name.isNim:
       continue
     var depPkgInfo = initPackageInfo()
     var found = findPkg(packages, dep, depPkgInfo)

--- a/tests/nimdep/nimdep.nimble
+++ b/tests/nimdep/nimdep.nimble
@@ -9,7 +9,7 @@ bin           = @["demo"]
 
 # Dependencies
 
-requires "nim == 1.7.1"
+requires "nim"
 
 task version, "Test nim version":
   exec "nim --version"

--- a/tests/nimdep/nimdep.nimble
+++ b/tests/nimdep/nimdep.nimble
@@ -1,0 +1,12 @@
+# Package
+
+version       = "0.1.0"
+author        = "Ivan Yonchovski"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["demo"]
+
+# Dependencies
+
+requires  "nim == 1.7.1"

--- a/tests/nimdep/nimdep.nimble
+++ b/tests/nimdep/nimdep.nimble
@@ -9,4 +9,7 @@ bin           = @["demo"]
 
 # Dependencies
 
-requires  "nim == 1.7.1"
+requires "nim == 1.7.1"
+
+task version, "Test nim version":
+  exec "nim --version"

--- a/tests/taskdeps/dependencies/dependencies.nimble
+++ b/tests/taskdeps/dependencies/dependencies.nimble
@@ -1,0 +1,15 @@
+# Package
+
+version       = "0.1.0"
+author        = "John Doe"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "."
+bin           = @["foo"]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+taskRequires "test", "unittest2 == 0.0.4"

--- a/tests/taskdeps/main/foo.nim
+++ b/tests/taskdeps/main/foo.nim
@@ -1,0 +1,1 @@
+import json_serialization

--- a/tests/taskdeps/main/main.nimble
+++ b/tests/taskdeps/main/main.nimble
@@ -4,7 +4,7 @@ version       = "0.1.0"
 author        = "John Doe"
 description   = "A new awesome nimble package"
 license       = "MIT"
-srcDir        = "."
+srcDir        = "src"
 bin           = @[]
 
 

--- a/tests/tasks/getpaths/getpaths.nimble
+++ b/tests/tasks/getpaths/getpaths.nimble
@@ -1,0 +1,17 @@
+# Package
+
+version       = "0.1.0"
+author        = "Ivan Yonchovski"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin           = @["run"]
+
+
+# Dependencies
+
+requires "benchy", "unittest2"
+
+task echoPaths, "":
+    echo getPaths()
+    echo getPathsClause()

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -131,11 +131,8 @@ proc safeMoveFile(src, dest: string) =
 proc uninstallDeps*() =
   ## Uninstalls all installed dependencies.
   ## Useful for cleaning up after a test case
-  let (output, _) = execNimble("list", "-i")
-  for line in output.splitLines:
-    let package = line.split("  ")[0]
-    if package != "":
-      verify execNimbleYes("uninstall", "-i", package)
+  removeDir pkgsDir
+  removeFile installDir / "nimbledata2.json"
 
 template testRefresh*(body: untyped) =
   # Backup current config

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -131,8 +131,12 @@ proc safeMoveFile(src, dest: string) =
 proc uninstallDeps*() =
   ## Uninstalls all installed dependencies.
   ## Useful for cleaning up after a test case
-  removeDir pkgsDir
-  removeFile installDir / "nimbledata2.json"
+  let (output, _) = execNimble("list", "-i")
+  for line in output.splitLines:
+    let package = line.split("  ")[0]
+    if package != "":
+      discard execNimbleYes("uninstall", "-i", package)
+
 
 template testRefresh*(body: untyped) =
   # Backup current config

--- a/tests/tgetpaths.nim
+++ b/tests/tgetpaths.nim
@@ -1,0 +1,17 @@
+# Copyright (C) Dominik Picheta. All rights reserved.
+# BSD License. Look at license.txt for more info.
+
+{.used.}
+
+import unittest, strutils, os
+import testscommon
+from nimblepkg/common import cd
+
+suite "nimble getPaths/getPathsClause":
+  test "check getPaths result":
+    cd "tasks/getpaths":
+      let (output, exitCode) = execNimble("echoPaths")
+      check output.contains("--path:")
+      check output.contains("benchy")
+      check output.contains("unittest2")
+      check exitCode == QuitSuccess

--- a/tests/tinitcommand.nim
+++ b/tests/tinitcommand.nim
@@ -9,6 +9,7 @@ suite "init":
   ## https://github.com/nim-lang/nimble/pull/983
   test "init within directory that is invalid package name will not create new directory":
     let tempdir = getTempDir() / "a-b"
+    if dirExists tempdir: removeDir(tempDir)
     createDir(tempdir)
     cd(tempdir):
       let args = ["init"]

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -172,6 +172,7 @@ requires "nim >= 1.5.1"
     let json = lockFileName.readFile.parseJson
     for (depName, depPath) in deps:
       let expectedVcsRevision = depPath.getVcsRevision
+      check depName in json{$lfjkPackages}
       let lockedVcsRevision =
         json{$lfjkPackages}{depName}{$lfjkPkgVcsRevision}.str.initSha1Hash
       check lockedVcsRevision == expectedVcsRevision

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -618,3 +618,7 @@ requires "nim >= 1.5.1"
       # check the nim version
       let (outputVersion, _) = execNimble("version")
       check outputVersion.contains(getRevision("nim"))
+
+      let (outputGlobalNim, exitCodeGlobalNim) = execNimbleYes("-y", "--use-system-nim", "build")
+      check exitCodeGlobalNim == QuitSuccess
+      check not outputGlobalNim.contains("bin/nim for compilation")

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -591,3 +591,24 @@ requires "nim >= 1.5.1"
         writeDevelopFile(developFileName, @[], @[dep1PkgRepoPath, mainPkgOriginRepoPath])
         let (_, exitCode) = execNimbleYes("--debug", "--verbose", "sync")
         check exitCode == QuitSuccess
+
+  test "can generate lock file for nim as dep":
+    cleanUp()
+    cd "nimdep":
+      removeFile "nimble.develop"
+      removeFile "nimble.lock"
+      removeDir "Nim"
+
+      check execNimbleYes("develop", "nim").exitCode == QuitSuccess
+      cd "Nim":
+        let (_, exitCode) = execNimbleYes("-y", "install")
+        check exitCode == QuitSuccess
+
+      # check if the compiler version will be used when doing build
+      testLockFile(@[("nim", "Nim")], isNew = true)
+      removeFile "nimble.develop"
+      removeDir "Nim"
+
+      let (output, exitCodeInstall) = execNimbleYes("-y", "build")
+      check exitCodeInstall == QuitSuccess
+      check output.contains("bin/nim for compilation")

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -591,6 +591,8 @@ requires "nim >= 1.5.1"
         writeDevelopFile(developFileName, @[], @[dep1PkgRepoPath, mainPkgOriginRepoPath])
         let (_, exitCode) = execNimbleYes("--debug", "--verbose", "sync")
         check exitCode == QuitSuccess
+  proc getRevision(dep: string, lockFileName = defaultLockFileName): string =
+    result = lockFileName.readFile.parseJson{$lfjkPackages}{dep}{$lfjkPkgVcsRevision}.str
 
   test "can generate lock file for nim as dep":
     cleanUp()
@@ -612,3 +614,7 @@ requires "nim >= 1.5.1"
       let (output, exitCodeInstall) = execNimbleYes("-y", "build")
       check exitCodeInstall == QuitSuccess
       check output.contains("bin/nim for compilation")
+
+      # check the nim version
+      let (outputVersion, _) = execNimble("version")
+      check outputVersion.contains(getRevision("nim"))

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -613,7 +613,8 @@ requires "nim >= 1.5.1"
 
       let (output, exitCodeInstall) = execNimbleYes("-y", "build")
       check exitCodeInstall == QuitSuccess
-      check output.contains("bin/nim for compilation")
+      let usingNim = when defined(Windows): "nim.exe for compilation" else: "bin/nim for compilation"
+      check output.contains(usingNim)
 
       # check the nim version
       let (outputVersion, _) = execNimble("version")
@@ -621,4 +622,4 @@ requires "nim >= 1.5.1"
 
       let (outputGlobalNim, exitCodeGlobalNim) = execNimbleYes("-y", "--use-system-nim", "build")
       check exitCodeGlobalNim == QuitSuccess
-      check not outputGlobalNim.contains("bin/nim for compilation")
+      check not outputGlobalNim.contains(usingNim)

--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -136,3 +136,9 @@ suite "Task level dependencies":
       check exitCode == QuitSuccess
       check output.processOutput.inLines("benchmarkRequires: \"benchy 0.0.1\"")
       check output.processOutput.inLines("testRequires: \"unittest2 0.0.4\"")
+
+  test "Lock files don't break":
+    # Tests for regression caused by tasks deps.
+    # nimlangserver is good candidate, has locks and quite a few dependencies
+    let (_, exitCode) = execNimble("install", "nimlangserver@#19715af")
+    check exitCode == QuitSuccess

--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -32,29 +32,31 @@ suite "Task level dependencies":
     inDir:
       let (output, exitCode) = execNimble("benchmark")
       check exitCode == QuitSuccess
-      check output.contains("dependencies for benchy@0.0.1")
-      check not output.contains("dependencies for unittest2@0.0.4")
+      check output.contains("benchy@0.0.1")
+      check not output.contains("unittest2@0.0.4")
 
   test "Dependency is not used when not running task":
     inDir:
       let (output, exitCode) = execNimble("install")
       check exitCode == QuitSuccess
-      check not output.contains("dependencies for unittest2@0.0.4")
-      check not output.contains("dependencies for benchy@0.0.1")
+      check not output.contains("unittest2@0.0.4")
+      check not output.contains("benchy@0.0.1")
 
   test "Dependency can be defined for test task":
     inDir:
       let (output, exitCode) = execNimble("test")
       check exitCode == QuitSuccess
-      check output.contains("dependencies for unittest2@0.0.4")
+      check output.contains("unittest2@0.0.4")
 
   test "Lock file has dependencies added to it":
     inDir:
       makeLockFile()
       # Check task level dependencies are in the lock file
       let json = parseFile("nimble.lock")
-      check "unittest2" in json["packages"]
-      let pkgInfo = json["packages"]["unittest2"]
+      check:
+        "test" in json["packages"]
+        "benchmark" in json["packages"]
+      let pkgInfo = json["packages"]["test"]["unittest2"]
       check pkgInfo["version"].getStr() == "0.0.4"
 
   test "Task dependencies from lock file are used":


### PR DESCRIPTION
- Fixes #953

Allow having nim as locked dependency.

- I will add unit tests once we agree on the approach and once nimble related
changes in nim are merged (I will link the PR in comment). Ditto for the
documentation.

Here it is the flow:

``` bash
nimble develop nim
nimble lock
```

After that `nimble install` and `nimble build` commands will use the locked
`nim` version