### PR TITLE
fix issue #1158

### DIFF
--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -108,7 +108,7 @@ proc getNimsFile(scriptName: string, options: Options): string =
 import system except getCommand, setCommand, switch, `--`, thisDir,
   packageName, version, author, description, license, srcDir, binDir, backend,
   skipDirs, skipFiles, skipExt, installDirs, installFiles, installExt, bin, foreignDeps,
-  requires, task, packageName
+  requires, requiresData, task, packageName
 
 import strutils
 import "$1"

--- a/tests/issue1158/issue1158.nimble
+++ b/tests/issue1158/issue1158.nimble
@@ -1,0 +1,17 @@
+
+# Package
+
+version       = "0.1.0"
+author        = "stoneface86"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+
+# Dependencies
+
+requires "nim >= 1.6.16"
+
+task echoRequires, "":
+  echo requiresData
+

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -424,3 +424,10 @@ suite "issues":
 
     # Clean up package file
     check execNimble(["refresh"]).exitCode == QuitSuccess
+
+  test "issue #1158":
+    cd "issue1158":
+      let (output, exitCode) = execNimble("--silent", "echoRequires")
+      check:
+        exitCode == QuitSuccess
+        output.strip() == "@[\"nim >= 1.6.16\"]"


### PR DESCRIPTION
Fix for #1158. When accessing the `dataRequires` var, nim reports that it is an ambiguous identifier and a module is needed to specify which one (either `system` or the auto-generated `nimscript_xxxxxxxx`). By adding `dataRequires` to the except list in nimscriptwrapper.nim, this error is avoided and the var can now be used as intended.

I have also included a test case in tests/tissues.nim