### PR TITLE
Allow local paths to be used for package specification.

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -581,6 +581,9 @@ proc getDownloadInfo*(pv: PkgTuple, options: Options,
   if pv.name.isURL:
     let (url, metadata) = getUrlData(pv.name)
     return (checkUrlType(url), url, metadata)
+  elif dirExists(pv.name):
+    let (url, metadata) = getUrlData("file://" & pv.name)
+    return (checkUrlType(url), url, metadata)
   else:
     var pkg = initPackage()
     if getPackage(pv.name, options, pkg, ignorePackageCache):

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -582,7 +582,7 @@ proc getDownloadInfo*(pv: PkgTuple, options: Options,
     let (url, metadata) = getUrlData(pv.name)
     return (checkUrlType(url), url, metadata)
   elif dirExists(pv.name):
-    let (url, metadata) = getUrlData("file://" & pv.name)
+    let (url, metadata) = getUrlData("file://" & expandFilename(pv.name))
     return (checkUrlType(url), url, metadata)
   else:
     var pkg = initPackage()

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -542,7 +542,7 @@ proc getDevelopDownloadDir*(url, subdir: string, options: Options): string =
   result =
     if options.action.path.isAbsolute:
       options.action.path / downloadDirName
-    elif uri.scheme == "file":
+    elif options.action.withDependencies and uri.scheme == "file":
       uri.path
     else:
       getCurrentDir() / options.action.path / downloadDirName

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -531,15 +531,19 @@ proc getDevelopDownloadDir*(url, subdir: string, options: Options): string =
   let url = url.removeTrailingSlash
   let subdir = subdir.removeTrailingSlash
 
+  let uri = parseUri(url)
+
   let downloadDirName =
     if subdir.len == 0:
-      parseUri(url).path.splitFile.name
+      uri.path.splitFile.name
     else:
       subdir.splitFile.name
 
   result =
     if options.action.path.isAbsolute:
       options.action.path / downloadDirName
+    elif uri.scheme == "file":
+      uri.path
     else:
       getCurrentDir() / options.action.path / downloadDirName
 


### PR DESCRIPTION
Same content as PR #1237. I reworked it because I accidentally committed an extra one.

## What this PR will allow to do

* Allow local packages to be specified using ordinary paths
* Deny local package cloning by specifying local path + `--withDependencies` when `nimble develop`.

This reduces confusion like #1134 and #1124.

## Case Study

### Install local package

```console
# before:
cd path/to/pkg && nimble install
nimble install file:///absolute/path/to/pkg

# after:
nimble install /absolute/path/to/pkg
nimble install relative/path/to/pkg
# + before
```

### Develop local package

```console
# before:
nimble develop file:///absolute/path/to/pkg # -> the pkg will be cloned into subdir

# after:
nimble develop path/to/pkg # -> the pkg will be cloned into subdir
nimble develop path/to/pkg --withDependencies # -> the pkg will NOT be cloned. nimble.develop points to original.
# + before
```

## Things to consider

Maybe we should have an option to clone local packages or not.