### PR TITLE
(fix) re-add https://nim-lang.org's package list

### DIFF
--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -23,7 +23,7 @@ proc initConfig(): Config =
   result.chcp = true
   result.cloneUsingHttps = true
   result.packageLists["official"] = PackageList(name: "Official", urls: @[
-    "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json"
+    "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json",
     "https://nim-lang.org/nimble/packages.json"
   ])
 

--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -24,12 +24,7 @@ proc initConfig(): Config =
   result.cloneUsingHttps = true
   result.packageLists["official"] = PackageList(name: "Official", urls: @[
     "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json"
-    # This URL serves extremely old data, and sometimes when Nimble cannot reach the above URL
-    # it uses this one which causes data that is years old to be used. This means that
-    # approximately 27189 packages will be missing, or roughly 86% of the entirity of Nim
-    # packages as of 9 September, 2023. Either this should be synchronized with the above URL
-    # regularly or permanently removed. It causes a ton of confusion as described in #1129.
-    # "https://nim-lang.org/nimble/packages.json"
+    "https://nim-lang.org/nimble/packages.json"
   ])
 
 proc clear(pkgList: var PackageList) =


### PR DESCRIPTION
Recently, there used to be two Nimble package lists present. 
One was hosted on GitHub and the other on the [Nim website](https://nim-lang.org). However, the latter was serving stale data for a good few years at this point due to basically nobody remembering that it existed.
After a ton of confusion from multiple people (see #1139, #1129, #1149, #1144, #1084, there's probably many more), the cause was found and the out-of-sync list was removed.

However, @PMunch and @ringabout have managed to keep the Nim website list in sync now, and that's good because GitHub's connections can be very erratic for many people (myself included). This PR reintroduces the Nim website packages list.

Please do not ask me why I wrote an entire essay on a few lines of code changed. I was terribly, *terribly* bored.

TL;DR: this PR re-adds an old packages list back, now that it's in synchronization and no longer serves stale data.
