### PR TITLE
lock: write lock file with final newline

### DIFF
--- a/src/nimblepkg/lockfile.nim
+++ b/src/nimblepkg/lockfile.nim
@@ -36,7 +36,11 @@ proc writeLockFile*(fileName: string, packages: LockFileDeps,
       $lfjkPackages: packagesJsonNode
       }
 
-  writeFile(fileName, mainJsonNode.pretty)
+  let contents = block:
+    var s = mainJsonNode.pretty
+    s.add '\n'
+    s
+  writeFile(fileName, contents)
 
 proc readLockFile*(filePath: string): LockFileDeps =
   {.warning[UnsafeDefault]: off.}

--- a/src/nimblepkg/lockfile.nim
+++ b/src/nimblepkg/lockfile.nim
@@ -36,11 +36,9 @@ proc writeLockFile*(fileName: string, packages: LockFileDeps,
       $lfjkPackages: packagesJsonNode
       }
 
-  let contents = block:
-    var s = mainJsonNode.pretty
-    s.add '\n'
-    s
-  writeFile(fileName, contents)
+  var s = mainJsonNode.pretty
+  s.add '\n'
+  writeFile(fileName, s)
 
 proc readLockFile*(filePath: string): LockFileDeps =
   {.warning[UnsafeDefault]: off.}


### PR DESCRIPTION
Before this commit, `nimble lock` wrote the lock file without a final newline:

```console
$ nimble lock
     Info:  Generating the lock file...
  Verifying dependencies for foo@0.1.0
  Success:  The lock file is generated.
$ cat nimble.lock
{
  "version": 1,
  "packages": {}
$ wc -l nimble.lock
3 nimble.lock
```

Fixes: #1056