### PR TITLE
Be less ambiguous when a project isn't under a VCS like Git or Mercurial

### DIFF
--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -347,14 +347,14 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
   ## This version uses a cache stored in ``options``, so calling it multiple
   ## times on the same ``nf`` shouldn't require re-evaluation of the Nimble
   ## file.
-
+  
   assert fileExists(nf)
 
   # Check the cache.
   if options.pkgInfoCache.hasKey(nf):
     pkgInfo = options.pkgInfoCache[nf]
     return
-
+  
   pkgInfo = initPackageInfo(options, nf)
   pkgInfo.isLink = not nf.startsWith(options.getPkgsDir)
 
@@ -397,7 +397,13 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
     pkgInfo.metaData.specialVersions.incl pkgInfo.basicInfo.version
     # If the `fileDir` is a VCS repository we can get some of the package meta
     # data from it.
-    pkgInfo.metaData.vcsRevision = getVcsRevision(fileDir)
+    try:
+      pkgInfo.metaData.vcsRevision = getVcsRevision(fileDir)
+    except CatchableError:
+      raise nimbleError(
+        msg = "Failed to get VCS revision of your project!",
+        hint = "Try making a commit to your project if you haven't made one yet."
+      )
 
     case getVcsType(fileDir)
       of vcsTypeGit: pkgInfo.metaData.downloadMethod = DownloadMethod.git

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -347,14 +347,12 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
   ## This version uses a cache stored in ``options``, so calling it multiple
   ## times on the same ``nf`` shouldn't require re-evaluation of the Nimble
   ## file.
-  
   assert fileExists(nf)
 
   # Check the cache.
   if options.pkgInfoCache.hasKey(nf):
     pkgInfo = options.pkgInfoCache[nf]
     return
-  
   pkgInfo = initPackageInfo(options, nf)
   pkgInfo.isLink = not nf.startsWith(options.getPkgsDir)
 

--- a/src/nimblepkg/syncfile.nim
+++ b/src/nimblepkg/syncfile.nim
@@ -48,7 +48,7 @@ proc getSyncFilePath(pkgInfo: PackageInfo): Path =
     raise nimbleError(
       msg  = "Sync file require current working directory to be under some " &
              "supported type of version control.",
-      hint = "Put package's working directory under version control.")
+      hint = "Put package's working directory under version control and create a commit to continue.")
 
   return vcsSpecialDirPath / (pkgInfo.basicInfo.name & syncFileExt).Path
 


### PR DESCRIPTION
This PR fixes #1180 by:
1) Fixing the first hint to tell the user to put the package's working directory under version control AND make a commit.
2) If they still choose to ignore it and just put the package's working directory under version control without making a commit, the subsequent errors will hint at the user to make a commit.
