### PR TITLE
Made it so compilation commands work as documented

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -772,7 +772,10 @@ proc getCompilationBinary*(options: Options, pkgInfo: PackageInfo): Option[strin
   of actionBuild, actionDoc, actionCompile:
     let file = options.action.file.changeFileExt("")
     if file.len > 0:
-      return some(pkgInfo.srcDir / file)
+      if fileExists(file):
+        return some(file)
+      else:
+        return some(pkgInfo.srcDir / file)
   of actionRun:
     let optRunFile = options.action.runFile
     let runFile =

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -772,7 +772,7 @@ proc getCompilationBinary*(options: Options, pkgInfo: PackageInfo): Option[strin
   of actionBuild, actionDoc, actionCompile:
     let file = options.action.file.changeFileExt("")
     if file.len > 0:
-      return some(file)
+      return some(pkgInfo.srcDir / file)
   of actionRun:
     let optRunFile = options.action.runFile
     let runFile =


### PR DESCRIPTION
> command can be used by developers to compile individual modules inside their package

Presently `nimble c nimblepkg/options` does not work. This seems to be the intended interface.