### PR TITLE
Improves nim installation by using csources (same as atlas)

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -21,7 +21,7 @@ import nimblepkg/packageinfotypes, nimblepkg/packageinfo, nimblepkg/version,
        nimblepkg/nimscriptwrapper, nimblepkg/developfile, nimblepkg/paths,
        nimblepkg/nimbledatafile, nimblepkg/packagemetadatafile,
        nimblepkg/displaymessages, nimblepkg/sha1hashes, nimblepkg/syncfile,
-       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/forge_aliases
+       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/forge_aliases, nimblepkg/nimenv
 
 const
   nimblePathsFileName* = "nimble.paths"
@@ -754,124 +754,6 @@ proc processLockedDependencies(pkgInfo: PackageInfo, options: Options):
 
   return res.toHashSet
 
-when defined(windows):
-  const
-    BatchFile = """
-  @echo off
-  set PATH="$1";%PATH%
-  """
-else:
-  const
-    ShellFile = "export PATH=$1:$$PATH\n"
-
-const ActivationFile = 
-  when defined(windows): "activate.bat" else: "activate.sh"
-
-proc infoAboutActivation(nimDest, nimVersion: string) =
-  when defined(windows):
-    echo "Info ", nimDest, "installed; activate with 'nim-" & nimVersion & "\\activate.bat'"
-    # info c, nimDest, "RUN\nnim-" & nimVersion & "\\activate.bat"
-  else:
-    echo "Info ", nimDest, "installed; activate with 'source nim-" & nimVersion & "/activate.sh'"
-    # info c, nimDest, "RUN\nsource nim-" & nimVersion & "/activate.sh"
-
-import std/strscans
-proc compileNim2*(nimDest: string, v: VersionRange, keepCsources: bool) =
-
-  template exec(command: string) =
-    let cmd = command # eval once
-    if os.execShellCmd(cmd) != 0:
-      display("Error", "Failed to execute: $1" % cmd, Error, HighPriority)
-      return
-  let nimVersion = v.getNimVersion()
-  let workspace = nimDest.parentDir()
-  if dirExists(workspace / nimDest):
-    if not fileExists(nimDest / ActivationFile):
-      display("Info", &"Directory {nimDest} already exists; remove or rename and try again")
-    else:
-      infoAboutActivation nimDest, $nimVersion
-    return
-
-  var major, minor, patch: int
-  if not nimVersion.isSpecial: 
-    if not scanf($nimVersion, "$i.$i.$i", major, minor, patch):
-      display("Error", "cannot parse version requirement", Error)
-      return
-  let csourcesVersion =
-    #TODO We could test special against the special versionn-x branch to get the right csources
-    if nimVersion.isSpecial or (major == 1 and minor >= 9) or major >= 2:
-      # already uses csources_v2
-      "csources_v2"
-    elif major == 0:
-      "csources" # has some chance of working
-    else:
-      "csources_v1"
-  cd workspace:
-    echo "Entering CSOURCES", csourcesVersion, " exists ", dirExists(csourcesVersion)
-    if not dirExists(csourcesVersion):
-      exec "git clone https://github.com/nim-lang/" & csourcesVersion
-
-  cd workspace / csourcesVersion:
-    when defined(windows):
-      exec "build.bat"
-    else:
-      let makeExe = findExe("make")
-      if makeExe.len == 0:
-        exec "sh build.sh"
-      else:
-        exec "make"
-  let nimExe0 = ".." / csourcesVersion / "bin" / "nim".addFileExt(ExeExt)
-  cd nimDest:
-    let nimExe = "bin" / "nim".addFileExt(ExeExt)
-    copyFileWithPermissions nimExe0, nimExe
-    exec nimExe & " c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch"
-    let kochExe = when defined(windows): "koch.exe" else: "./koch"
-    exec kochExe & " boot -d:release --skipUserCfg --skipParentCfg --hints:off"
-    exec kochExe & " tools --skipUserCfg --skipParentCfg --hints:off"
-    # unless --keep is used delete the csources because it takes up about 2GB and
-    # is not necessary afterwards:
-    if not keepCsources:
-      removeDir workspace / csourcesVersion / "c_code"
-    let pathEntry = workspace / nimDest / "bin"
-    when defined(windows):
-      writeFile "activate.bat", BatchFile % pathEntry.replace('/', '\\')
-    else:
-      writeFile "activate.sh", ShellFile % pathEntry
-    infoAboutActivation nimDest, $nimVersion
-
-proc compileNim(realDir: string, v: VersionRange) =
-  writeStackTrace()
-  compileNim2(realDir, v, true)
-  return
-  # quit(&"THIS TESTS IS COMPILING NIIIIIIM {realDir}", 1)
-  # let command = when defined(windows): "build_all.bat" else: "./build_all.sh"
-  # cd realDir:
-  #   display("Info:", "compiling nim in $1" % realDir, priority = HighPriority)
-  #   tryDoCmdEx(command)
-
-proc useNimFromDir(options: var Options, realDir: string, v: VersionRange, tryCompiling = false) =
-  const binaryName = when defined(windows): "nim.exe" else: "nim"
-
-  let
-    nim = realDir / "bin" / binaryName
-    fileExists = fileExists(options.nimBin)
-
-  if not fileExists(nim):
-    if tryCompiling and options.prompt("Develop version of nim was found but it is not compiled. Compile it now?"):
-      compileNim(realDir, v)
-    else:
-      raise nimbleError("Trying to use nim from $1 " % realDir,
-                        "If you are using develop mode nim make sure to compile it.")
-
-  options.nimBin = nim
-  let separator = when defined(windows): ";" else: ":"
-
-  putEnv("PATH", realDir / "bin" & separator & getEnv("PATH"))
-  if fileExists:
-    display("Info:", "switching to $1 for compilation" % options.nim, priority = HighPriority)
-  else:
-    display("Info:", "using $1 for compilation" % options.nim, priority = HighPriority)
-
 proc install(packages: seq[PkgTuple], options: Options,
              doPrompt, first, fromLockFile: bool,
              preferredPackages: seq[PackageInfo] = @[]): PackageDependenciesInfo =
@@ -923,7 +805,7 @@ proc install(packages: seq[PkgTuple], options: Options,
       try:
         var opt = options
         if pv.name.isNim:
-          compileNim(downloadDir, pv.ver)
+          compileNim(opt, downloadDir, pv.ver)
           opt.useNimFromDir(downloadDir, pv.ver, true)
         result = installFromDir(downloadDir, pv.ver, opt, url,
                                 first, fromLockFile, vcsRevision,
@@ -2499,11 +2381,10 @@ proc setNimBin*(options: var Options) =
         if isInstalled(name, dep, options):
           options.useNimFromDir(getDependencyDir(name, dep, options), v)
         elif not options.offline:
-          #HERE
           let depsOnly = options.depsOnly
           options.depsOnly = false
           let downloadResult = downloadDependency(name, dep, options, false)
-          compileNim(downloadResult.downloadDir, v)
+          compileNim(options, downloadResult.downloadDir, v)
           options.useNimFromDir(downloadResult.downloadDir, v)
           let pkgInfo = installDependency(initTable[string, LockFileDep](), downloadResult, options, @[])
           options.useNimFromDir(pkgInfo.getRealDir, v)

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -105,22 +105,22 @@ proc hasVersion*(packagesVersions: Table[string, PackageVersions], name: string,
         return true
   false
 
-proc getNimVersion*(pvs: seq[PkgTuple]): Version =
-  proc getVersion(ver: VersionRange): Version =
-    case ver.kind:
-    of verLater, verEarlier, verEqLater, verEqEarlier, verEq:
-      ver.ver
-    of verSpecial:
-      ver.spe
-    of verIntersect, verTilde, verCaret:
-      getVersion(ver.verILeft)
-    of verAny:
-      newVersion "0.0.0"
+proc getNimVersion*(ver: VersionRange): Version =
+  case ver.kind:
+  of verLater, verEarlier, verEqLater, verEqEarlier, verEq:
+    ver.ver
+  of verSpecial:
+    ver.spe
+  of verIntersect, verTilde, verCaret:
+    getNimVersion(ver.verILeft)
+  of verAny:
+    newVersion "0.0.0"
 
+proc getNimVersion*(pvs: seq[PkgTuple]): Version =
   result = newVersion("0.0.0")
   for pv in pvs:
     if pv.name == "nim":
-      result = getVersion(pv.ver)
+      result = getNimVersion(pv.ver)
 
 proc findDependencyForDep(g: DepGraph; dep: string): int {.inline.} =
   assert g.packageToDependency.hasKey(dep), dep & " not found"

--- a/src/nimblepkg/nimenv.nim
+++ b/src/nimblepkg/nimenv.nim
@@ -77,6 +77,8 @@ proc compileNim*(options: Options, nimDest: string, v: VersionRange) =
     if not keepCsources:
       removeDir workspace / csourcesVersion / "c_code"
     let pathEntry = workspace / nimDest / "bin"
+    #remove nimble so it doesnt interfer with the current one:
+    removeFile "bin" / "nimble".addFileExt(ExeExt)
     when defined(windows):
       writeFile "activate.bat", BatchFile % pathEntry.replace('/', '\\')
     else:

--- a/src/nimblepkg/nimenv.nim
+++ b/src/nimblepkg/nimenv.nim
@@ -16,9 +16,9 @@ const ActivationFile =
 
 proc infoAboutActivation(nimDest, nimVersion: string) =
   when defined(windows):
-    display("Info", nimDest, "installed; activate with 'nim-" & nimVersion & "\\activate.bat'")
+    display("Info", nimDest & "installed; activate with 'nim-" & nimVersion & "activate.bat'")
   else:
-    display("Info", nimDest, "installed; activate with 'source nim-" & nimVersion & "/activate.sh'")
+    display("Info", nimDest & "installed; activate with 'source nim-" & nimVersion & "activate.sh'")
 
 proc compileNim*(options: Options, nimDest: string, v: VersionRange) =
   let keepCsources = options.useSatSolver #SAT Solver has a cache instead of a temp dir for downloads

--- a/src/nimblepkg/nimenv.nim
+++ b/src/nimblepkg/nimenv.nim
@@ -16,11 +16,9 @@ const ActivationFile =
 
 proc infoAboutActivation(nimDest, nimVersion: string) =
   when defined(windows):
-    echo "Info ", nimDest, "installed; activate with 'nim-" & nimVersion & "\\activate.bat'"
-    # info c, nimDest, "RUN\nnim-" & nimVersion & "\\activate.bat"
+    display("Info", nimDest, "installed; activate with 'nim-" & nimVersion & "\\activate.bat'")
   else:
-    echo "Info ", nimDest, "installed; activate with 'source nim-" & nimVersion & "/activate.sh'"
-    # info c, nimDest, "RUN\nsource nim-" & nimVersion & "/activate.sh"
+    display("Info", nimDest, "installed; activate with 'source nim-" & nimVersion & "/activate.sh'")
 
 proc compileNim*(options: Options, nimDest: string, v: VersionRange) =
   let keepCsources = options.useSatSolver #SAT Solver has a cache instead of a temp dir for downloads

--- a/src/nimblepkg/nimenv.nim
+++ b/src/nimblepkg/nimenv.nim
@@ -1,0 +1,110 @@
+import std/[strscans, os, strutils, strformat]
+import version, nimblesat, cli, common, options
+
+when defined(windows):
+  const
+    BatchFile = """
+  @echo off
+  set PATH="$1";%PATH%
+  """
+else:
+  const
+    ShellFile = "export PATH=$1:$$PATH\n"
+
+const ActivationFile = 
+  when defined(windows): "activate.bat" else: "activate.sh"
+
+proc infoAboutActivation(nimDest, nimVersion: string) =
+  when defined(windows):
+    echo "Info ", nimDest, "installed; activate with 'nim-" & nimVersion & "\\activate.bat'"
+    # info c, nimDest, "RUN\nnim-" & nimVersion & "\\activate.bat"
+  else:
+    echo "Info ", nimDest, "installed; activate with 'source nim-" & nimVersion & "/activate.sh'"
+    # info c, nimDest, "RUN\nsource nim-" & nimVersion & "/activate.sh"
+
+proc compileNim*(options: Options, nimDest: string, v: VersionRange) =
+  let keepCsources = options.useSatSolver #SAT Solver has a cache instead of a temp dir for downloads
+  template exec(command: string) =
+    let cmd = command # eval once
+    if os.execShellCmd(cmd) != 0:
+      display("Error", "Failed to execute: $1" % cmd, Error, HighPriority)
+      return
+  let nimVersion = v.getNimVersion()
+  let workspace = nimDest.parentDir()
+  if dirExists(workspace / nimDest):
+    if not fileExists(nimDest / ActivationFile):
+      display("Info", &"Directory {nimDest} already exists; remove or rename and try again")
+    else:
+      infoAboutActivation nimDest, $nimVersion
+    return
+
+  var major, minor, patch: int
+  if not nimVersion.isSpecial: 
+    if not scanf($nimVersion, "$i.$i.$i", major, minor, patch):
+      display("Error", "cannot parse version requirement", Error)
+      return
+  let csourcesVersion =
+    #TODO We could test special against the special versionn-x branch to get the right csources
+    if nimVersion.isSpecial or (major == 1 and minor >= 9) or major >= 2:
+      # already uses csources_v2
+      "csources_v2"
+    elif major == 0:
+      "csources" # has some chance of working
+    else:
+      "csources_v1"
+  cd workspace:
+    echo "Entering CSOURCES", csourcesVersion, " exists ", dirExists(csourcesVersion)
+    if not dirExists(csourcesVersion):
+      exec "git clone https://github.com/nim-lang/" & csourcesVersion
+
+  cd workspace / csourcesVersion:
+    when defined(windows):
+      exec "build.bat"
+    else:
+      let makeExe = findExe("make")
+      if makeExe.len == 0:
+        exec "sh build.sh"
+      else:
+        exec "make"
+  let nimExe0 = ".." / csourcesVersion / "bin" / "nim".addFileExt(ExeExt)
+  cd nimDest:
+    let nimExe = "bin" / "nim".addFileExt(ExeExt)
+    copyFileWithPermissions nimExe0, nimExe
+    exec nimExe & " c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch"
+    let kochExe = when defined(windows): "koch.exe" else: "./koch"
+    exec kochExe & " boot -d:release --skipUserCfg --skipParentCfg --hints:off"
+    exec kochExe & " tools --skipUserCfg --skipParentCfg --hints:off"
+    # unless --keep is used delete the csources because it takes up about 2GB and
+    # is not necessary afterwards:
+    if not keepCsources:
+      removeDir workspace / csourcesVersion / "c_code"
+    let pathEntry = workspace / nimDest / "bin"
+    when defined(windows):
+      writeFile "activate.bat", BatchFile % pathEntry.replace('/', '\\')
+    else:
+      writeFile "activate.sh", ShellFile % pathEntry
+    infoAboutActivation nimDest, $nimVersion
+
+
+proc useNimFromDir*(options: var Options, realDir: string, v: VersionRange, tryCompiling = false) =
+  const binaryName = when defined(windows): "nim.exe" else: "nim"
+
+  let
+    nim = realDir / "bin" / binaryName
+    fileExists = fileExists(options.nimBin)
+
+  if not fileExists(nim):
+    if tryCompiling and options.prompt("Develop version of nim was found but it is not compiled. Compile it now?"):
+      compileNim(options, realDir, v)
+    else:
+      raise nimbleError("Trying to use nim from $1 " % realDir,
+                        "If you are using develop mode nim make sure to compile it.")
+
+  options.nimBin = nim
+  let separator = when defined(windows): ";" else: ":"
+
+  putEnv("PATH", realDir / "bin" & separator & getEnv("PATH"))
+  if fileExists:
+    display("Info:", "switching to $1 for compilation" % options.nim, priority = HighPriority)
+  else:
+    display("Info:", "using $1 for compilation" % options.nim, priority = HighPriority)

--- a/tests/nimnimble/nim1.6.20/nim1620.nimble
+++ b/tests/nimnimble/nim1.6.20/nim1620.nimble
@@ -1,0 +1,12 @@
+# Package
+
+version       = "0.1.0"
+author        = "jmgomez"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+
+# Dependencies
+
+requires "nim == 1.6.20"

--- a/tests/nimnimble/nim1.6.20/src/nim1620.nim
+++ b/tests/nimnimble/nim1.6.20/src/nim1620.nim
@@ -1,0 +1,7 @@
+# This is just an example to get you started. A typical library package
+# exports the main API in this file. Note that you cannot rename this file
+# but you can remove it if you wish.
+
+proc add*(x, y: int): int =
+  ## Adds two numbers together.
+  return x + y

--- a/tests/nimnimble/nim1.6.20/src/nim1620/submodule.nim
+++ b/tests/nimnimble/nim1.6.20/src/nim1620/submodule.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. Users of your library will
+# import this file by writing ``import nim1620/submodule``. Feel free to rename or
+# remove this file altogether. You may create additional modules alongside
+# this file as required.
+
+type
+  Submodule* = object
+    name*: string
+
+proc initSubmodule*(): Submodule =
+  ## Initialises a new ``Submodule`` object.
+  Submodule(name: "Anonymous")

--- a/tests/nimnimble/nim1.6.20/tests/test1.nim
+++ b/tests/nimnimble/nim1.6.20/tests/test1.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. You may wish to put all of your
+# tests into a single file, or separate them into multiple `test1`, `test2`
+# etc. files (better names are recommended, just make sure the name starts with
+# the letter 't').
+#
+# To run these tests, simply execute `nimble test`.
+
+import unittest
+
+import nim1620
+test "can add":
+  check add(5, 5) == 10

--- a/tests/nimnimble/nim2.0.4/nim204.nimble
+++ b/tests/nimnimble/nim2.0.4/nim204.nimble
@@ -1,0 +1,12 @@
+# Package
+
+version       = "0.1.0"
+author        = "jmgomez"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+
+# Dependencies
+
+requires "nim == 2.0.4"

--- a/tests/nimnimble/nim2.0.4/src/nim204.nim
+++ b/tests/nimnimble/nim2.0.4/src/nim204.nim
@@ -1,0 +1,7 @@
+# This is just an example to get you started. A typical library package
+# exports the main API in this file. Note that you cannot rename this file
+# but you can remove it if you wish.
+
+proc add*(x, y: int): int =
+  ## Adds two numbers together.
+  return x + y

--- a/tests/nimnimble/nim2.0.4/src/nim204/submodule.nim
+++ b/tests/nimnimble/nim2.0.4/src/nim204/submodule.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. Users of your library will
+# import this file by writing ``import nim204/submodule``. Feel free to rename or
+# remove this file altogether. You may create additional modules alongside
+# this file as required.
+
+type
+  Submodule* = object
+    name*: string
+
+proc initSubmodule*(): Submodule =
+  ## Initialises a new ``Submodule`` object.
+  Submodule(name: "Anonymous")

--- a/tests/nimnimble/nim2.0.4/tests/test1.nim
+++ b/tests/nimnimble/nim2.0.4/tests/test1.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. You may wish to put all of your
+# tests into a single file, or separate them into multiple `test1`, `test2`
+# etc. files (better names are recommended, just make sure the name starts with
+# the letter 't').
+#
+# To run these tests, simply execute `nimble test`.
+
+import unittest
+
+import nim204
+test "can add":
+  check add(5, 5) == 10

--- a/tests/nimnimble/nimdevel/nimdevel.nimble
+++ b/tests/nimnimble/nimdevel/nimdevel.nimble
@@ -1,0 +1,12 @@
+# Package
+
+version       = "0.1.0"
+author        = "jmgomez"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+
+# Dependencies
+
+requires "nim#devel"

--- a/tests/nimnimble/nimdevel/src/nimdevel.nim
+++ b/tests/nimnimble/nimdevel/src/nimdevel.nim
@@ -1,0 +1,7 @@
+# This is just an example to get you started. A typical library package
+# exports the main API in this file. Note that you cannot rename this file
+# but you can remove it if you wish.
+
+proc add*(x, y: int): int =
+  ## Adds two numbers together.
+  return x + y

--- a/tests/nimnimble/nimdevel/src/nimdevel/submodule.nim
+++ b/tests/nimnimble/nimdevel/src/nimdevel/submodule.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. Users of your library will
+# import this file by writing ``import nimdevel/submodule``. Feel free to rename or
+# remove this file altogether. You may create additional modules alongside
+# this file as required.
+
+type
+  Submodule* = object
+    name*: string
+
+proc initSubmodule*(): Submodule =
+  ## Initialises a new ``Submodule`` object.
+  Submodule(name: "Anonymous")

--- a/tests/nimnimble/nimdevel/tests/test1.nim
+++ b/tests/nimnimble/nimdevel/tests/test1.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. You may wish to put all of your
+# tests into a single file, or separate them into multiple `test1`, `test2`
+# etc. files (better names are recommended, just make sure the name starts with
+# the letter 't').
+#
+# To run these tests, simply execute `nimble test`.
+
+import unittest
+
+import nimdevel
+test "can add":
+  check add(5, 5) == 10

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -29,6 +29,7 @@ import ttwobinaryversions
 import tuninstall
 import ttaskdeps
 import tsat
+import tniminstall
 # nonim tests are very slow and (often) break the CI.
 
 # import tnonim

--- a/tests/tniminstall.nim
+++ b/tests/tniminstall.nim
@@ -1,7 +1,7 @@
 
 {.used.}
 
-import unittest, os, osproc, strutils, sequtils, strscans
+import unittest, os, strutils, sequtils, strscans
 import testscommon
 from nimblepkg/common import cd
 
@@ -26,7 +26,7 @@ suite "Nim install":
         cd nimVerDir:
           let nimVer = nimVerDir.replace("nim", "")
           echo "Checking version ", nimVer
-          let (output, exitCode) = execNimble("install", "-l")
+          let (_, exitCode) = execNimble("install", "-l")
           let pkgPath = getCurrentDir() / "nimbledeps" / "pkgs2"
           check exitCode == QuitSuccess
           check walkDir(pkgPath).toSeq.anyIt(it[1].isNimPkgVer(nimVer))      

--- a/tests/tniminstall.nim
+++ b/tests/tniminstall.nim
@@ -1,0 +1,32 @@
+
+{.used.}
+
+import unittest, os, osproc, strutils, sequtils, strscans
+import testscommon
+from nimblepkg/common import cd
+
+proc isNimPkgVer(folder: string, ver: string): bool = 
+  let name = folder.split("-")
+  result = name.len == 3 and name[1].contains(ver)
+  echo "Checking ", folder, " for ", ver, " result: ", result
+  if ver == "devel":
+  #We know devel is bigger than 2.1 and it should be an odd number (notice what we test here is actually the #)
+    var major, minor, patch: int 
+    if scanf(name[1], "$i.$i.$i", major, minor, patch):
+      return major >= 2 and minor >= 1 and minor mod 2 == 1
+    else: return false
+
+     
+  
+
+suite "Nim install":
+  test "Should be able to install different Nim versions":
+    cd "nimnimble":
+      for nimVerDir in ["nim1.6.20", "nim2.0.4", "nimdevel"]:
+        cd nimVerDir:
+          let nimVer = nimVerDir.replace("nim", "")
+          echo "Checking version ", nimVer
+          let (output, exitCode) = execNimble("install", "-l")
+          let pkgPath = getCurrentDir() / "nimbledeps" / "pkgs2"
+          check exitCode == QuitSuccess
+          check walkDir(pkgPath).toSeq.anyIt(it[1].isNimPkgVer(nimVer))      


### PR DESCRIPTION
Notice when SAT is enabled, csources is stored in the cache. 
Missing:
- [x] Proper reporting
- [x] Handle special versions (assume csources_2?). We could have special cases for #version-x
- [x] Refactor to another file (nimble.nim is crazy big already)
- [x] Test cases
- [x] Fixes an issue where the packageCache wasnt being shared in local mode
- [x] Remove nimble from nim compilation Fixes #1175