### PR TITLE
Add option to install from nimble file

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -622,9 +622,13 @@ proc processLockedDependencies(pkgInfo: PackageInfo, options: Options):
     else:
       raise nimbleError("Unsatisfied dependency: " & pkgInfo.basicInfo.name)
 
-proc getDownloadInfo*(pv: PkgTuple, options: Options,
-                      doPrompt: bool, ignorePackageCache = false): (DownloadMethod, string,
-                                        Table[string, string]) =
+proc getDownloadInfo*(
+  pv: PkgTuple,
+  options: Options,
+  doPrompt: bool,
+  ignorePackageCache = false
+): (DownloadMethod, string, Table[string, string]) =
+  ## download info
   if pv.name.isURL:
     let (url, metadata) = getUrlData(pv.name)
     return (checkUrlType(url), url, metadata)
@@ -664,6 +668,11 @@ proc install(packages: seq[PkgTuple], options: Options,
         "\nThey will be ignored and installed as normal packages.")
     result = installFromDir(currentDir, newVRAny(), options, "", first,
                             fromLockFile)
+  elif options.action.isNimbleFile:
+    let pv = packages[0]
+    let pkgInfo = getPkgInfoFromFile(pv.name, options, forValidation=true)
+    result = installFromDir(pkgInfo.myPath.parentDir(), pv.ver, options, "",
+                            first, fromLockFile)
   else:
     # Install each package.
     for pv in packages:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -137,6 +137,9 @@ proc getUrlData*(url: string): (string, Table[string, string]) =
 proc isURL*(name: string): bool =
   name.startsWith(peg" @'://' ")
 
+proc isNimble*(name: string): bool =
+  name.startsWith(peg" @'://' ")
+
 proc cloneSpecificRevision(downloadMethod: DownloadMethod,
                            url, downloadDir: string,
                            vcsRevision: Sha1Hash) =

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -75,6 +75,7 @@ type
       devActions*: seq[DevelopAction]
       path*: string
       noRebuild*: bool
+      isNimbleFile*: bool
       withDependencies*: bool
         ## Whether to put in develop mode also the dependencies of the packages
         ## listed in the develop command.
@@ -109,6 +110,7 @@ Commands:
                [-d, --depsOnly]   Install only dependencies.
                [-p, --passNim]    Forward specified flag to compiler.
                [--noRebuild]      Don't rebuild binaries if they're up-to-date.
+               [--nimble-file]    Use nimble file instead of pkgname. 
   develop      [pkgname, ...]     Clones a list of packages for development.
                                   Adds them to a develop file if specified or
                                   to `nimble.develop` if not specified and
@@ -528,6 +530,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     case f
     of "depsonly", "d":
       result.depsOnly = true
+    of "nimble-file":
+      result.action.isNimbleFile = true
     of "norebuild":
       result.action.noRebuild = true
     of "passnim", "p":

--- a/tests/tuninstall.nim
+++ b/tests/tuninstall.nim
@@ -11,6 +11,16 @@ from nimblepkg/common import cd
 from nimblepkg/version import newVersion
 
 suite "uninstall":
+  test "can install deps from nimble file":
+    let srcDirTest = "develop/srcdirtest/srcdirtest.nimble"
+    cleanDir(installDir)
+    check execNimbleYes("install", "--onlyDeps", "--nimble-file", srcDirTest).exitCode == QuitSuccess
+
+  test "can install from nimble file":
+    let srcDirTest = "develop/srcdirtest/srcdirtest.nimble"
+    cleanDir(installDir)
+    check execNimbleYes("install", "--nimble-file", srcDirTest).exitCode == QuitSuccess
+
   test "cannot install packagebin2 in --offline mode":
     cleanDir(installDir)
     let args = ["--offline", "install", pkgBin2Url]


### PR DESCRIPTION
This PR adds an option to the `install` command to work from a local Nimble file. This makes it just a bit easier to install a package or dependencies in a CI or environment setup scripts. Doing a `cd pkgdir && nimble ...` can be annoying in some CI scripts. I figured an explicit option produced cleaner code and semantics than just checking if a pkgname ended with a ".nimble" extension. Though doing a `local://` or `file://` might another option. 

Really it's not a *necessary* feature and partly I was motived partly by adding a small feature to Nimble to learn about it. If it's handy, great, if not no worries! :) 

Examples:

```sh
./nimble install --depsOnly --nimble-file testpkg/testpkg.nimble 
./nimble install --nimble-file testpkg/testpkg.nimble 
```

