### PR TITLE
(fix) packageinfo: checkInstallFile now correctly compares files; fixes #1226

### DIFF
--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -411,7 +411,8 @@ proc checkInstallFile(pkgInfo: PackageInfo,
   for ignoreFile in pkgInfo.skipFiles:
     if ignoreFile.endswith("nimble"):
       raise nimbleError(ignoreFile & " must be installed.")
-    if samePaths(file, origDir / ignoreFile):
+
+    if file == absolutePath(ignoreFile):
       result = true
       break
 

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -411,7 +411,6 @@ proc checkInstallFile(pkgInfo: PackageInfo,
   for ignoreFile in pkgInfo.skipFiles:
     if ignoreFile.endswith("nimble"):
       raise nimbleError(ignoreFile & " must be installed.")
-
     if file == absolutePath(ignoreFile):
       result = true
       break


### PR DESCRIPTION
`checkInstallFile` incorrectly calls `samePath` to compare a file from the install list and a file from the ignore list. This PR just makes the function compare the file from the install list to the absolute path of the file from the ignore list. This fixes #1226