### PR TITLE
Add forge aliases for different Git forge providers

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -21,7 +21,7 @@ import nimblepkg/packageinfotypes, nimblepkg/packageinfo, nimblepkg/version,
        nimblepkg/nimscriptwrapper, nimblepkg/developfile, nimblepkg/paths,
        nimblepkg/nimbledatafile, nimblepkg/packagemetadatafile,
        nimblepkg/displaymessages, nimblepkg/sha1hashes, nimblepkg/syncfile,
-       nimblepkg/deps, nimblepkg/nimblesat
+       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/forge_aliases
 
 const
   nimblePathsFileName* = "nimble.paths"
@@ -792,7 +792,7 @@ proc install(packages: seq[PkgTuple], options: Options,
   ##   True if we are installing dependencies from the lock file.
   ## ``preferredPackages``
   ##   Prefer these packages when performing `processFreeDependencies`
-
+  
   if packages == @[]:
     let currentDir = getCurrentDir()
     if currentDir.developFileExists:
@@ -804,15 +804,31 @@ proc install(packages: seq[PkgTuple], options: Options,
                             preferredPackages = preferredPackages)
   else:
     # Install each package.
+    
     for pv in packages:
-      let (meth, url, metadata) = getDownloadInfo(pv, options, doPrompt)
+      let isAlias = isForgeAlias(pv.name)
+
+      let (meth, url, metadata) = 
+        if not isAlias:
+          getDownloadInfo(pv, options, doPrompt)
+        else:
+          (git, "", initTable[string, string]())
+
       let subdir = metadata.getOrDefault("subdir")
       var downloadPath = ""
       if options.useSatSolver and subdir == "": #Ignore the cache if subdir is set
           downloadPath =  getCacheDownloadDir(url, pv.ver, options)
+
       let (downloadDir, downloadVersion, vcsRevision) =
-         downloadPkg(url, pv.ver, meth, subdir, options,
+        if not isAlias:
+          downloadPkg(url, pv.ver, meth, subdir, options,
                     downloadPath = downloadPath, vcsRevision = notSetSha1Hash)
+        else:
+          downloadPkg(
+            newForge(pv.name).expand(),
+            pv.ver, meth, subdir, options,
+            downloadPath = downloadPath, vcsRevision = notSetSha1Hash
+          )
       try:
         var opt = options
         if pv.name.isNim:
@@ -872,7 +888,6 @@ proc addPackages(packages: seq[PkgTuple], options: var Options) =
     appendStr: string
     addedPkgs: seq[string]
 
-  # If the package doesn't exist, raise an error.
   for apkg in packages:
     var 
       exists = false
@@ -881,21 +896,24 @@ proc addPackages(packages: seq[PkgTuple], options: var Options) =
     let 
       pUri = parseUri(apkg.name)
       isValidUrl = pUri.hostname != "" # TODO: use a better way to detect a potential URL
-
-    for pkg in pkgList:
-      if pkg.name == apkg.name:
-        exists = true
-        version = case apkg.ver.kind
-        of verAny:
-          ""
-        else:
-          $apkg.ver
-        break
+      isValidAlias = isForgeAlias(apkg.name)
     
-    if not exists and not isValidUrl:
-      raise nimbleError(
-        "No such package \"$1\" was found in the package list." % [apkg.name]
-      )
+    if not isValidAlias:
+      for pkg in pkgList:
+        if pkg.name == apkg.name:
+          exists = true
+          version = case apkg.ver.kind
+          of verAny:
+            ""
+          else:
+            $apkg.ver
+          break
+    
+      if not exists and
+        not isValidUrl:
+        raise nimbleError(
+          "No such package \"$1\" was found in the package list." % [apkg.name]
+        )
     
     var doAppend = true
     for dep in deps:

--- a/src/nimblepkg/forge_aliases.nim
+++ b/src/nimblepkg/forge_aliases.nim
@@ -1,0 +1,120 @@
+# Copyright (C) Dominik Picheta. All rights reserved.
+# BSD License. Look at license.txt for more info.
+
+import std/strutils
+import common
+
+type
+  ForgeKind* = enum
+    fgGitHub
+    fgGitLab
+    fgSourceHut
+    fgCodeberg
+
+  Forge* = ref object
+    case kind*: ForgeKind
+    of fgGitHub:
+      ghUsername*, ghRepo*: string
+    of fgGitLab:
+      glUsername*, glRepo*: string
+    of fgSourceHut:
+      shUsername*, shRepo*: string
+    of fgCodeberg:
+    cbUsername*, cbRepo*: string
+
+proc expand*(alias: Forge): string {.inline.} =
+  var expanded = "https://" # add an option to use http instead?
+
+  case alias.kind
+  of fgGitHub:
+    expanded &= "github.com/" & alias.ghUsername & '/' & alias.ghRepo
+  of fgGitLab:
+    expanded &= "gitlab.com/" & alias.glUsername & '/' & alias.glRepo
+  of fgSourceHut:
+    expanded &= "git.sr.ht/" & alias.shUsername & '/' & alias.shRepo
+  of fgCodeberg:
+    expanded &= "codeberg.org/" & alias.cbRepo & '/' & alias.cbRepo
+
+  expanded
+
+proc isForgeAlias*(value: string): bool {.inline.} =
+  let splitted = value.split(':')
+
+  splitted.len == 2
+
+proc parseForgeKind*(value: string): ForgeKind {.inline.} =
+  let splitted = value.split(':')
+  
+  case splitted[0].toLowerAscii()
+  of "github", "gh": return fgGitHub
+  of "gitlab", "gl": return fgGitLab
+  of "sourcehut", "srht", "shart": return fgSourceHut
+  of "codeberg", "cb", "cberg": return fgCodeberg
+  else:
+    raise nimbleError("Invalid forge alias name: " & value[0])
+
+proc parseGenericAlias*(value: string, appendTilde: bool = false): tuple[username, repo: string] {.inline.} =
+  let splitted = value.split(':')
+
+  if splitted[1].len < 1:
+    raise nimbleError(
+      "Invalid forge alias format; correct format:" & 
+      "\n\t<alias>:<username>/<repository>\n" &
+      "     ^^^^^"
+    )
+
+  let secondSplit = splitted[1].split('/')
+
+  if secondSplit.len < 2:
+    raise nimbleError(
+      "Invalid forge alias format; correct format:" & 
+      "\n\t<alias>:<username>/<repository>\n" &
+      "                        ^^^^^^^^^^"
+    )
+
+  let
+    username = block:
+      var name = secondSplit[0]
+
+      if name.len < 1:
+        raise nimbleError("No username provided in forge alias: " & value)
+
+      if appendTilde and not name.startsWith('~'):
+        name = '~' & name
+      
+      name
+
+    repository = secondSplit[1]
+
+  (username: username, repo: repository)
+
+proc newForge*(value: string): Forge {.inline.} =
+  let
+    kind = parseForgeKind(value)
+    generic = parseGenericAlias(value, kind == fgSourceHut)
+
+  case kind
+  of fgGitHub:
+    return Forge(
+      kind: fgGitHub,
+      ghUsername: generic.username,
+      ghRepo: generic.repo
+    )
+  of fgGitLab:
+    return Forge(
+      kind: fgGitLab,
+      glUsername: generic.username,
+      glRepo: generic.repo
+    )
+  of fgSourceHut:
+    return Forge(
+      kind: fgSourceHut,
+      shUsername: generic.username,
+      shRepo: generic.repo
+    )
+  of fgCodeberg:
+    return Forge(
+      kind: fgCodeberg,
+      cbUsername: generic.username,
+      cbRepo: generic.repo
+    )

--- a/tests/tforgeparser.nim
+++ b/tests/tforgeparser.nim
@@ -1,0 +1,40 @@
+# Copyright (C) Dominik Picheta. All rights reserved.
+# BSD License. Look at license.txt for more info.
+
+{.used.}
+import std/[unittest, os]
+import nimblepkg/forge_aliases
+
+let 
+  gh = "gh:xTrayambak/testing"
+  srht = "srht:~abc/xyz"
+  berg = "codeberg:lorem/ipsum"
+  gl = "gitlab:door/sit"
+
+suite "forge aliases":
+  test "can parse alias kinds":
+    assert parseForgeKind(gh) == fgGitHub
+    assert parseForgeKind(srht) == fgSourceHut
+    assert parseForgeKind(berg) == fgCodeberg
+    assert parseForgeKind(gl) == fgGitLab
+
+  test "can parse generically":
+    let
+      pgh = parseGenericAlias(gh)
+      psrht = parseGenericAlias(srht, appendTilde = true)
+      pberg = parseGenericAlias(berg)
+      pgl = parseGenericAlias(gl)
+
+    assert pgh.username == "xTrayambak"
+    assert psrht.username == "~abc"
+    assert pberg.username == "lorem"
+    assert pgl.username == "door"
+
+    assert pgh.repo == "testing"
+    assert psrht.repo == "xyz"
+    assert pberg.repo == "ipsum"
+    assert pgl.repo == "sit"
+
+  test "can handle sourcehut tildes":
+    let psrht = parseGenericAlias("srht:abc/xyz", appendTilde = true)
+    assert psrht.username == "~abc"


### PR DESCRIPTION
This PR adds "forge aliases" - they're an easy way to avoid writing out full URLs for packages that aren't on the Nimble index. \
They work similarly to how Nix's system works.

Here's a few examples:
```
$ nimble install gh:xTrayambak/librng
$ nimble install srht:bptato/chame
```

It also handles special "quirks" in a forge (eg., SourceHut adds a tilde in front of the username, so this handles it if the user didn't add it themselves) \
I've written a few tests for the alias "parser" as well. It works with the `install` and `add` commands, and as a result also works fine if you add the alias inside your
Nimble file like this:
```
# Package

version       = "0.1.0"
author        = "Lorem Ipsum"
description   = "Lorem Ipsum Door Sit"
license       = "MIT"
bin           = @["lorem"]

# Dependencies

requires "nim >= 2.0.0"
requires "gh:xTrayambak/librng"
requires "srht:bptato/chame"
requires "srht:~user/repository"
```
Please let me know if I missed something out or if I should add something else to this.
