### PR TITLE
Support installing packages from SSH URL

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -135,7 +135,7 @@ proc getUrlData*(url: string): (string, Table[string, string]) =
   return ($uri, {"subdir": subdir}.toTable())
 
 proc isURL*(name: string): bool =
-  name.startsWith(peg" @'://' ")
+  name.startsWith(peg" @'://' ") or name.startsWith(peg"\ident+'@'@':'.+")
 
 proc cloneSpecificRevision(downloadMethod: DownloadMethod,
                            url, downloadDir: string,

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -469,9 +469,10 @@ proc parseArgument*(key: string, result: var Options) =
   of actionNil:
     assert false
   of actionInstall, actionPath, actionDevelop, actionUninstall, actionUpgrade:
-    # Parse pkg@verRange
-    if '@' in key:
-      let i = find(key, '@')
+    # Parse pkg@verRange or git@github.com:nim-lang/nimble.git
+    let i = rfind(key, '@')
+    let maybeUrl = rfind(key, {'/', ':'})
+    if i > maybeUrl:
       let (pkgName, pkgVer) = (key[0 .. i-1], key[i+1 .. key.len-1])
       if pkgVer.len == 0:
         raise nimbleError("Version range expected after '@'.")


### PR DESCRIPTION
Support installing packages from SSH URL, for example, `git@github.com:nim-lang/fusion.git`.
Use an SSH URL to avoid entering your account and password when downloading a private code base.
```shell
[root@haoyu nimble] ./nimble install git@github.com:nim-lang/fusion.git
Downloading git@github.com:nim-lang/fusion.git using git
  Verifying dependencies for fusion@1.2
 Installing fusion@1.2
  Success:  fusion installed successfully.
```
