### PR TITLE
Improve version management of nim by nimble

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2022,7 +2022,8 @@ proc getAlteredPath(options: Options): string =
       let folder = fullInfo.getOutputDir(bin).parentDir.quoteShell
       paths.add folder
   paths.reverse
-  result = fmt "{paths.join(separator)}{separator}{getEnv(\"PATH\")}"
+
+  result = fmt "{options.nimBin.parentDir}{separator}{paths.join(separator)}{separator}{getEnv(\"PATH\")}"
 
 proc shellenv(options: var Options) =
   setVerbosity(SilentPriority)

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1655,7 +1655,7 @@ proc check(errors: ValidationErrors, graph: LockFileDeps) =
 proc getDependenciesForLocking(pkgInfo: PackageInfo, options: Options):
     seq[PackageInfo] =
   ## Get all of the dependencies and then force the upgrade spec
-  var res = pkgInfo.processAllDependencies(options).toSeq
+  var res = pkgInfo.processAllDependencies(options).toSeq.mapIt(it.toFullInfo(options))
 
   if pkgInfo.hasLockedDeps():
     # if we are performing lock and there is a lock file we make sure that the

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2090,9 +2090,6 @@ proc doAction(options: var Options) =
   if options.showVersion:
     writeVersion()
 
-  if options.action.typ in {actionTasks, actionRun, actionBuild, actionCompile}:
-    # Implicitly disable package validation for these commands.
-    options.disableValidation = true
 
   case options.action.typ
   of actionRefresh:
@@ -2289,6 +2286,9 @@ when isMainModule:
     opt = parseCmdLine()
     opt.setNimbleDir
     opt.loadNimbleData
+    if opt.action.typ in {actionTasks, actionRun, actionBuild, actionCompile, actionDevelop}:
+      # Implicitly disable package validation for these commands.
+      opt.disableValidation = true
     opt.setNimBin
     opt.doAction()
   except NimbleQuit as quit:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -495,7 +495,7 @@ proc downloadPkg*(url: string, verRange: VersionRange,
   (result.version, result.vcsRevision) = doDownload(
     modUrl, downloadDir, verRange, downMethod, options, vcsRevision)
 
-  if validateRange and verRange.kind != verSpecial:
+  if validateRange and verRange.kind notin {verSpecial, verAny}:
     ## Makes sure that the downloaded package's version satisfies the requested
     ## version range.
     let pkginfo = getPkgInfo(result[0], options)

--- a/src/nimblepkg/topologicalsort.nim
+++ b/src/nimblepkg/topologicalsort.nim
@@ -102,7 +102,10 @@ proc topologicalSort*(graph: LockFileDeps):
       "The dependency graph is not a DAG.")
     display("Warning", message, Warning, HighPriority)
 
-  for node, _ in graph:
+  var sortedNames = graph.keys.toSeq
+  sortedNames.sort(cmp)
+
+  for node in sortedNames:
     nodesInfo[node] = (mark: nmNotMarked, cameFrom: "")
 
   proc visit(node: string) =
@@ -125,8 +128,8 @@ proc topologicalSort*(graph: LockFileDeps):
     nodeInfo.mark = nmPermanent
     order.add node
 
-  for node, nodeInfo in nodesInfo:
-    if nodeInfo.mark != nmPermanent:
+  for node in sortedNames:
+    if nodesInfo[node].mark != nmPermanent:
       visit(node)
 
   if cycles.len > 0:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -5,7 +5,6 @@ import testscommon
 
 # suits imports
 
-import tnonim
 import tinitcommand
 import tcheckcommand
 import tcleancommand
@@ -29,3 +28,7 @@ import ttestcommand
 import ttwobinaryversions
 import tuninstall
 import ttaskdeps
+
+# nonim tests are very slow and (often) break the CI.
+
+# import tnonim

--- a/tests/tnonim.nim
+++ b/tests/tnonim.nim
@@ -1,5 +1,5 @@
-# # Copyright (C) Dominik Picheta. All rights reserved.
-# # BSD License. Look at license.txt for more info.
+# Copyright (C) Dominik Picheta. All rights reserved.
+# BSD License. Look at license.txt for more info.
 
 {.used.}
 

--- a/tests/tnonim.nim
+++ b/tests/tnonim.nim
@@ -7,6 +7,7 @@ import unittest, os, osproc, strutils
 import testscommon
 from nimblepkg/common import cd
 
+
 suite "No global nim":
   let
     path = getEnv("PATH")
@@ -15,10 +16,49 @@ suite "No global nim":
     putEnv("PATH", findExe("git").parentDir)
   putEnv("NIMBLE_DIR", nimbleCacheDir)
 
-  test "The nim from the lock file used":
+  proc cleanup() =
     cd "nimdep":
-
       removeDir(nimbleCacheDir)
+      removeFile("nimble.develop")
+      removeDir("Nim")
+
+  test "No nim lock file":
+    cleanup()
+    cd "nimdep":
+      let (output, exitCode) =
+        execCmdEx(nimblePath & " version -y --noLockFile")
+      echo output
+      check exitCode == QuitSuccess
+
+      let usingNim = when defined(Windows): "nim.exe for compilation" else: "bin/nim for compilation"
+      check output.contains(usingNim)
+      check output.contains("compiling nim in ")
+
+      # check not compiled again
+      let (outputAfterInstalled, exitCodeAfterInstalled) =
+        execCmdEx(nimblePath & " version -y --noLockFile")
+      check exitCodeAfterInstalled == QuitSuccess
+      check not outputAfterInstalled.contains("compiling nim in ")
+
+      # install develop version
+      check QuitSuccess == execCmdEx(nimblePath & " develop nim -y --noLockFile").exitCode
+
+      let (outputAfterDevelop, exitCodeAfterDevelop) =
+        execCmdEx(nimblePath & " version -y --noLockFile")
+      check exitCodeAfterDevelop == QuitSuccess
+      check outputAfterDevelop.contains("Develop version of nim was found but it is not compiled. Compile it now?")
+      check outputAfterDevelop.contains("compiling nim in ")
+
+      # make sure second develop call won't result in compiling and asking again
+      let (outputAfterDevelop2, exitCodeAfterDevelop2) =
+        execCmdEx(nimblePath & " version -y --noLockFile")
+      check exitCodeAfterDevelop2 == QuitSuccess
+      check not outputAfterDevelop2.contains("Develop version of nim was found but it is not compiled. Compile it now?")
+      check not outputAfterDevelop2.contains("compiling nim in ")
+
+  test "The nim from the lock file used":
+    cleanup()
+    cd "nimdep":
 
       let (output, exitCode) =
         execCmdEx(nimblePath & " version -y --lock-file=nimble-no-global-nim.lock")
@@ -35,8 +75,8 @@ suite "No global nim":
       check not outputAfterInstalled.contains("koch")
 
   test "Nimble install -d works":
+    cleanup()
     cd "nimdep":
-      removeDir(nimbleCacheDir)
       let (output, exitCode) =
         execCmdEx(nimblePath & " install -d -y --lock-file=nimble-no-global-nim.lock")
       check exitCode == QuitSuccess
@@ -47,3 +87,4 @@ suite "No global nim":
 
   putEnv("PATH", path)
   delEnv("NIMBLE_DIR")
+  cleanup()

--- a/tests/tnonim.nim
+++ b/tests/tnonim.nim
@@ -1,5 +1,5 @@
-# Copyright (C) Dominik Picheta. All rights reserved.
-# BSD License. Look at license.txt for more info.
+# # Copyright (C) Dominik Picheta. All rights reserved.
+# # BSD License. Look at license.txt for more info.
 
 {.used.}
 

--- a/tests/tshellenv.nim
+++ b/tests/tshellenv.nim
@@ -23,8 +23,11 @@ suite "Shell env":
 
       when defined windows:
         check prefix == "set PATH"
+        const extension = ".exe"
       else:
+        const extension = ""
         check prefix == "export PATH"
 
-      check dirs[0].extractFileName == "shellenv"
-      check dirs[1].extractFileName == "testutils-0.5.0-756d0757c4dd06a068f9d38c7f238576ba5ee897"
+      check (dirs[0] / ("nim" & extension)).fileExists
+      check dirs[1].extractFileName == "shellenv"
+      check dirs[2].extractFileName == "testutils-0.5.0-756d0757c4dd06a068f9d38c7f238576ba5ee897"


### PR DESCRIPTION
The following algorithm is implemented:

1. Use --nim param if specified(no validation of the version)
2. Use develop version if present(no validation of
the version)
3. Use locked nim
4. Use global version if matches `require` section
5. Download and install matching version of `requires` specification does not
match the existing one