### PR TITLE
Improvenimdirselection

### DIFF
--- a/nimble.nimble
+++ b/nimble.nimble
@@ -12,6 +12,7 @@ installExt = @["nim"]
 # Dependencies
 
 requires "nim >= 0.13.0", "sat"
+# requires "nim < 2.0.6", "sat"
 requires "checksums"
 
 when defined(nimdistros):

--- a/src/nimblepkg/nimenv.nim
+++ b/src/nimblepkg/nimenv.nim
@@ -1,4 +1,4 @@
-import std/[strscans, os, strutils, strformat]
+import std/[strscans, os, osproc, strutils, strformat, options]
 import version, nimblesat, cli, common, options
 
 when defined(windows):
@@ -120,3 +120,13 @@ proc useNimFromDir*(options: var Options, realDir: string, v: VersionRange, tryC
     display("Info:", "switching to $1 for compilation" % options.nim, priority = HighPriority)
   else:
     display("Info:", "using $1 for compilation" % options.nim, priority = HighPriority)
+
+proc getNimVersionFromBin*(nimBin: string): Option[Version] =
+  let cmd = nimBin & " --version"
+  if nimBin.fileExists:
+    let info = execProcess(cmd)
+    var major, minor, patch: int
+    for line in info.splitLines:
+      if scanf(line, "Nim Compiler Version $i.$i.$i", major, minor, patch):
+          let ver = $major & "." & $minor & "." & $patch
+          return some newVersion(ver)


### PR DESCRIPTION
  ## returns the nim directory prioritizing the nimBin one if it satisfais the requirement of the project
  ## otherwise it returns the major version of the nim installed packages that satisfies the requirement of the project
  ## if no nim package satisfies the requirement of the project it returns the nimBin parent directory
  ## only used by the `nimble dump` command which is used to drive the lsp