### PR TITLE
 add support for -g flag, fix #1069

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -617,7 +617,7 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
         raise nimbleError(multiplePathOptionsGivenMsg)
     of "with-dependencies":
       result.action.withDependencies = true
-    of "global":
+    of "g", "global":
       result.action.global = true
     of "develop-file":
       if result.action.developFile.len == 0:


### PR DESCRIPTION
The -g flag in the Nimble package manager would result in an error due to the flag being unrecognized, it is short of global flag