### PR TITLE
Add `sponsor` command

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2101,12 +2101,7 @@ proc sponsor(options: Options) =
         displayInfo(pkg.name)
 
         for donation in pkg.donations:
-          let url = donation.constructDonationURL()
-          displayInfo(
-            "$1: $2 ($3)" % [
-              $donation.meth, donation.username, url
-            ]
-          )
+          displayInfo($donation)
 
         displayHint("To sponsor this library's developer, run `nimble sponsor " & pkg.name & '`')
         echo('\n')
@@ -2130,14 +2125,10 @@ proc sponsor(options: Options) =
         displayError("You can contact them directly to sponsor them in some other way instead.")
         return
 
-      for donation in pkg.donations:
-        let url = donation.constructDonationURL()
-        displayInfo(
-          "$1: $2 ($3)" % [
-            $donation.meth, donation.username, url
-          ]
-        )
+      for donationUrl in pkg.donations:
+        let url = $donationUrl
 
+        displayInfo(url)
         openDefaultBrowser(url)
       
       return

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -63,7 +63,7 @@ type
     actionInstall, actionSearch, actionList, actionBuild, actionPath,
     actionUninstall, actionCompile, actionDoc, actionCustom, actionTasks,
     actionDevelop, actionCheck, actionLock, actionRun, actionSync, actionSetup,
-    actionClean, actionDeps, actionShellEnv, actionShell, actionAdd
+    actionClean, actionDeps, actionShellEnv, actionShell, actionAdd, actionSponsor
 
   DevelopActionType* = enum
     datAdd, datRemoveByPath, datRemoveByName, datInclude, datExclude
@@ -108,6 +108,8 @@ type
       custRunFlags*: seq[string]
     of actionDeps:
       format*: string
+    of actionSponsor:
+      optionalPackage*: string
     of actionShellEnv, actionShell:
       discard
 
@@ -330,6 +332,8 @@ proc parseActionType*(action: string): ActionType =
     result = actionShell
   of "add":
     result = actionAdd
+  of "sponsor":
+    result = actionSponsor
   else:
     result = actionCustom
 
@@ -510,6 +514,8 @@ proc parseArgument*(key: string, result: var Options) =
     result.action.file = key
   of actionRun:
     result.setRunOptions(key, key, true)
+  of actionSponsor:
+    result.action.optionalPackage = key
   of actionCustom:
     result.action.arguments.add(key)
   else:

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -1,17 +1,12 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import sets, tables
+import sets, tables, uri
 import version, sha1hashes
 
 type
   DownloadMethod* {.pure.} = enum
     git = "git", hg = "hg"
-
-  DonationMethod* {.pure.} = enum
-    GitHub = "github"
-    OpenCollective = "opencollective"
-    Patreon = "patreon"
 
   Checksums* = object
     sha1*: Sha1Hash
@@ -77,9 +72,7 @@ type
     paths*: seq[string] 
     entryPoints*: seq[string] #useful for tools like the lsp.
   
-  Donation* = object
-    meth*: DonationMethod
-    username*: string
+  DonationLink* = URI
 
   Package* = object ## Definition of package from packages.json.
     # Required fields in a package.
@@ -93,7 +86,7 @@ type
     version*: Version
     dvcsTag*: string
     web*: string # Info url for humans.
-    donations*: seq[Donation] ## A list of donation methods that can be used to support its developer.
+    donations*: seq[DonationLink] ## A list of donation website URIs that can be used to support its developer.
     alias*: string ## A name of another package, that this package aliases.
 
   PackageDependenciesInfo* = tuple[deps: HashSet[PackageInfo], pkg: PackageInfo]

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -8,6 +8,11 @@ type
   DownloadMethod* {.pure.} = enum
     git = "git", hg = "hg"
 
+  DonationMethod* {.pure.} = enum
+    GitHub = "github"
+    OpenCollective = "opencollective"
+    Patreon = "patreon"
+
   Checksums* = object
     sha1*: Sha1Hash
 
@@ -71,7 +76,11 @@ type
     isLink*: bool
     paths*: seq[string] 
     entryPoints*: seq[string] #useful for tools like the lsp.
-    
+  
+  Donation* = object
+    meth*: DonationMethod
+    username*: string
+
   Package* = object ## Definition of package from packages.json.
     # Required fields in a package.
     name*: string
@@ -84,6 +93,7 @@ type
     version*: Version
     dvcsTag*: string
     web*: string # Info url for humans.
+    donations*: seq[Donation] ## A list of donation methods that can be used to support its developer.
     alias*: string ## A name of another package, that this package aliases.
 
   PackageDependenciesInfo* = tuple[deps: HashSet[PackageInfo], pkg: PackageInfo]


### PR DESCRIPTION
# Prelude

[See this issue](https://github.com/nim-lang/packages/issues/2917) \
This PR exists as a base for what can be the final implementation for this. Do **NOT** merge this yet! \
This PR adds a new command: `nimble sponsor`

# The sponsor command
The sponsor command optionally takes in a package as an argument. If one is not provided, it shows all packages that are accepting donations (the package below does not actually take donations, it's just been modified to show how this command works in my packages_official.json)
![image](https://github.com/user-attachments/assets/3868c43e-7f5a-49d2-8483-e562ab49400c)

If a package is provided, the links for sending donations to the library maintainer are opened in the user's browser and also outputted to their terminal if they don't have a web browser installed. (Again, the package below does not actually take donations.)
![image](https://github.com/user-attachments/assets/7ee37060-873f-4a00-a068-63cdaeb33e4c)
