### PR TITLE
Expose path of executing nimble to tasks

### DIFF
--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -233,6 +233,8 @@ template after*(action: untyped, body: untyped): untyped =
     success = true
     retVal = `action After`()
 
+const nimbleExe* {.strdefine.} = "nimble"
+
 proc getPkgDir*(): string =
   ## Returns the package directory containing the .nimble file currently
   ## being evaluated.

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -233,7 +233,7 @@ template after*(action: untyped, body: untyped): untyped =
     success = true
     retVal = `action After`()
 
-const nimbleExe* {.strdefine.} = "nimble"
+const nimbleBin* {.strdefine.} = "nimble"
 
 proc getPkgDir*(): string =
   ## Returns the package directory containing the .nimble file currently

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -233,7 +233,7 @@ template after*(action: untyped, body: untyped): untyped =
     success = true
     retVal = `action After`()
 
-const nimbleBin* {.strdefine.} = "nimble"
+const nimbleExe* {.strdefine.} = "nimble"
 
 proc getPkgDir*(): string =
   ## Returns the package directory containing the .nimble file currently

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -233,8 +233,6 @@ template after*(action: untyped, body: untyped): untyped =
     success = true
     retVal = `action After`()
 
-const nimbleExe* {.strdefine.} = "nimble"
-
 proc getPkgDir*(): string =
   ## Returns the package directory containing the .nimble file currently
   ## being evaluated.

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -48,9 +48,10 @@ proc execNimscript(
       else: ""
 
   var cmd = (
-    "$# e $# --colors:on $# $# $# $# $#" % [
+    "$# e $# $# --colors:on $# $# $# $# $#" % [
       getNimBin(options).quoteShell,
       "--hints:off --verbosity:0",
+      "--define:nimbleExe=" & getAppFilename().quoteShell,
       compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,
@@ -109,14 +110,12 @@ import system except getCommand, setCommand, switch, `--`, thisDir,
   skipDirs, skipFiles, skipExt, installDirs, installFiles, installExt, bin, foreignDeps,
   requires, task, packageName
 
-const nimbleExe = r"$1"
-
 import strutils
-import "$2"
-include "$3"
+import "$1"
+include "$2"
 
 onExit()
-""" % [getAppFilename().replace("\"", "\"\""), nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
+""" % [nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
     discard tryRemoveFile(iniFile)
 
   result = nimsFile

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -48,9 +48,10 @@ proc execNimscript(
       else: ""
 
   var cmd = (
-    "$# e $# --colors:on $# $# $# $# $#" % [
+    "$# e $# $# --colors:on $# $# $# $# $#" % [
       getNimBin(options).quoteShell,
       "--hints:off --verbosity:0",
+      "--define:nimbleExe=" & paramStr(0).quoteShell,
       compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,
@@ -60,7 +61,6 @@ proc execNimscript(
   ).strip()
 
   if isCustomTask:
-    cmd &= " --define:nimbleExe=" & paramStr(0).quoteShell
     for i in options.action.arguments:
       cmd &= " " & i.quoteShell()
     cmd &= " " & join(options.action.custRunFlags, " ")

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -116,7 +116,7 @@ import "$2"
 include "$3"
 
 onExit()
-""" % [getAppFilename(), nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
+""" % [getAppFilename().replace("\"", "\\\""), nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
     discard tryRemoveFile(iniFile)
 
   result = nimsFile

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -60,6 +60,7 @@ proc execNimscript(
   ).strip()
 
   if isCustomTask:
+    cmd &= " --define:nimbleExe=" & paramStr(0).quoteShell
     for i in options.action.arguments:
       cmd &= " " & i.quoteShell()
     cmd &= " " & join(options.action.custRunFlags, " ")

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -109,14 +109,14 @@ import system except getCommand, setCommand, switch, `--`, thisDir,
   skipDirs, skipFiles, skipExt, installDirs, installFiles, installExt, bin, foreignDeps,
   requires, task, packageName
 
-const nimbleExe = "$3"
+const nimbleExe = "$1"
 
 import strutils
-import "$1"
-include "$2"
+import "$2"
+include "$3"
 
 onExit()
-""" % [nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/"), getAppFilename()])
+""" % [getAppFilename(), nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
     discard tryRemoveFile(iniFile)
 
   result = nimsFile

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -48,10 +48,9 @@ proc execNimscript(
       else: ""
 
   var cmd = (
-    "$# e $# $# --colors:on $# $# $# $# $#" % [
+    "$# e $# --colors:on $# $# $# $# $#" % [
       getNimBin(options).quoteShell,
       "--hints:off --verbosity:0",
-      "--define:nimbleExe=" & getAppFilename().quoteShell,
       compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,
@@ -110,12 +109,14 @@ import system except getCommand, setCommand, switch, `--`, thisDir,
   skipDirs, skipFiles, skipExt, installDirs, installFiles, installExt, bin, foreignDeps,
   requires, task, packageName
 
+const nimbleExe = "$3"
+
 import strutils
 import "$1"
 include "$2"
 
 onExit()
-""" % [nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
+""" % [nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/"), getAppFilename()])
     discard tryRemoveFile(iniFile)
 
   result = nimsFile

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -51,7 +51,7 @@ proc execNimscript(
     "$# e $# $# --colors:on $# $# $# $# $#" % [
       getNimBin(options).quoteShell,
       "--hints:off --verbosity:0",
-      "--define:nimbleExe=" & paramStr(0).quoteShell,
+      "--define:nimbleExe=" & getAppFilename().quoteShell,
       compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -51,7 +51,7 @@ proc execNimscript(
     "$# e $# $# --colors:on $# $# $# $# $#" % [
       getNimBin(options).quoteShell,
       "--hints:off --verbosity:0",
-      "--define:nimbleExe=" & getAppFilename().quoteShell,
+      "--define:nimbleBin=" & getAppFilename().quoteShell,
       compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -51,7 +51,7 @@ proc execNimscript(
     "$# e $# $# --colors:on $# $# $# $# $#" % [
       getNimBin(options).quoteShell,
       "--hints:off --verbosity:0",
-      "--define:nimbleBin=" & getAppFilename().quoteShell,
+      "--define:nimbleExe=" & getAppFilename().quoteShell,
       compFlags,
       nimsFile.quoteShell,
       nimbleFile.quoteShell,

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -116,7 +116,7 @@ import "$2"
 include "$3"
 
 onExit()
-""" % [getAppFilename().replace("\"", "\\\""), nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
+""" % [getAppFilename().replace("\"", "\"\""), nimscriptApiFile.replace("\\", "/"), scriptName.replace("\\", "/")])
     discard tryRemoveFile(iniFile)
 
   result = nimsFile

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -109,7 +109,7 @@ import system except getCommand, setCommand, switch, `--`, thisDir,
   skipDirs, skipFiles, skipExt, installDirs, installFiles, installExt, bin, foreignDeps,
   requires, task, packageName
 
-const nimbleExe = "$1"
+const nimbleExe = r"$1"
 
 import strutils
 import "$2"


### PR DESCRIPTION
So the executing nimble can be used in tasks i.e. `exec nimbleExe & " install -y"` over `exec "nimble install -y"` 