### PR TITLE
Add LGPLv3 + static linking exception license

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1059,6 +1059,8 @@ This should ideally be a valid SPDX identifier. See https://spdx.org/licenses/.
     "BSD-3-Clause",
     "LGPL-2.1",
     "LGPL-3.0",
+    # LGPLv3 with static linking exception https://spdx.org/licenses/LGPL-3.0-linking-exception.html
+    "LGPL-3.0-linking-exception",
     "EPL-2.0",
     "AGPL-3.0",
     # This is what npm calls "UNLICENSED" (which is too similar to "Unlicense")


### PR DESCRIPTION
Add "LGPL-3.0-linking-exception" to the list of suggested licenses.
It provides the protections of GPLv3 while allowing both static and dynamic linking.

See https://spdx.org/licenses/LGPL-3.0-linking-exception.html