### PR TITLE
Add --mm:refc when building nimble

### DIFF
--- a/src/nimble.nim.cfg
+++ b/src/nimble.nim.cfg
@@ -2,5 +2,6 @@
 #--noNimblePath
 --path:"$nim/"
 --path:"./vendor/nim"
+--mm:refc
 -d:ssl
 -d:nimcore # Enable 'gorge' in Nim's VM. See https://github.com/nim-lang/Nim/issues/8096

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -207,5 +207,5 @@ putEnv("NIMBLE_TEST_BINARY_PATH", nimblePath)
 # Always recompile.
 block:
   # Verbose name is used for exit code so assert is clearer
-  let (output, nimbleCompileExitCode) = execCmdEx("nim c --mm:refc " & nimbleCompilePath)
+  let (output, nimbleCompileExitCode) = execCmdEx("nim c " & nimbleCompilePath)
   doAssert nimbleCompileExitCode == QuitSuccess, output


### PR DESCRIPTION
- without this flag `nimble lock` crashes. Note that tests are also compiled
with this flag so do the nimble packaged from Nim repo