### PR TITLE
drop deps sha1

### DIFF
--- a/src/nimblepkg/sha1hashes.nim
+++ b/src/nimblepkg/sha1hashes.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import strformat, strutils, json, std/sha1, hashes
+import strformat, strutils, json, hashes
 import common
 
 type
@@ -25,6 +25,10 @@ proc invalidSha1Hash(value: string): ref InvalidSha1HashError =
   ## Creates a new exception object for an invalid sha1 hash value.
   result = newNimbleError[InvalidSha1HashError](
     &"The string '{value}' does not represent a valid sha1 hash value.")
+
+proc isValidSha1Hash*(s: string): bool =
+  ## Checks if a string is a valid sha1 hash sum.
+  s.len == 40 and allCharsInSet(s, HexDigits)
 
 proc initSha1Hash*(value: string): Sha1Hash =
   ## Creates a new `Sha1Hash` object from a string by making all latin letters

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -3,11 +3,11 @@
 
 {.used.}
 
-import sequtils, strutils, strformat, os, osproc, sugar, unittest, macros,
-       std/sha1
+import sequtils, strutils, strformat, os, osproc, sugar, unittest, macros
 
 from nimblepkg/common import cd, nimblePackagesDirName, ProcessOutput
 from nimblepkg/developfile import developFileVersion
+from nimblepkg/sha1hashes import isValidSha1Hash
 
 const
   stringNotFound* = -1


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/21702

If nimble depends on `std/checksums`, it might make everything complex. Fortunately, only a small function needs to be duplicated.