### PR TITLE
tweak docs to clarify install depsOnly option

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -180,6 +180,12 @@ Example:
     ...
     nake installed successfully
 
+Packages needed for developing or testing a project can be installed by
+passing the `--depsOnly` option and leaving out the package name.  
+Example:
+
+    $ cd myProgram/ && nimble install --depsOnly
+
 Nimble always fetches and installs the latest version of a package. Note that
 the latest version is defined as the latest tagged version in the Git (or Mercurial)
 repository, if the package has no tagged versions then the latest commit in the

--- a/readme.markdown
+++ b/readme.markdown
@@ -213,7 +213,7 @@ The ``install`` command can also be used for locally testing or developing a
 Nimble package by leaving out the package name parameter. Your current working
 directory must be a Nimble package and contain a valid ``package.nimble`` file.
 
-Nimble will install the package residing in the current working directory if you
+Nimble will install the package residing in the current working directory when you
 don't specify a package name and the directory contains a ``package.nimble`` file.
 This can be useful for developers who are locally testing their ``.nimble`` files
 before submitting them to the official package list.
@@ -221,8 +221,8 @@ See the [Creating Packages](#creating-packages) section for more info on this.
 
 Dependencies required for developing or testing a project can be installed by
 passing `--depsOnly` without specifying a package name. Nimble will then install
-any missing dependencies listed in the package's ``package.nimble`` file. Note 
-that the required dependencies will be installed globally.
+any missing dependencies listed in the package's ``package.nimble`` file in the 
+current working directoy. Note that dependencies will be installed globally.
 
 For example to install the dependencies for a Nimble project ``myPackage``:
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -209,20 +209,20 @@ files.
 
 #### Local Package Development
 
-The ``install`` command can also be used when testing or developing a Nimble
-package locally by leaving out the package name parameter. Your current working
-directory must contain a ``package.nimble`` file to use Nimble this way.
+The ``install`` command can also be used for locally testing or developing a
+Nimble package by leaving out the package name parameter. Your current working
+directory must be a Nimble package and contain a valid ``package.nimble`` file.
 
-A package can be installed from local sources if you don't specify a package
-name and there is a ``package.nimble`` file in your current working directory.
-Nimble will then install the package residing in the current working directory.
+Nimble will install the package residing in the current working directory if you
+don't specify a package name and the directory contains a ``package.nimble`` file.
 This can be useful for developers who are locally testing their ``.nimble`` files
 before submitting them to the official package list.
 See the [Creating Packages](#creating-packages) section for more info on this.
 
-Alternatively passing `--depsOnly` without a package name will install all the
-dependencies required for developing or testing a project as listed in the
-``package.nimble`` file. 
+Dependencies required for developing or testing a project can be installed by
+passing `--depsOnly` without specifying a package name. Nimble will then install
+any missing dependencies listed in the package's ``package.nimble`` file. Note 
+that the required dependencies will be installed globally.
 
 For example to install the dependencies for a Nimble project ``myPackage``:
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -180,12 +180,6 @@ Example:
     ...
     nake installed successfully
 
-Packages needed for developing or testing a project can be installed by
-passing the `--depsOnly` option and leaving out the package name.  
-Example:
-
-    $ cd myProgram/ && nimble install --depsOnly
-
 Nimble always fetches and installs the latest version of a package. Note that
 the latest version is defined as the latest tagged version in the Git (or Mercurial)
 repository, if the package has no tagged versions then the latest commit in the
@@ -208,16 +202,31 @@ version range, for example:
 
 The latter command will install a version that is greater than ``0.5``.
 
-If you don't specify a parameter and there is a ``package.nimble`` file in your
-current working directory then Nimble will install the package residing in
-the current working directory. This can be useful for developers who are locally
-testing their ``.nimble`` files before submitting them to the official package
-list. See the [Creating Packages](#creating-packages) section for more info on this.
-
 Nim flags provided to `nimble install` will be forwarded to the compiler when
 building any binaries. Such compiler flags can be made persistent by using Nim
 [configuration](https://nim-lang.org/docs/nimc.html#compiler-usage-configuration-files)
 files.
+
+#### Local Package Development
+
+The ``install`` command can also be used when testing or developing a Nimble
+package locally by leaving out the package name parameter. Your current working
+directory must contain a ``package.nimble`` file to use Nimble this way.
+
+A package can be installed from local sources if you don't specify a package
+name and there is a ``package.nimble`` file in your current working directory.
+Nimble will then install the package residing in the current working directory.
+This can be useful for developers who are locally testing their ``.nimble`` files
+before submitting them to the official package list.
+See the [Creating Packages](#creating-packages) section for more info on this.
+
+Alternatively passing `--depsOnly` without a package name will install all the
+dependencies required for developing or testing a project as listed in the
+``package.nimble`` file. 
+
+For example to install the dependencies for a Nimble project ``myPackage``:
+
+    $ cd myPackage/ && nimble install --depsOnly
 
 #### Package URLs
 

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -106,7 +106,8 @@ Usage: nimble [nimbleopts] COMMAND [cmdopts]
 
 Commands:
   install      [pkgname, ...]     Installs a list of packages.
-               [-d, --depsOnly]   Install only dependencies.
+               [-d, --depsOnly]   Only install dependencies. Leave out pkgname
+                                  to install deps for a local nimble package. 
                [-p, --passNim]    Forward specified flag to compiler.
                [--noRebuild]      Don't rebuild binaries if they're up-to-date.
   develop      [pkgname, ...]     Clones a list of packages for development.


### PR DESCRIPTION
So I never realized you could leave out the pkgname and it'd use the local nimble file. It's clear in hindsight but reading the docs and help I always assumed `install` always required the package name. Hopefully this tweak might save others from missing this too. 