### PR TITLE
Remove the test for nimlangserver

### DIFF
--- a/tests/ttaskdeps.nim
+++ b/tests/ttaskdeps.nim
@@ -155,9 +155,3 @@ suite "Task level dependencies":
       check exitCode == QuitSuccess
       check output.processOutput.inLines("benchmarkRequires: \"benchy 0.0.1\"")
       check output.processOutput.inLines("testRequires: \"unittest2 0.0.4\"")
-
-  test "Lock files don't break":
-    # Tests for regression caused by tasks deps.
-    # nimlangserver is good candidate, has locks and quite a few dependencies
-    let (_, exitCode) = execNimbleYes("install", "nimlangserver@#19715af")
-    check exitCode == QuitSuccess


### PR DESCRIPTION
- that particular version won't be buildable due to using deprecated(?)
import statement. The build of langserver has been fixed with
https://github.com/nim-lang/langserver/commit/5188cdc79cccd18cc2b1b5c269c9e38e5aeb39d7
and the build status will be tracked by its CI. Thus removing the test