### PR TITLE
Fix two typos in error messages

### DIFF
--- a/src/nimblepkg/displaymessages.nim
+++ b/src/nimblepkg/displaymessages.nim
@@ -149,7 +149,7 @@ proc invalidDevelopDependenciesVersionsMsg*(errors: seq[string]): string =
 
 proc pkgAlreadyExistsInTheCacheMsg*(name, version, checksum: string): string =
   &"A package \"{name}@{version}\" with checksum \"{checksum}\" already " &
-   "exists the the cache."
+   "exists in the cache."
 
 proc pkgAlreadyExistsInTheCacheMsg*(pkgInfo: PackageInfo): string =
   pkgAlreadyExistsInTheCacheMsg(

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -125,7 +125,7 @@ proc validatePackageStructure(pkgInfo: PackageInfo, options: Options) =
                   "the main module, or if it is one of several " &
                   "modules exposed by '$4', then move it into a '$2' subdirectory. " &
                   "If it's a test file or otherwise not required " &
-                  "to build the the package '$1', prevent its installation " &
+                  "to build the package '$1', prevent its installation " &
                   "by adding `skipFiles = @[\"$3\"]` to the .nimble file. See " &
                   "https://github.com/nim-lang/nimble#libraries for more info.") %
                   [pkgInfo.basicInfo.name & ext, correctDir & DirSep, file & ext, pkgInfo.basicInfo.name]


### PR DESCRIPTION
- Fix typo (to build the the package -> to build the package)
- Fix typo (exists the the cache -> exists in the cache)
