### PR TITLE
Implement task level dependencies

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -344,7 +344,8 @@ Currently the lock file have the structure as in the following example:
       ],
       "checksums": {
         "sha1": "a1cdaa77995f2d1381e8f9dc129594f2fa2ee07f"
-      }
+      },
+      "task": null
     },
     ...
   }
@@ -367,6 +368,7 @@ packages' names also must be in the lock file.
 verifying that a downloaded package is exactly the same as the pinned in the
 lock file package. Currently, only `sha1` checksums are supported
 * `sha1` - The *sha1* checksum of the package files.
+* `task` - The task the dependency belongs to. Is `null` is it doesn't belong to any one task (i.e. Just a normal requirement)
 
 If a lock file `nimble.lock` exists, then on performing all Nimble commands
 which require searching for dependencies and downloading them in the case they

--- a/readme.markdown
+++ b/readme.markdown
@@ -344,8 +344,7 @@ Currently the lock file have the structure as in the following example:
       ],
       "checksums": {
         "sha1": "a1cdaa77995f2d1381e8f9dc129594f2fa2ee07f"
-      },
-      "task": null
+      }
     },
     ...
   }
@@ -368,7 +367,6 @@ packages' names also must be in the lock file.
 verifying that a downloaded package is exactly the same as the pinned in the
 lock file package. Currently, only `sha1` checksums are supported
 * `sha1` - The *sha1* checksum of the package files.
-* `task` - The task the dependency belongs to. Is `null` is it doesn't belong to any one task (i.e. Just a normal requirement)
 
 If a lock file `nimble.lock` exists, then on performing all Nimble commands
 which require searching for dependencies and downloading them in the case they

--- a/readme.markdown
+++ b/readme.markdown
@@ -680,6 +680,13 @@ Executing task hello in /Users/user/projects/pkg/pkg.nimble
 Hello World!
 ```
 
+Dependencies that are only needed for a certain task can be declared with `taskRequires` like so
+
+```nim
+taskRequires "hello", "choosenim == 0.4.0"
+```
+
+
 You can place any Nim code inside these tasks. As long as that code does not
 access the FFI. The ``nimscript``
 [module](https://nim-lang.org/docs/nimscript.html) in Nim's standard library defines

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -95,7 +95,7 @@ proc processFreeDependencies(pkgInfo: PackageInfo, options: Options):
     reverseDependencies: seq[PackageBasicInfo] = @[]
     requirements = pkgInfo.requires
 
-  if isMain and command in pkgInfo.taskRequires:
+  if isMain and (command in pkgInfo.taskRequires or command == "test"):
     # If this is the main file then add its needed
     # requirements for running a task
     requirements &= pkgInfo.taskRequires[command]
@@ -2023,10 +2023,10 @@ proc doAction(options: var Options) =
       nimbleFile = findNimbleFile(getCurrentDir(), true)
       pkgInfo = getPkgInfoFromFile(nimbleFile, options)
 
+    discard pkgInfo.processAllDependencies(options)
     if command in pkgInfo.nimbleTasks:
       # If valid task defined in nimscript, run it
       var execResult: ExecutionResult[bool]
-      discard pkgInfo.processAllDependencies(options)
       if execCustom(nimbleFile, options, execResult):
         if execResult.hasTaskRequestedCommand():
           var options = execResult.getOptionsForCommand(options)

--- a/src/nimblepkg/deps.nim
+++ b/src/nimblepkg/deps.nim
@@ -12,7 +12,8 @@ proc depsRecursive*(pkgInfo: PackageInfo,
                     dependencies: seq[PackageInfo],
                     errors: ValidationErrors): seq[DependencyNode] =
   result = @[]
-  for (name, ver) in pkgInfo.requires:
+
+  for (name, ver) in pkgInfo.fullRequirements:
     var depPkgInfo = initPackageInfo()
     let
       found = dependencies.findPkg((name, ver), depPkgInfo)

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -28,7 +28,7 @@ var
   skipDirs*, skipFiles*, skipExt*, installDirs*, installFiles*,
     installExt*, bin*: seq[string] = @[] ## Nimble metadata.
   requiresData*: seq[string] = @[] ## The package's dependencies.
-  taskRequirements*: Table[string, seq[string]] ## Task dependencies
+  taskRequiresData*: Table[string, seq[string]] ## Task dependencies
   foreignDeps*: seq[string] = @[] ## The foreign dependencies. Only
                                   ## exported for 'distros.nim'.
 
@@ -50,10 +50,10 @@ proc requires*(deps: varargs[string]) =
 
 proc taskRequires*(task: string, deps: varargs[string]) =
   ## Call this to set the list of requirements for a certain task
-  if task notin taskRequirements:
-    taskRequirements[task] = @[]
+  if task notin taskRequiresData:
+    taskRequiresData[task] = @[]
   for d in deps:
-    taskRequirements[task] &= d
+    taskRequiresData[task] &= d
 
 proc getParams(): tuple[scriptFile, projectFile, outFile, actionName: string,
                         commandLineParams: seq[string]] =
@@ -145,9 +145,15 @@ proc printPkgInfo(): string =
   printSeqIfLen beforeHooks
   printSeqIfLen afterHooks
 
-  if requiresData.len != 0:
+  if requiresData.len != 0 or taskRequiresData.len != 0:
     result &= "\n[Deps]\n"
-    result &= &"requires: \"{requiresData.join(\", \")}\"\n"
+    # Write package level dependencies
+    if requiresData.len != 0:
+      result &= &"requires: \"{requiresData.join(\", \")}\"\n"
+    # Write task level dependencies
+    for task, requiresData in taskRequiresData.pairs:
+      result &= &"{task}Requires: \"{requiresData.join(\", \")}\"\n"
+
 
 proc onExit*() =
   if actionName.len == 0 or actionName == "help":

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -28,7 +28,7 @@ var
   skipDirs*, skipFiles*, skipExt*, installDirs*, installFiles*,
     installExt*, bin*: seq[string] = @[] ## Nimble metadata.
   requiresData*: seq[string] = @[] ## The package's dependencies.
-
+  taskRequirements*: Table[string, seq[string]] ## Task dependencies
   foreignDeps*: seq[string] = @[] ## The foreign dependencies. Only
                                   ## exported for 'distros.nim'.
 
@@ -47,6 +47,13 @@ proc requires*(deps: varargs[string]) =
   ## Call this to set the list of requirements of your Nimble
   ## package.
   for d in deps: requiresData.add(d)
+
+proc taskRequires*(task: string, deps: varargs[string]) =
+  ## Call this to set the list of requirements for a certain task
+  if task notin taskRequirements:
+    taskRequirements[task] = @[]
+  for d in deps:
+    taskRequirements[task] &= d
 
 proc getParams(): tuple[scriptFile, projectFile, outFile, actionName: string,
                         commandLineParams: seq[string]] =

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -45,6 +45,7 @@ type
     developLocaldeps*: bool # True if local deps + nimble develop pkg1 ...
     disableSslCertCheck*: bool
     enableTarballs*: bool # Enable downloading of packages as tarballs from GitHub.
+    task*: string # Name of the task that is getting ran
     package*: string
       # For which package in the dependency tree the command should be executed.
       # If not provided by default it applies to the current directory package.

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json, strutils, os, parseopt, uri, tables, terminal
+import json, strutils, os, parseopt, uri, tables, terminal, sets
 import sequtils, sugar
 import std/options as std_opt
 from httpclient import Proxy, newProxy

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json, strutils, os, parseopt, uri, tables, terminal, sets
+import json, strutils, os, parseopt, uri, tables, terminal
 import sequtils, sugar
 import std/options as std_opt
 from httpclient import Proxy, newProxy

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -519,6 +519,12 @@ proc getPkgDest*(pkgInfo: PackageBasicInfo, options: Options): string =
 proc getPkgDest*(pkgInfo: PackageInfo, options: Options): string =
   pkgInfo.basicInfo.getPkgDest(options)
 
+proc fullRequirements*(pkgInfo: PackageInfo): seq[PkgTuple] =
+  ## Returns all requirements for a task (Normal requirements and all task level requirements)
+  result &= pkgInfo.requires
+  for requirements in pkgInfo.taskRequires.values:
+    result &= requirements
+
 proc `==`*(pkg1: PackageInfo, pkg2: PackageInfo): bool =
   pkg1.myPath == pkg2.myPath
 

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -520,10 +520,11 @@ proc getPkgDest*(pkgInfo: PackageInfo, options: Options): string =
   pkgInfo.basicInfo.getPkgDest(options)
 
 proc fullRequirements*(pkgInfo: PackageInfo): seq[PkgTuple] =
-  ## Returns all requirements for a task (Normal requirements and all task level requirements)
-  result &= pkgInfo.requires
+  ## Returns all requirements for a package (All top level + all task requirements)
+  result = pkgInfo.requires
   for requirements in pkgInfo.taskRequires.values:
     result &= requirements
+
 
 proc `==`*(pkg1: PackageInfo, pkg2: PackageInfo): bool =
   pkg1.myPath == pkg2.myPath

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -55,6 +55,7 @@ type
     installFiles*: seq[string]
     installExt*: seq[string]
     requires*: seq[PkgTuple]
+    taskRequires*: Table[string, seq[PkgTuple]]
     bin*: Table[string, string]
     binDir*: string
     srcDir*: string

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import sets, tables
+import sets, tables, std/options
 import version, sha1hashes
 
 type
@@ -18,6 +18,7 @@ type
     downloadMethod*: DownloadMethod
     dependencies*: seq[string]
     checksums*: Checksums
+    task: Option[string]
 
   LockFileDeps* = OrderedTable[string, LockFileDep]
 

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import sets, tables, std/options
+import sets, tables
 import version, sha1hashes
 
 type
@@ -18,7 +18,6 @@ type
     downloadMethod*: DownloadMethod
     dependencies*: seq[string]
     checksums*: Checksums
-    task: Option[string]
 
   LockFileDeps* = OrderedTable[string, LockFileDep]
 

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -289,7 +289,7 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
               let task = normalizedKey.dup(removeSuffix("requires"))
               # Tasks have already been parsed, so we can safely check
               # if the task is valid or not
-              if task notin result.nimbleTasks:
+              if task notin result.nimbleTasks and task != "test":
                 raise nimbleError(fmt"Task {task} doesn't exist for requirement'")
 
               if task notin result.taskRequires:

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -290,7 +290,7 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
               # Tasks have already been parsed, so we can safely check
               # if the task is valid or not
               if task notin result.nimbleTasks and task != "test":
-                raise nimbleError(fmt"Task {task} doesn't exist for requirement'")
+                raise nimbleError(fmt"Task {task} doesn't exist for requirement {ev.value}")
 
               if task notin result.taskRequires:
                 result.taskRequires[task] = @[]

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -1,6 +1,6 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
-import parsecfg, sets, streams, strutils, os, tables, sugar
+import parsecfg, sets, streams, strutils, os, tables, sugar, strformat
 from sequtils import apply, map, toSeq
 
 import common, version, tools, nimscriptwrapper, options, cli, sha1hashes,
@@ -279,13 +279,28 @@ proc readPackageInfoFromNimble(path: string; result: var PackageInfo) =
           else:
             raise nimbleError("Invalid field: " & ev.key)
         of "deps", "dependencies":
-          case ev.key.normalize
+          let normalizedKey = ev.key.normalize
+          case normalizedKey
           of "requires":
             for v in ev.value.multiSplit:
               result.requires.add(parseRequires(v.strip))
           else:
-            raise nimbleError("Invalid field: " & ev.key)
-        else: raise nimbleError(
+            if normalizedKey.endsWith("requires"):
+              let task = normalizedKey.dup(removeSuffix("requires"))
+              # Tasks have already been parsed, so we can safely check
+              # if the task is valid or not
+              if task notin result.nimbleTasks:
+                raise nimbleError(fmt"Task {task} doesn't exist for requirement'")
+
+              if task notin result.taskRequires:
+                result.taskRequires[task] = @[]
+              # Add all requirements for the task
+              for v in ev.value.multiSplit:
+                result.taskRequires[task].add(parseRequires(v.strip))
+            else:
+              raise nimbleError("Invalid field: " & ev.key)
+        else:
+          raise nimbleError(
               "Invalid section: " & currentSection)
       of cfgOption: raise nimbleError(
             "Invalid package info, should not contain --" & ev.value)

--- a/tests/taskdeps/dependencies/.gitignore
+++ b/tests/taskdeps/dependencies/.gitignore
@@ -1,0 +1,1 @@
+nimble.lock

--- a/tests/taskdeps/dependencies/.gitignore
+++ b/tests/taskdeps/dependencies/.gitignore
@@ -1,1 +1,0 @@
-nimble.lock

--- a/tests/taskdeps/dependencies/tasks.nimble
+++ b/tests/taskdeps/dependencies/tasks.nimble
@@ -1,0 +1,18 @@
+# Package
+
+version       = "0.1.0"
+author        = "John Doe"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "."
+bin           = @[]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+taskRequires "a", "unittest2 == 0.0.4"
+
+task a, "Description for a":
+    echo "blah blah"

--- a/tests/taskdeps/dependencies/tasks.nimble
+++ b/tests/taskdeps/dependencies/tasks.nimble
@@ -11,8 +11,8 @@ bin           = @[]
 # Dependencies
 
 requires "nim >= 0.19.0"
-
 taskRequires "a", "unittest2 == 0.0.4"
+taskRequires "test", "unittest2"
 
 task a, "Description for a":
     echo "blah blah"

--- a/tests/taskdeps/dependencies/tests/test.nim
+++ b/tests/taskdeps/dependencies/tests/test.nim
@@ -1,0 +1,2 @@
+{.warning[UnusedImport]: off.}
+import unittest2/customFile

--- a/tests/taskdeps/error/error.nimble
+++ b/tests/taskdeps/error/error.nimble
@@ -11,8 +11,4 @@ bin           = @[]
 # Dependencies
 
 requires "nim >= 0.19.0"
-taskRequires "a", "unittest2 == 0.0.4"
-taskRequires "test", "unittest2"
-
-task a, "Description for a":
-    echo "blah blah"
+taskRequires "benchmark", "benchy == 0.0.1"

--- a/tests/taskdeps/main/benchmark.nim
+++ b/tests/taskdeps/main/benchmark.nim
@@ -1,0 +1,4 @@
+import benchy
+
+timeIt "test":
+  discard

--- a/tests/taskdeps/main/main.nimble
+++ b/tests/taskdeps/main/main.nimble
@@ -12,4 +12,8 @@ bin           = @[]
 
 requires "nim >= 0.19.0"
 
+taskRequires "benchmark", "benchy == 0.0.1"
 taskRequires "test", "unittest2 == 0.0.4"
+
+task benchmark, "Runs benchmarks":
+  setCommand("c", "benchmark")

--- a/tests/taskdeps/main/tests/test.nim
+++ b/tests/taskdeps/main/tests/test.nim
@@ -1,0 +1,9 @@
+import unittest2
+
+when defined(useDevelop):
+  echo "Using custom file"
+  import unittest2/customFile
+
+suite "Test":
+  test "Foo":
+    check true

--- a/tests/taskdeps/subdep/subdep.nimble
+++ b/tests/taskdeps/subdep/subdep.nimble
@@ -1,0 +1,11 @@
+# Package
+
+version       = "0.1.0"
+author        = "John Doe"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "."
+bin           = @[]
+
+
+taskRequires "test", "threading >= 0.1.0"

--- a/tests/taskdeps/test/tasks.nimble
+++ b/tests/taskdeps/test/tasks.nimble
@@ -1,0 +1,15 @@
+# Package
+
+version       = "0.1.0"
+author        = "John Doe"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "."
+bin           = @[]
+
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+taskRequires "test", "unittest2 == 0.0.4"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -26,3 +26,4 @@ import tsetupcommand
 import ttestcommand
 import ttwobinaryversions
 import tuninstall
+import ttaskdeps

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -128,6 +128,15 @@ proc safeMoveFile(src, dest: string) =
     copyFile(src, dest)
     removeFile(src)
 
+proc uninstallDeps*() =
+  ## Uninstalls all installed dependencies.
+  ## Useful for cleaning up after a test case
+  let (output, exitCode) = execNimble("list", "-i")
+  for line in output.splitLines:
+    let package = line.split("  ")[0]
+    if package != "":
+      verify execNimbleYes("uninstall", "-i", package)
+
 template testRefresh*(body: untyped) =
   # Backup current config
   let configFile {.inject.} = getConfigDir() / "nimble" / "nimble.ini"

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -195,4 +195,7 @@ proc writeDevelopFile*(path: string, includes: seq[string],
 putEnv("NIMBLE_TEST_BINARY_PATH", nimblePath)
 
 # Always recompile.
-doAssert execCmdEx("nim c " & nimbleCompilePath).exitCode == QuitSuccess
+block:
+  # Verbose name is used for exit code so assert is clearer
+  let (output, nimbleCompileExitCode) = execCmdEx("nim c " & nimbleCompilePath)
+  doAssert nimbleCompileExitCode == QuitSuccess, output

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -131,7 +131,7 @@ proc safeMoveFile(src, dest: string) =
 proc uninstallDeps*() =
   ## Uninstalls all installed dependencies.
   ## Useful for cleaning up after a test case
-  let (output, exitCode) = execNimble("list", "-i")
+  let (output, _) = execNimble("list", "-i")
   for line in output.splitLines:
     let package = line.split("  ")[0]
     if package != "":

--- a/tests/tmoduletests.nim
+++ b/tests/tmoduletests.nim
@@ -3,14 +3,13 @@
 
 {.used.}
 
-import unittest, os, osproc, strutils
+import unittest, os, osproc, strutils, testscommon
 
 suite "Module tests":
   template moduleTest(modulePath: string) =
     let moduleName = splitFile(modulePath).name
     test moduleName:
-      check execCmdEx("nim c -r " & modulePath).
-        exitCode == QuitSuccess
+      verify execCmdEx("nim c -r " & modulePath)
 
   for module in walkDir("../src/nimblepkg"):
     if readFile(module.path).contains("unittest"):

--- a/tests/tnimbletasks.nim
+++ b/tests/tnimbletasks.nim
@@ -33,20 +33,3 @@ suite "nimble tasks":
       check output.contains("a         Description for a")
       check exitCode == QuitSuccess
 
-
-  test "Can specify custom requirement for a task":
-    cd "tasks/dependencies":
-      let (output, exitCode) = execNimble("tasks")
-      check exitCode == QuitSuccess
-
-  test "Dependency is used when running task":
-    cd "tasks/dependencies":
-      let (output, exitCode) = execNimble("a")
-      check exitCode == QuitSuccess
-      check output.contains("dependencies for unittest2@0.0.4")
-
-  test "Dependency is not used when not running task":
-    cd "tasks/dependencies":
-      let (output, exitCode) = execNimble("install")
-      check exitCode == QuitSuccess
-      check not output.contains("dependencies for unittest2@0.0.4")

--- a/tests/tnimbletasks.nim
+++ b/tests/tnimbletasks.nim
@@ -32,3 +32,21 @@ suite "nimble tasks":
       let (output, exitCode) = execNimble("tasks")
       check output.contains("a         Description for a")
       check exitCode == QuitSuccess
+
+
+  test "Can specify custom requirement for a task":
+    cd "tasks/dependencies":
+      let (output, exitCode) = execNimble("tasks")
+      check exitCode == QuitSuccess
+
+  test "Dependency is used when running task":
+    cd "tasks/dependencies":
+      let (output, exitCode) = execNimble("test")
+      check exitCode == QuitSuccess
+      check output.contains("dependencies for unittest2@>= 0.0.1")
+
+  test "Dependency is not used when not running task":
+    cd "tasks/dependencies":
+      let (output, exitCode) = execNimble("install")
+      check exitCode == QuitSuccess
+      check not output.contains("dependencies for unittest2@>= 0.0.1")

--- a/tests/tnimbletasks.nim
+++ b/tests/tnimbletasks.nim
@@ -41,12 +41,12 @@ suite "nimble tasks":
 
   test "Dependency is used when running task":
     cd "tasks/dependencies":
-      let (output, exitCode) = execNimble("test")
+      let (output, exitCode) = execNimble("a")
       check exitCode == QuitSuccess
-      check output.contains("dependencies for unittest2@>= 0.0.1")
+      check output.contains("dependencies for unittest2@0.0.4")
 
   test "Dependency is not used when not running task":
     cd "tasks/dependencies":
       let (output, exitCode) = execNimble("install")
       check exitCode == QuitSuccess
-      check not output.contains("dependencies for unittest2@>= 0.0.1")
+      check not output.contains("dependencies for unittest2@0.0.4")

--- a/tests/tnimbletasks.nim
+++ b/tests/tnimbletasks.nim
@@ -32,4 +32,3 @@ suite "nimble tasks":
       let (output, exitCode) = execNimble("tasks")
       check output.contains("a         Description for a")
       check exitCode == QuitSuccess
-

--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -1,63 +1,86 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
+{.used.}
+
 import unittest, strutils, os
 import testscommon
 import json
 from nimblepkg/common import cd
 
+template makeLockFile() =
+  ## Makes lock file, cleans up after itself
+  verify execNimble("lock")
+  defer: removeFile("nimble.lock")
+
+template inDir(body: untyped) =
+  ## Runs code inside taskdeps folder
+  cd "taskdeps/main/":
+    body
+
 suite "Task level dependencies":
+  verify execNimbleYes("update")
+
   teardown:
     uninstallDeps()
+
   test "Can specify custom requirement for a task":
-    cd "taskdeps/dependencies":
-      let (output, exitCode) = execNimble("tasks")
-      check exitCode == QuitSuccess
+    inDir:
+      verify execNimble("tasks")
 
   test "Dependency is used when running task":
-    cd "taskdeps/dependencies":
-      let (output, exitCode) = execNimble("a")
+    inDir:
+      let (output, exitCode) = execNimble("benchmark")
       check exitCode == QuitSuccess
-      check output.contains("dependencies for unittest2@0.0.4")
+      check output.contains("dependencies for benchy@0.0.1")
+      check not output.contains("dependencies for unittest2@0.0.4")
 
   test "Dependency is not used when not running task":
-    cd "taskdeps/dependencies":
+    inDir:
       let (output, exitCode) = execNimble("install")
       check exitCode == QuitSuccess
       check not output.contains("dependencies for unittest2@0.0.4")
-      discard execNimble("uninstall", "-i", "tasks")
+      check not output.contains("dependencies for benchy@0.0.1")
 
   test "Dependency can be defined for test task":
-    cd "taskdeps/test":
+    inDir:
       let (output, exitCode) = execNimble("test")
       check exitCode == QuitSuccess
       check output.contains("dependencies for unittest2@0.0.4")
 
   test "Lock file has dependencies added to it":
-    cd "taskdeps/dependencies":
-      removeFile("nimble.lock")
-      verify execNimble("lock")
+    inDir:
+      makeLockFile()
       # Check task level dependencies are in the lock file
       let json = parseFile("nimble.lock")
       check "unittest2" in json["packages"]
       let pkgInfo = json["packages"]["unittest2"]
       check pkgInfo["version"].getStr() == "0.0.4"
-      check pkgInfo["task"].getStr() == "test"
-      removeFile("nimble.lock")
+
+  test "Task dependencies from lock file are used":
+    inDir:
+      makeLockFile()
+      uninstallDeps()
+      let (output, exitCode) = execNimble("test")
+      check exitCode == QuitSuccess
+      check not output.contains("benchy installed successfully")
+      check output.contains("unittest2 installed successfully")
+
 
   test "Lock file doesn't install task dependencies":
-    cd "taskdeps/lock":
-      verify execNimble("lock")
+    inDir:
+      makeLockFile()
       # Uninstall the dependencies and see if nimble
       # tries to install them later
       uninstallDeps()
 
       let (output, exitCode) = execNimble("install")
       check exitCode == QuitSuccess
-      check "https://github.com/status-im/nim-unittest2 using git" notin output
+      check not output.contains("benchy installed successfully")
+      check not output.contains("unittest2 installed successfully")
 
   test "Deps prints out all tasks dependencies":
-    cd "taskdeps/dependencies":
+    inDir:
       # Uninstall the dependencies fist to make sure deps command
       # still installs everything correctly
       uninstallDeps()
@@ -72,11 +95,44 @@ suite "Task level dependencies":
       check found
 
   test "Develop file is used":
-    cd "taskdeps/dependencies":
-      removeDir("nim-unittest2")
-      removeFile("nimble.develop")
+    inDir:
+      defer:
+        removeDir("nim-unittest2")
+        removeFile("nimble.develop")
 
       verify execNimble("develop", "unittest2")
+      # Add in a file to the develop file
+      # We will then try and import this
       createDir "nim-unittest2/unittest2"
       "nim-unittest2/unittest2/customFile.nim".writeFile("")
-      verify execNimble("test")
+      let (output, exitCode) = execNimble("-d:useDevelop", "test")
+      check exitCode == QuitSuccess
+      check "Using custom file" in output
+
+  test "Dependencies aren't verified twice":
+    inDir:
+      let (output, _) = execNimble("test")
+      check output.count("dependencies for unittest2@0.0.4") == 1
+
+  test "Requirements for tasks in dependencies aren't used":
+    cd "taskdeps/subdep/":
+      let (output, _) = execNimbleYes("install")
+      check "threading" notin output
+
+    inDir:
+      let (output, exitCode) = execNimble("test")
+      check exitCode == QuitSuccess
+      check "threading" notin output
+
+  test "Error thrown when setting requirement for task that doesn't exist":
+    cd "taskdeps/error/":
+      let (output, exitCode) = execNimble("check")
+      check exitCode == QuitFailure
+      check "Task benchmark doesn't exist for requirement benchy == 0.0.1" in output
+
+  test "Dump contains information":
+    inDir:
+      let (output, exitCode) = execNimble("dump")
+      check exitCode == QuitSuccess
+      check output.processOutput.inLines("benchmarkRequires: \"benchy 0.0.1\"")
+      check output.processOutput.inLines("testRequires: \"unittest2 0.0.4\"")

--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -7,6 +7,8 @@ import json
 from nimblepkg/common import cd
 
 suite "Task level dependencies":
+  teardown:
+    uninstallDeps()
   test "Can specify custom requirement for a task":
     cd "taskdeps/dependencies":
       let (output, exitCode) = execNimble("tasks")
@@ -40,7 +42,7 @@ suite "Task level dependencies":
       check "unittest2" in json["packages"]
       let pkgInfo = json["packages"]["unittest2"]
       check pkgInfo["version"].getStr() == "0.0.4"
-      check pkgInfo["task"] == "test"
+      check pkgInfo["task"].getStr() == "test"
       removeFile("nimble.lock")
 
   test "Lock file doesn't install task dependencies":
@@ -68,3 +70,13 @@ suite "Task level dependencies":
         if dependency["name"].getStr() == "unittest2":
           found = true
       check found
+
+  test "Develop file is used":
+    cd "taskdeps/dependencies":
+      removeDir("nim-unittest2")
+      removeFile("nimble.develop")
+
+      verify execNimble("develop", "unittest2")
+      createDir "nim-unittest2/unittest2"
+      "nim-unittest2/unittest2/customFile.nim".writeFile("")
+      verify execNimble("test")

--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -1,0 +1,54 @@
+# Copyright (C) Dominik Picheta. All rights reserved.
+# BSD License. Look at license.txt for more info.
+
+import unittest, strutils, os
+import testscommon
+import json
+from nimblepkg/common import cd
+
+suite "Task level dependencies":
+  test "Can specify custom requirement for a task":
+    cd "taskdeps/dependencies":
+      let (output, exitCode) = execNimble("tasks")
+      check exitCode == QuitSuccess
+
+  test "Dependency is used when running task":
+    cd "taskdeps/dependencies":
+      let (output, exitCode) = execNimble("a")
+      check exitCode == QuitSuccess
+      check output.contains("dependencies for unittest2@0.0.4")
+
+  test "Dependency is not used when not running task":
+    cd "taskdeps/dependencies":
+      let (output, exitCode) = execNimble("install")
+      check exitCode == QuitSuccess
+      check not output.contains("dependencies for unittest2@0.0.4")
+
+  test "Dependency can be defined for test task":
+    cd "taskdeps/test":
+      let (output, exitCode) = execNimble("test")
+      check exitCode == QuitSuccess
+      check output.contains("dependencies for unittest2@0.0.4")
+
+  test "Lock file has dependencies added to it":
+    cd "taskdeps/dependencies":
+      removeFile("nimble.lock")
+      let (_, exitCode) = execNimble("lock")
+      check exitCode == QuitSuccess
+      # Check task level dependencies are in the lock file
+      let json = parseFile("nimble.lock")
+      check "unittest2" in json["packages"]
+      let pkgInfo = json["packages"]["unittest2"]
+      check pkgInfo["version"].getStr() == "0.0.4"
+
+  test "Deps prints out all tasks":
+    cd "taskdeps/dependencies":
+      let (output, exitCode) = execNimble("--format:json", "deps")
+      check exitCode == QuitSuccess
+      let json = parseJson(output)
+
+      var found = false
+      for dependency in json:
+        if dependency["name"].getStr() == "unittest2":
+          found = true
+      check found

--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -23,6 +23,7 @@ suite "Task level dependencies":
       let (output, exitCode) = execNimble("install")
       check exitCode == QuitSuccess
       check not output.contains("dependencies for unittest2@0.0.4")
+      discard execNimble("uninstall", "-i", "tasks")
 
   test "Dependency can be defined for test task":
     cd "taskdeps/test":
@@ -33,17 +34,32 @@ suite "Task level dependencies":
   test "Lock file has dependencies added to it":
     cd "taskdeps/dependencies":
       removeFile("nimble.lock")
-      let (_, exitCode) = execNimble("lock")
-      check exitCode == QuitSuccess
+      verify execNimble("lock")
       # Check task level dependencies are in the lock file
       let json = parseFile("nimble.lock")
       check "unittest2" in json["packages"]
       let pkgInfo = json["packages"]["unittest2"]
       check pkgInfo["version"].getStr() == "0.0.4"
+      check pkgInfo["task"] == "test"
+      removeFile("nimble.lock")
 
-  test "Deps prints out all tasks":
+  test "Lock file doesn't install task dependencies":
+    cd "taskdeps/lock":
+      verify execNimble("lock")
+      # Uninstall the dependencies and see if nimble
+      # tries to install them later
+      uninstallDeps()
+
+      let (output, exitCode) = execNimble("install")
+      check exitCode == QuitSuccess
+      check "https://github.com/status-im/nim-unittest2 using git" notin output
+
+  test "Deps prints out all tasks dependencies":
     cd "taskdeps/dependencies":
-      let (output, exitCode) = execNimble("--format:json", "deps")
+      # Uninstall the dependencies fist to make sure deps command
+      # still installs everything correctly
+      uninstallDeps()
+      let (output, exitCode) = execNimble("--format:json", "--silent", "deps")
       check exitCode == QuitSuccess
       let json = parseJson(output)
 


### PR DESCRIPTION
Implements #482

Syntax works like so
```nim
taskRequires "taskName", "somePackage == 0.1.0"
```

This is done instead of allowing `requires` at task level since it means a task such as `test` doesn't need to be redefined just to add dependencies to it (also is easier to implement).

More work still needs to be done, making draft now in case anyone wants to give input while I hack away at it.

What needs to be done (These might work, I just need to write test cases to see if they work)

- [x] Support lock files
- [x] Support `deps` related commands (All dependencies should be outputted)
- [x] Support develop