### PR TITLE
common: bump nimbleVersion from 0.14.0 to 0.14.1

### DIFF
--- a/src/nimblepkg/common.nim
+++ b/src/nimblepkg/common.nim
@@ -22,7 +22,7 @@ type
   ProcessOutput* = tuple[output: string, exitCode: int]
 
 const
-  nimbleVersion* = "0.14.0"
+  nimbleVersion* = "0.14.1"
   nimblePackagesDirName* = "pkgs2"
   nimblePackagesLinksDirName* ="links"
   nimbleBinariesDirName* = "bin"


### PR DESCRIPTION
Commit afd03bc000f4 ("bump nimble to 0.14.1", 2022-12-16) only bumped the version in `nimble.nimble`. Bump it in `common.nim` too, so that `nimble --version` no longer reports 0.14.0 as the version.

See earlier bumps:

- 0a23c44cd8d6 ("Bump version to 0.14.0", 2021-10-02)
- fe1349c89327 ("Bump to 0.13.1 without hacks.", 2021-03-05)
- a57588a278a3 ("updated version to 0.13.0", 2021-02-08)

Fixes: #1058