### PR TITLE
Nim Binaries

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,12 +1,12 @@
 on:
   push:
     tags:
-    - 'v*' # "v1.2.3"
+      - "v*" # "v1.2.3"
     branches:
-    - master
-    paths-ignore: ['nimble-guide/**', '**/*.md']
+      - master
+    paths-ignore: ["nimble-guide/**", "**/*.md"]
   pull_request:
-    paths-ignore: ['nimble-guide/**', '**/*.md']
+    paths-ignore: ["nimble-guide/**", "**/*.md"]
   workflow_dispatch:
 
 jobs:
@@ -50,7 +50,7 @@ jobs:
       run:
         shell: bash
 
-    name: '${{ matrix.target.triple }}'
+    name: "${{ matrix.target.triple }}"
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout
@@ -61,9 +61,9 @@ jobs:
 
       - uses: jiro4989/setup-nim-action@v2
         with:
-          nim-version: 'stable'
+          nim-version: "stable"
           yes: true
-      
+
       - name: Install dependencies
         run: nimble install -y
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -61,6 +61,11 @@ jobs:
           nim-version: 'stable'
           yes: true
 
+      - name: Update submodules
+        run: |
+          git submodule init
+          git submodule update
+          
       - name: Install dependencies
         run: nimble install -y
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -55,17 +55,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: 'stable'
           yes: true
-
-      - name: Update submodules
-        run: |
-          git submodule init
-          git submodule update
-          
+      
       - name: Install dependencies
         run: nimble install -y
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install mercurial
       - name: Install dependencies
-        run: nimble install -y
+        run: nimble install -y --disableNimBinaries
       - name: Run nim c -r tester
         run: |
           cd tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          # - windows-latest
           - macos-latest
           - ubuntu-latest
         nimversion:
@@ -34,7 +34,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install mercurial
       - name: Install dependencies
-        run: nimble install -y --disableNimBinaries
+        run: nimble install -y
       - name: Run nim c -r tester
         run: |
           cd tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os:
-          # - windows-latest
+          - windows-latest
           - macos-latest
           - ubuntu-latest
         nimversion:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nimversion }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/zippy"]
+	path = vendor/zippy
+	url = https://github.com/guzba/zippy.git

--- a/config.nims
+++ b/config.nims
@@ -1,4 +1,6 @@
 # Disable "ObservableStores" warning for the entire project because it gives
 # too many false positives.
+import std/os
 switch("warning", "ObservableStores:off")
 switch("define", "ssl")
+switch("path", "vendor" / "zippy" / "src")

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -798,7 +798,7 @@ proc install(packages: seq[PkgTuple], options: Options,
       if options.useSatSolver and subdir == "": #Ignore the cache if subdir is set
           downloadPath =  getCacheDownloadDir(url, pv.ver, options)
       var nimInstalled = none(NimInstalled)
-      if pv.isNim: #TODO check for the flag and the special verison 
+      if pv.isNim: 
         nimInstalled = installNimFromBinariesDir(pv, options)
        
       let (downloadDir, downloadVersion, vcsRevision) =
@@ -2425,7 +2425,9 @@ proc setNimBin*(options: var Options) =
   if options.nimBin.isNone:
     # Search installed packages to continue with
     let nimVersion = ("nim", VersionRange(kind: verAny))
-    let installedPkgs = getInstalledPkgsMin(options.getPkgsDir(), options) & getInstalledPkgsMin(options.nimBinariesDir, options)
+    let installedPkgs = getInstalledPkgsMin(options.getPkgsDir(), options)
+    #Is this actually needed? If so, guard it with the setNimBinaries flag
+    # & getInstalledPkgsMin(options.nimBinariesDir, options)
     var pkg = initPackageInfo()
     if findPkg(installedPkgs, nimVersion, pkg):
       options.useNimFromDir(pkg.getRealDir, pkg.basicInfo.version.toVersionRange())

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -21,7 +21,8 @@ import nimblepkg/packageinfotypes, nimblepkg/packageinfo, nimblepkg/version,
        nimblepkg/nimscriptwrapper, nimblepkg/developfile, nimblepkg/paths,
        nimblepkg/nimbledatafile, nimblepkg/packagemetadatafile,
        nimblepkg/displaymessages, nimblepkg/sha1hashes, nimblepkg/syncfile,
-       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/forge_aliases, nimblepkg/nimenv
+       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/forge_aliases, nimblepkg/nimenv,
+       nimblepkg/downloadnim
 
 const
   nimblePathsFileName* = "nimble.paths"
@@ -224,7 +225,7 @@ proc processFreeDependencies(pkgInfo: PackageInfo,
           result.incl pkg
 
       pkg = installedPkg # For addRevDep
-      fillMetaData(pkg, pkg.getRealDir(), false)
+      fillMetaData(pkg, pkg.getRealDir(), false, options)
 
       # This package has been installed so we add it to our pkgList.
       pkgList.add pkg
@@ -391,7 +392,7 @@ proc removePackage(pkgInfo: PackageInfo, options: Options) =
 
   if not pkgInfo.hasMetaData:
     try:
-      fillMetaData(pkgInfo, pkgDestDir, true)
+      fillMetaData(pkgInfo, pkgDestDir, true, options)
     except MetaDataError, ValueError:
       promptRemoveEntirePackageDir(pkgDestDir, options)
       removeDir(pkgDestDir)
@@ -417,7 +418,7 @@ proc packageExists(pkgInfo: PackageInfo, options: Options):
     except CatchableError as error:
       raise nimbleError(&"The package inside \"{pkgDestDir}\" is invalid.",
                         details = error)
-    fillMetaData(oldPkgInfo, pkgDestDir, true)
+    fillMetaData(oldPkgInfo, pkgDestDir, true, options)
     return some(oldPkgInfo)
 
 proc processLockedDependencies(pkgInfo: PackageInfo, options: Options):
@@ -442,16 +443,6 @@ proc allDependencies(pkgInfo: PackageInfo, options: Options): HashSet[PackageInf
   result.incl pkgInfo.processFreeDependencies(pkgInfo.requires, options)
   for requires in pkgInfo.taskRequires.values:
     result.incl pkgInfo.processFreeDependencies(requires, options)
-
-proc isSubdirOf(subdir, baseDir: string): bool =
-  let
-    normalizedSubdir = subdir.normalizedPath
-    normalizedBaseDir = baseDir.normalizedPath & DirSep
-
-  when defined(windows):
-    normalizedSubdir.toLower.startsWith(normalizedBaseDir.toLower)
-  else:
-    normalizedSubdir.startsWith(normalizedBaseDir)
 
 proc expandPaths(pkgInfo: PackageInfo, options: Options): seq[string] =
   var pkgInfo = pkgInfo.toFullInfo(options)
@@ -649,7 +640,7 @@ proc getDependency(name: string, dep: LockFileDep, options: Options):
   ## Returns a `PackageInfo` for an already installed dependency from the
   ## lock file.
   let depDirName = getDependencyDir(name, dep, options)
-  let nimbleFilePath = findNimbleFile(depDirName, false)
+  let nimbleFilePath = findNimbleFile(depDirName, false, options)
   getInstalledPackageMin(options, depDirName, nimbleFilePath).toFullInfo(options)
 
 type
@@ -793,13 +784,12 @@ proc install(packages: seq[PkgTuple], options: Options,
                             preferredPackages = preferredPackages)
   else:
     # Install each package.
-    
     for pv in packages:
       let isAlias = isForgeAlias(pv.name)
 
       let (meth, url, metadata) = 
         if not isAlias:
-          getDownloadInfo(pv, options, doPrompt)
+          getDownloadInfo(pv, options, doPrompt) #TODO dont download if its nim
         else:
           (git, "", initTable[string, string]())
 
@@ -807,12 +797,14 @@ proc install(packages: seq[PkgTuple], options: Options,
       var downloadPath = ""
       if options.useSatSolver and subdir == "": #Ignore the cache if subdir is set
           downloadPath =  getCacheDownloadDir(url, pv.ver, options)
-      # if pv.name.isNim:
-      #   downloadPath = "/Volumes/Store/Projects/nim/nimble/temptest/nimtest"
-
-
+      var nimInstalled = none(NimInstalled)
+      if pv.isNim: #TODO check for the flag and the special verison 
+        nimInstalled = installNimFromBinariesDir(pv, options)
+       
       let (downloadDir, downloadVersion, vcsRevision) =
-        if not isAlias:
+        if nimInstalled.isSome():
+          (nimInstalled.get().dir, nimInstalled.get().ver, notSetSha1Hash)
+        elif not isAlias:
           downloadPkg(url, pv.ver, meth, subdir, options,
                     downloadPath = downloadPath, vcsRevision = notSetSha1Hash)
         else:
@@ -824,7 +816,8 @@ proc install(packages: seq[PkgTuple], options: Options,
       try:
         var opt = options
         if pv.name.isNim:
-          compileNim(opt, downloadDir, pv.ver)
+          if not downloadDir.isSubdirOf(options.nimBinariesDir):
+            compileNim(opt, downloadDir, pv.ver)
           opt.useNimFromDir(downloadDir, pv.ver, true)
         result = installFromDir(downloadDir, pv.ver, opt, url,
                                 first, fromLockFile, vcsRevision,
@@ -871,7 +864,7 @@ proc addPackages(packages: seq[PkgTuple], options: var Options) =
     )
   
   let 
-    dir = findNimbleFile(getCurrentDir(), true)
+    dir = findNimbleFile(getCurrentDir(), true, options)
     pkgInfo = getPkgInfo(getCurrentDir(), options)
     pkgList = options.getPackageList()
     deps = pkgInfo.requires
@@ -1445,7 +1438,7 @@ proc uninstall(options: var Options) =
   removePackages(pkgsToDelete, options)
 
 proc listTasks(options: Options) =
-  let nimbleFile = findNimbleFile(getCurrentDir(), true)
+  let nimbleFile = findNimbleFile(getCurrentDir(), true, options)
   nimscriptwrapper.listTasks(nimbleFile, options)
 
 proc developAllDependencies(pkgInfo: PackageInfo, options: var Options, topLevel = false)
@@ -2357,7 +2350,7 @@ proc doAction(options: var Options) =
     var optsCopy = options
     optsCopy.task = options.action.command.normalize
     let
-      nimbleFile = findNimbleFile(getCurrentDir(), true)
+      nimbleFile = findNimbleFile(getCurrentDir(), true, options)
       pkgInfo = getPkgInfoFromFile(nimbleFile, optsCopy)
 
     if optsCopy.task in pkgInfo.nimbleTasks:
@@ -2428,10 +2421,11 @@ proc setNimBin*(options: var Options) =
 
   proc install(package: PkgTuple, options: Options): HashSet[PackageInfo] =
     result = install(@[package], options, doPrompt = false, first = false, fromLockFile = false).deps
+  
   if options.nimBin.isNone:
     # Search installed packages to continue with
     let nimVersion = ("nim", VersionRange(kind: verAny))
-    let installedPkgs = getInstalledPkgsMin(options.getPkgsDir(), options)
+    let installedPkgs = getInstalledPkgsMin(options.getPkgsDir(), options) & getInstalledPkgsMin(options.nimBinariesDir, options)
     var pkg = initPackageInfo()
     if findPkg(installedPkgs, nimVersion, pkg):
       options.useNimFromDir(pkg.getRealDir, pkg.basicInfo.version.toVersionRange())
@@ -2469,7 +2463,7 @@ proc setNimBin*(options: var Options) =
       let installedPkgs = getInstalledPkgsMin(options.getPkgsDir(), options)
       var pkg = initPackageInfo()
       if findPkg(installedPkgs, require, pkg):
-        options.useNimFromDir(pkg.getRealDir, require.ver)
+        options.useNimFromDir(pkg.getRealDir, require.ver)      
       else:
         if not options.offline and options.prompt("No nim version matching $1. Download it now?" % $require.ver):
           for pkg in install(require, options):

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2465,7 +2465,7 @@ proc setNimBin*(options: var Options) =
       let installedPkgs = getInstalledPkgsMin(options.getPkgsDir(), options)
       var pkg = initPackageInfo()
       if findPkg(installedPkgs, require, pkg):
-        options.useNimFromDir(pkg.getRealDir, require.ver)      
+        options.useNimFromDir(pkg.getRealDir, require.ver)
       else:
         if not options.offline and options.prompt("No nim version matching $1. Download it now?" % $require.ver):
           for pkg in install(require, options):

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -485,7 +485,7 @@ proc downloadPkg*(url: string, verRange: VersionRange,
   result.dir = downloadDir / subdir
   #when using a persistent download dir we can skip the download if it's already done
   try:
-    discard findNimbleFile(result.dir, true)
+    discard findNimbleFile(result.dir, true, options)
     return
   except NimbleError: 
     #Continue with the download

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -759,6 +759,8 @@ proc getNimVersion(nimDir: string): Option[Version] =
     return ver
 
 proc installNimFromBinariesDir*(require: PkgTuple, options: Options): Option[NimInstalled] =
+  if options.disableNimBinaries:
+    return none(NimInstalled)
   # Check if already installed
   let nimBininstalledPkgs = getInstalledPkgsMin(options.nimBinariesDir, options)
   var pkg = initPackageInfo()

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -203,7 +203,7 @@ const
   websiteUrlGz = "https://nim-lang.org/download/nim-$1.tar.gz"
   csourcesUrl = "https://github.com/nim-lang/csources"
   dlArchive = "archive/$1.tar.gz"
-  binaryUrl = "https://nim-lang.org/download/nim-$1$2_x$3" & getBinArchiveFormat()
+  binaryUrl {.used.} = "https://nim-lang.org/download/nim-$1$2_x$3" & getBinArchiveFormat()
   userAgent = "nimble/" & nimbleVersion
 
 const # Windows-only

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -485,9 +485,7 @@ proc downloadImpl(version: Version, options: Options): string =
 
     let hasUnxz = findExe("unxz") != ""
     let url = (if hasUnxz: websiteUrlXz else: websiteUrlGz) % $version
-    # let url = binaryUrl % [$version, "-linux", $arch]
     #Note for macOs its using x86 we need to update the binaries and then the macos url
-
     if not needsDownload(url, outputPath, options):
       return outputPath
     echo "url: ", url

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -385,9 +385,6 @@ proc downloadFile*(url, outputPath: string) =
   # For debugging.
   display("GET:", url, priority = DebugPriority)
 
-  # Telemetry
-  let startTime = epochTime()
-
   # Create outputPath's directory if it doesn't exist already.
   createDir(outputPath.splitFile.dir)
 

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -544,7 +544,7 @@ proc getOfficialReleases*(options: Options): seq[Version] =
   #Later on, this file will be moved to a new global cache file that we are going to 
   #introduce when enabling the "enumerate all versions" feature
   let oficialReleasesCachedFile =
-    options.getPkgsDir().absolutePath() / "official-nim-releases.json"
+    options.nimbleDir.absolutePath() / "official-nim-releases.json"
   if oficialReleasesCachedFile.fileExists():
     return oficialReleasesCachedFile.readFile().parseJson().to(seq[Version])
   var parsedContents: JsonNode

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -750,10 +750,15 @@ proc extractNimIfNeeded*(path, extractDir: string, options: Options, attempts: i
   if isNimDirProperlyExtracted(extractDir):
     return true
   #dir exists but is not properly extracted. We need to wipe it out and extract from scratch
-  if attempts > 3:
+  if attempts > 5:
     return false
   removeDir(extractDir)
   extract(path, extractDir)
+  when defined(windows):
+    #beforeInstall 
+    let buildAll = extractDir / "build_all.bat"
+    if not buildAll.fileExists():
+      writeFile(buildAll, "echo hello;")
   return extractNimIfNeeded(path, extractDir, options, attempts + 1)
 
 
@@ -761,7 +766,7 @@ proc downloadAndExtractNim*(
     version: Version, options: Options): Option[string] =
   try:
     let extractDir = options.getNimInstallationDir(version)
-    if extractDir.dirExists(): #TODO test if binary is valid?
+    if extractDir.dirExists() and isNimDirProperlyExtracted(extractDir): #TODO test if binary is valid?
       display("Info:", "Nim $1 already installed" % $version)
       return some extractDir
     let path = downloadNim(version, options)

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -617,7 +617,7 @@ proc getOfficialReleases*(options: Options): seq[Version] =
     parsedContents = parseJson(rawContents)
   except CatchableError:
     display("Warning", "Error getting official releases from github", Warning, HighPriority)
-    #Another temp hack to avoid reaching github api limit
+    #Another temp hack to avoid reaching github api limit when the file doesnt exists
     return @[newVersion("2.2.0"), newVersion("2.0.12"), newVersion("2.0.10"), newVersion("2.0.8"), newVersion("2.0.6"), newVersion("2.0.4"), newVersion("2.0.2"), newVersion("2.0.0"), newVersion("1.6.20"), newVersion("1.6.18"), newVersion("1.6.16"), newVersion("1.6.14"), newVersion("1.6.12"), newVersion("1.6.10"), newVersion("1.6.8"), newVersion("1.6.6"), newVersion("1.6.4"), newVersion("1.6.2"), newVersion("1.6.0"), newVersion("1.4.8"), newVersion("1.4.6"), newVersion("1.4.4"), newVersion("1.4.2"), newVersion("1.4.0"), newVersion("1.2.18"), newVersion("1.2.16"), newVersion("1.2.14"), newVersion("1.2.12"), newVersion("1.2.10"), newVersion("1.2.8")]
   let cutOffVersion = newVersion("0.16.0")
 

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -363,23 +363,23 @@ proc downloadFileNim(url, outputPath: string) =
 
   client.downloadFile(url, outputPath)
 
-when defined(windows):
-  import puppy
-  proc downloadFilePuppy(url, outputPath: string) =
-    displayDebug("Downloading using Puppy")
-    let req = fetch(
-      Request(
-        url: parseUrl(url),
-        verb: "get",
-        headers: @[Header(key: "User-Agent", value: userAgent)],
-      )
-    )
-    if req.code == 200:
-      writeFile(outputPath, req.body)
-    else:
-      raise newException(
-        HTTPRequestError, "Expected HTTP code $1 got $2" % [$200, $req.code]
-      )
+# when defined(windows):
+#   import puppy
+#   proc downloadFilePuppy(url, outputPath: string) =
+#     displayDebug("Downloading using Puppy")
+#     let req = fetch(
+#       Request(
+#         url: parseUrl(url),
+#         verb: "get",
+#         headers: @[Header(key: "User-Agent", value: userAgent)],
+#       )
+#     )
+#     if req.code == 200:
+#       writeFile(outputPath, req.body)
+#     else:
+#       raise newException(
+#         HTTPRequestError, "Expected HTTP code $1 got $2" % [$200, $req.code]
+#       )
 
 proc downloadFile*(url, outputPath: string) =
   # For debugging.
@@ -394,11 +394,11 @@ proc downloadFile*(url, outputPath: string) =
   # Download to temporary file to prevent problems when choosenim crashes.
   let tempOutputPath = outputPath & "_temp"
   try:
-    when defined(curl):
-      downloadFileCurl(url, tempOutputPath)
-    elif defined(windows):
-      downloadFilePuppy(url, tempOutputPath)
-    else:
+    # when defined(curl):
+    #   downloadFileCurl(url, tempOutputPath)
+    # elif defined(windows):
+    #   downloadFilePuppy(url, tempOutputPath)
+    # else:
       downloadFileNim(url, tempOutputPath)
   except HttpRequestError:
     echo("") # Skip line with progress bar.
@@ -559,49 +559,49 @@ proc downloadDLLs*(options: Options): string =
   return outputPath
 
 proc retrieveUrl*(url: string): string =
-  when defined(curl):
-    display("Curl", "Requesting " & url, priority = DebugPriority)
-    # Based on: https://curl.haxx.se/libcurl/c/simple.html
-    let curl = libcurl.easy_init()
+  # when defined(curl):
+  #   display("Curl", "Requesting " & url, priority = DebugPriority)
+  #   # Based on: https://curl.haxx.se/libcurl/c/simple.html
+  #   let curl = libcurl.easy_init()
 
-    # Set which URL to retrieve and tell curl to follow redirects.
-    checkCurl curl.easy_setopt(OPT_URL, url)
-    checkCurl curl.easy_setopt(OPT_FOLLOWLOCATION, 1)
+  #   # Set which URL to retrieve and tell curl to follow redirects.
+  #   checkCurl curl.easy_setopt(OPT_URL, url)
+  #   checkCurl curl.easy_setopt(OPT_FOLLOWLOCATION, 1)
 
-    var res = ""
-    # Set up write callback.
-    proc onWrite(data: ptr char, size: cint, nmemb: cint, userData: pointer): cint =
-      var res = cast[ptr string](userData)
-      var buffer = newString(size * nmemb)
-      copyMem(addr buffer[0], data, buffer.len)
-      res[].add(buffer)
-      result = buffer.len.cint
+  #   var res = ""
+  #   # Set up write callback.
+  #   proc onWrite(data: ptr char, size: cint, nmemb: cint, userData: pointer): cint =
+  #     var res = cast[ptr string](userData)
+  #     var buffer = newString(size * nmemb)
+  #     copyMem(addr buffer[0], data, buffer.len)
+  #     res[].add(buffer)
+  #     result = buffer.len.cint
 
-    checkCurl curl.easy_setopt(OPT_WRITEFUNCTION, onWrite)
-    checkCurl curl.easy_setopt(OPT_WRITEDATA, addr res)
+  #   checkCurl curl.easy_setopt(OPT_WRITEFUNCTION, onWrite)
+  #   checkCurl curl.easy_setopt(OPT_WRITEDATA, addr res)
 
-    let usrAgentCopy = userAgent
-    checkCurl curl.easy_setopt(OPT_USERAGENT, unsafeAddr usrAgentCopy[0])
+  #   let usrAgentCopy = userAgent
+  #   checkCurl curl.easy_setopt(OPT_USERAGENT, unsafeAddr usrAgentCopy[0])
 
-    # Download the file.
-    checkCurl curl.easy_perform()
+  #   # Download the file.
+  #   checkCurl curl.easy_perform()
 
-    # Verify the response code.
-    var responseCode: int
-    checkCurl curl.easy_getinfo(INFO_RESPONSE_CODE, addr responseCode)
+  #   # Verify the response code.
+  #   var responseCode: int
+  #   checkCurl curl.easy_getinfo(INFO_RESPONSE_CODE, addr responseCode)
 
-    display("Curl", res, priority = DebugPriority)
+  #   display("Curl", res, priority = DebugPriority)
 
-    if responseCode != 200:
-      raise newException(
-        HTTPRequestError,
-        "Expected HTTP code $1 got $2 for $3" % [$200, $responseCode, url],
-      )
+  #   if responseCode != 200:
+  #     raise newException(
+  #       HTTPRequestError,
+  #       "Expected HTTP code $1 got $2 for $3" % [$200, $responseCode, url],
+  #     )
 
-    return res
-  elif defined(windows):
-    return fetch(url, headers = @[Header(key: "User-Agent", value: userAgent)])
-  else:
+  #   return res
+  # elif defined(windows):
+  #   return fetch(url, headers = @[Header(key: "User-Agent", value: userAgent)])
+  # else:
     display("Http", "Requesting " & url, priority = DebugPriority)
     var client = newHttpClient(proxy = getProxy(), userAgent = userAgent)
     return client.getContent(url)
@@ -754,7 +754,7 @@ proc downloadAndExtractNimMatchedVersion*(
 
 type NimInstalled* = tuple[dir: string, ver: Version]
 proc getNimVersion(nimDir: string): Option[Version] =
-  let ver = getNimVersionFromBin(nimDir / "bin" / "nim")
+  let ver = getNimVersionFromBin(nimDir / "bin" / "nim".addFileExt(ExeExt))
   if ver.isSome():
     return ver
 

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -611,9 +611,14 @@ proc getOfficialReleases*(options: Options): seq[Version] =
   let oficialReleasesCachedFile = options.getPkgsDir().absolutePath() / "official-nim-releases.json"
   if oficialReleasesCachedFile.fileExists():
     return oficialReleasesCachedFile.readFile().parseJson().to(seq[Version])
-
-  let rawContents = retrieveUrl(githubTagReleasesUrl.addGithubAuthentication())
-  let parsedContents = parseJson(rawContents)
+  var parsedContents: JsonNode
+  try:
+    let rawContents = retrieveUrl(githubTagReleasesUrl.addGithubAuthentication())
+    parsedContents = parseJson(rawContents)
+  except CatchableError:
+    display("Warning", "Error getting official releases from github", Warning, HighPriority)
+    #Another temp hack to avoid reaching github api limit
+    return @[newVersion("2.2.0"), newVersion("2.0.12"), newVersion("2.0.10"), newVersion("2.0.8"), newVersion("2.0.6"), newVersion("2.0.4"), newVersion("2.0.2"), newVersion("2.0.0"), newVersion("1.6.20"), newVersion("1.6.18"), newVersion("1.6.16"), newVersion("1.6.14"), newVersion("1.6.12"), newVersion("1.6.10"), newVersion("1.6.8"), newVersion("1.6.6"), newVersion("1.6.4"), newVersion("1.6.2"), newVersion("1.6.0"), newVersion("1.4.8"), newVersion("1.4.6"), newVersion("1.4.4"), newVersion("1.4.2"), newVersion("1.4.0"), newVersion("1.2.18"), newVersion("1.2.16"), newVersion("1.2.14"), newVersion("1.2.12"), newVersion("1.2.10"), newVersion("1.2.8")]
   let cutOffVersion = newVersion("0.16.0")
 
   var releases: seq[Version] = @[]

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -1,0 +1,787 @@
+import
+  std/[httpclient, strutils, os, osproc, terminal, times, json, uri, sequtils, options]
+import zippy/tarballs as zippy_tarballs
+import zippy/ziparchives as zippy_zips
+
+import common, options, packageinfo, nimenv
+
+when defined(curl):
+  import math
+
+import version, cli
+when defined(curl):
+  import libcurl except Version
+
+# import cliparams, common, utils
+# import telemetry
+proc getBinArchiveFormat*(): string =
+  when defined(windows):
+    return ".zip"
+  else:
+    return ".tar.xz"
+
+proc getProxy*(): Proxy =
+  ## Returns ``nil`` if no proxy is specified.
+  var url = ""
+  try:
+    if existsEnv("http_proxy"):
+      url = getEnv("http_proxy")
+    elif existsEnv("https_proxy"):
+      url = getEnv("https_proxy")
+  except ValueError:
+    display(
+      "Warning:",
+      "Unable to parse proxy from environment: " & getCurrentExceptionMsg(),
+      Warning,
+      HighPriority,
+    )
+
+  if url.len > 0:
+    var parsed = parseUri(url)
+    if parsed.scheme.len == 0 or parsed.hostname.len == 0:
+      parsed = parseUri("http://" & url)
+    let auth =
+      if parsed.username.len > 0:
+        parsed.username & ":" & parsed.password
+      else:
+        ""
+    return newProxy($parsed, auth)
+  else:
+    return nil
+
+proc getCpuArch*(): int =
+  ## Get CPU arch on Windows - get env var PROCESSOR_ARCHITECTURE
+  var failMsg = ""
+
+  let
+    archEnv = getEnv("PROCESSOR_ARCHITECTURE")
+    arch6432Env = getEnv("PROCESSOR_ARCHITEW6432")
+  if arch6432Env.len != 0:
+    # https://blog.differentpla.net/blog/2013/03/10/processor-architew6432/
+    result = 64
+  elif "64" in archEnv:
+    # https://superuser.com/a/1441469
+    result = 64
+  elif "86" in archEnv:
+    result = 32
+  else:
+    failMsg =
+      "PROCESSOR_ARCHITECTURE = " & archEnv & ", PROCESSOR_ARCHITEW6432 = " & arch6432Env
+
+  # Die if unsupported - better fail than guess
+  if result == 0:
+    raise newException(NimbleError, "Could not detect CPU architecture: " & failMsg)
+
+proc getNimBinariesDir*(options: Options): string =
+  return options.nimBinariesDir
+
+proc getMingwPath*(options: Options): string =
+  let arch = getCpuArch()
+  return getNimBinariesDir(options) / "mingw" & $arch
+
+proc getMingwBin*(options: Options): string =
+  return getMingwPath(options) / "bin"
+
+proc isDefaultCCInPath*(): bool =
+  # Fixes issue #104
+  when defined(macosx):
+    return findExe("clang") != ""
+  else:
+    return findExe("gcc") != ""
+
+proc getGccArch*(options: Options): int =
+  ## Get gcc arch by getting pointer size x 8
+  var
+    outp = ""
+    errC = 0
+
+  when defined(windows):
+    # Add MingW bin dir to PATH so getGccArch can find gcc.
+    let pathEnv = getEnv("PATH")
+    if not isDefaultCCInPath() and dirExists(options.getMingwBin()):
+      putEnv("PATH", options.getMingwBin() & PathSep & pathEnv)
+
+    (outp, errC) = execCmdEx(
+      "cmd /c echo int main^(^) { return sizeof^(void *^); } | gcc -xc - -o archtest && archtest"
+    )
+
+    putEnv("PATH", pathEnv)
+  else:
+    (outp, errC) = execCmdEx(
+      "echo \"int main() { return sizeof(void *); }\" | gcc -xc - -o archtest && ./archtest"
+    )
+
+  removeFile("archtest".addFileExt(ExeExt))
+
+  if errC in [4, 8]:
+    return errC * 8
+  else:
+    # Fallback when arch detection fails. See https://github.com/dom96/choosenim/issues/284
+    return when defined(windows): 32 else: 64
+
+proc isRosetta*(): bool =
+  let res = gorgeEx("sysctl -in sysctl.proc_translated")
+  if res.exitCode == 0:
+    return res.output.strip() == "1"
+  return false
+
+proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
+  let os =
+    when defined(windows):
+      "windows"
+    elif defined(linux):
+      "linux"
+    elif defined(macosx):
+      "osx"
+    elif defined(freebsd):
+      "freebsd"
+  for jn in parsedContents.getElems():
+    if jn["name"].getStr().contains("devel"):
+      let tagName = jn{"tag_name"}.getStr("")
+      for asset in jn["assets"].getElems():
+        let aname = asset["name"].getStr()
+        let url = asset{"browser_download_url"}.getStr("")
+        if os in aname:
+          when not defined(macosx):
+            if "x" & $arch in aname:
+              result = (url, tagName)
+          else:
+            # when choosenim become arm64 binary, isRosetta will be false. But we don't have nightlies for arm64 yet.
+            # So, we should check if choosenim is compiled as x86_64 (nim's system.hostCPU returns amd64 even on Apple Silicon machines)
+            if not isRosetta() and hostCPU == "amd64":
+              result = (url, tagName)
+        if result[0].len != 0:
+          break
+    if result[0].len != 0:
+      break
+
+proc getLatestCommit*(repo, branch: string): string =
+  ## Get latest commit for remote Git repo with ls-remote
+  ##
+  ## Returns "" if Git isn't available
+  let git = findExe("git")
+  if git.len != 0:
+    var cmd = when defined(windows): "cmd /c " else: ""
+    cmd &= git.quoteShell & " ls-remote " & repo & " " & branch
+
+    let (outp, errC) = execCmdEx(cmd)
+    if errC == 0:
+      for line in outp.splitLines():
+        result = line.split('\t')[0]
+        break
+    else:
+      display("Warning", outp & "\ngit ls-remote failed", Warning, HighPriority)
+
+proc doCmdRaw*(cmd: string) =
+  var command = cmd
+  # To keep output in sequence
+  stdout.flushFile()
+  stderr.flushFile()
+
+  if defined(macosx) and isRosetta():
+    command = "arch -arm64 " & command
+
+  displayDebug("Executing", command)
+  displayDebug("Work Dir", getCurrentDir())
+  let (output, exitCode) = execCmdEx(command)
+  displayDebug("Finished", "with exit code " & $exitCode)
+  displayDebug("Output", output)
+
+  if exitCode != QuitSuccess:
+    raise newException(
+      NimbleError,
+      "Execution failed with exit code $1\nCommand: $2\nOutput: $3" %
+        [$exitCode, command, output],
+    )
+
+const
+  githubTagReleasesUrl = "https://api.github.com/repos/nim-lang/Nim/tags"
+  githubNightliesReleasesUrl =
+    "https://api.github.com/repos/nim-lang/nightlies/releases"
+  githubUrl = "https://github.com/nim-lang/Nim"
+  websiteUrlXz = "https://nim-lang.org/download/nim-$1.tar.xz"
+  websiteUrlGz = "https://nim-lang.org/download/nim-$1.tar.gz"
+  csourcesUrl = "https://github.com/nim-lang/csources"
+  dlArchive = "archive/$1.tar.gz"
+  binaryUrl = "https://nim-lang.org/download/nim-$1$2_x$3" & getBinArchiveFormat()
+  userAgent = "nimble/" & nimbleVersion
+
+const # Windows-only
+  mingwUrl = "https://nim-lang.org/download/mingw$1.zip"
+  dllsUrl = "https://nim-lang.org/download/dlls.zip"
+
+const progressBarLength = 50
+
+proc showIndeterminateBar(progress, speed: BiggestInt, lastPos: var int) =
+  try:
+    eraseLine()
+  except OSError:
+    echo ""
+  if lastPos >= progressBarLength:
+    lastPos = 0
+
+  var spaces = repeat(' ', progressBarLength)
+  spaces[lastPos] = '#'
+  lastPos.inc()
+  stdout.write(
+    "[$1] $2mb $3kb/s" % [spaces, $(progress div (1000 * 1000)), $(speed div 1000)]
+  )
+  stdout.flushFile()
+
+proc showBar(fraction: float, speed: BiggestInt) =
+  try:
+    eraseLine()
+  except OSError:
+    echo ""
+  let hashes = repeat('#', int(fraction * progressBarLength))
+  let spaces = repeat(' ', progressBarLength - hashes.len)
+  stdout.write(
+    "[$1$2] $3% $4kb/s" %
+      [hashes, spaces, formatFloat(fraction * 100, precision = 4), $(speed div 1000)]
+  )
+  stdout.flushFile()
+
+proc addGithubAuthentication(url: string): string =
+  let ghtoken = getEnv("GITHUB_TOKEN")
+  if ghtoken == "":
+    return url
+  else:
+    display(
+      "Info:",
+      "Using the 'GITHUB_TOKEN' environment variable for GitHub API Token.",
+      priority = HighPriority,
+    )
+    return
+      url.replace("https://api.github.com", "https://" & ghtoken & "@api.github.com")
+
+when defined(curl):
+  proc checkCurl(code: Code) =
+    if code != E_OK:
+      raise newException(AssertionError, "CURL failed: " & $easy_strerror(code))
+
+  proc downloadFileCurl(url, outputPath: string) =
+    displayDebug("Downloading using Curl")
+    # Based on: https://curl.haxx.se/libcurl/c/url2file.html
+    let curl = libcurl.easy_init()
+    defer:
+      curl.easy_cleanup()
+
+    # Enable progress bar.
+    #checkCurl curl.easy_setopt(OPT_VERBOSE, 1)
+    checkCurl curl.easy_setopt(OPT_NOPROGRESS, 0)
+
+    # Set which URL to download and tell curl to follow redirects.
+    checkCurl curl.easy_setopt(OPT_URL, url)
+    checkCurl curl.easy_setopt(OPT_FOLLOWLOCATION, 1)
+
+    type UserData = ref object
+      file: File
+      lastProgressPos: int
+      bytesWritten: int
+      lastSpeedUpdate: float
+      speed: BiggestInt
+      needsUpdate: bool
+
+    # Set up progress callback.
+    proc onProgress(userData: pointer, dltotal, dlnow, ultotal, ulnow: float): cint =
+      result = 0 # Ensure download isn't terminated.
+
+      let userData = cast[UserData](userData)
+
+      # Only update once per second.
+      if userData.needsUpdate:
+        userData.needsUpdate = false
+      else:
+        return
+
+      let fraction = dlnow.float / dltotal.float
+      if fraction.classify == fcNan:
+        return
+
+      if fraction == Inf:
+        showIndeterminateBar(dlnow.BiggestInt, userData.speed, userData.lastProgressPos)
+      else:
+        showBar(fraction, userData.speed)
+
+    checkCurl curl.easy_setopt(OPT_PROGRESSFUNCTION, onProgress)
+
+    # Set up write callback.
+    proc onWrite(data: ptr char, size: cint, nmemb: cint, userData: pointer): cint =
+      let userData = cast[UserData](userData)
+      let len = size * nmemb
+      result = userData.file.writeBuffer(data, len).cint
+      doAssert result == len
+
+      # Handle speed measurement.
+      const updateInterval = 0.25
+      userData.bytesWritten += result
+      if epochTime() - userData.lastSpeedUpdate > updateInterval:
+        userData.speed = userData.bytesWritten * int(1 / updateInterval)
+        userData.bytesWritten = 0
+        userData.lastSpeedUpdate = epochTime()
+        userData.needsUpdate = true
+
+    checkCurl curl.easy_setopt(OPT_WRITEFUNCTION, onWrite)
+
+    # Open file for writing and set up UserData.
+    let userData = UserData(
+      file: open(outputPath, fmWrite),
+      lastProgressPos: 0,
+      lastSpeedUpdate: epochTime(),
+      speed: 0,
+    )
+    defer:
+      userData.file.close()
+    checkCurl curl.easy_setopt(OPT_WRITEDATA, userData)
+    checkCurl curl.easy_setopt(OPT_PROGRESSDATA, userData)
+
+    # Download the file.
+    checkCurl curl.easy_perform()
+
+    # Verify the response code.
+    var responseCode: int
+    checkCurl curl.easy_getinfo(INFO_RESPONSE_CODE, addr responseCode)
+
+    if responseCode != 200:
+      raise newException(
+        HTTPRequestError, "Expected HTTP code $1 got $2" % [$200, $responseCode]
+      )
+
+proc downloadFileNim(url, outputPath: string) =
+  displayDebug("Downloading using HttpClient")
+  var client = newHttpClient(proxy = getProxy())
+
+  var lastProgressPos = 0
+  proc onProgressChanged(total, progress, speed: BiggestInt) {.closure, gcsafe.} =
+    let fraction = progress.float / total.float
+    if fraction == Inf:
+      showIndeterminateBar(progress, speed, lastProgressPos)
+    else:
+      showBar(fraction, speed)
+
+  client.onProgressChanged = onProgressChanged
+
+  client.downloadFile(url, outputPath)
+
+when defined(windows):
+  import puppy
+  proc downloadFilePuppy(url, outputPath: string) =
+    displayDebug("Downloading using Puppy")
+    let req = fetch(
+      Request(
+        url: parseUrl(url),
+        verb: "get",
+        headers: @[Header(key: "User-Agent", value: userAgent)],
+      )
+    )
+    if req.code == 200:
+      writeFile(outputPath, req.body)
+    else:
+      raise newException(
+        HTTPRequestError, "Expected HTTP code $1 got $2" % [$200, $req.code]
+      )
+
+proc downloadFile*(url, outputPath: string) =
+  # For debugging.
+  display("GET:", url, priority = DebugPriority)
+
+  # Telemetry
+  let startTime = epochTime()
+
+  # Create outputPath's directory if it doesn't exist already.
+  createDir(outputPath.splitFile.dir)
+
+  # Download to temporary file to prevent problems when choosenim crashes.
+  let tempOutputPath = outputPath & "_temp"
+  try:
+    when defined(curl):
+      downloadFileCurl(url, tempOutputPath)
+    elif defined(windows):
+      downloadFilePuppy(url, tempOutputPath)
+    else:
+      downloadFileNim(url, tempOutputPath)
+  except HttpRequestError:
+    echo("") # Skip line with progress bar.
+    let msg =
+      "Couldn't download file from $1.\nResponse was: $2" %
+      [url, getCurrentExceptionMsg()]
+    display("Info:", msg, Warning, MediumPriority)
+    raise
+
+  moveFile(tempOutputPath, outputPath)
+
+  showBar(1, 0)
+  echo("")
+
+proc getDownloadPath*(downloadUrl: string, options: Options): string =
+  let (_, name, ext) = downloadUrl.splitFile()
+  getNimBinariesDir(options) / name & ext
+
+  # report(initTiming(DownloadTime, url, startTime, $LabelSuccess), params)
+
+proc needsDownload(
+    downloadUrl: string, outputPath: var string, options: Options
+): bool =
+  ## Returns whether the download should commence.
+  ##
+  ## The `outputPath` argument is filled with the valid download path.
+  result = true
+  outputPath = getDownloadPath(downloadUrl, options)
+  if outputPath.fileExists():
+    # TODO: Verify sha256.
+    display("Info:", "$1 already downloaded" % outputPath, priority = HighPriority)
+    return false
+
+proc retrieveUrl*(url: string): string
+proc downloadImpl(version: Version, options: Options): string =
+  let arch = getGccArch(options)
+  displayDebug("Detected", "arch as " & $arch & "bit")
+  if version.isSpecial():
+    var reference, url = ""
+    if $version in ["#devel", "#head"]: # and not params.latest:
+      # Install nightlies by default for devel channel
+      try:
+        let rawContents =
+          retrieveUrl(githubNightliesReleasesUrl.addGithubAuthentication())
+        let parsedContents = parseJson(rawContents)
+        (url, reference) = getNightliesUrl(parsedContents, arch)
+        if url.len == 0:
+          display(
+            "Warning",
+            "Recent nightly release not found, installing latest devel commit.",
+            Warning, HighPriority,
+          )
+        reference = if reference.len == 0: "devel" else: reference
+      except HTTPRequestError:
+        # Unable to get nightlies release json from github API, fallback
+        # to `choosenim devel --latest`
+        display(
+          "Warning", "Nightlies build unavailable, building latest commit", Warning,
+          HighPriority,
+        )
+
+    if url.len == 0:
+      let
+        commit = getLatestCommit(githubUrl, "devel")
+        archive = if commit.len != 0: commit else: "devel"
+      reference =
+        case normalize($version)
+        of "#head":
+          archive
+        else:
+          ($version)[1 .. ^1]
+      url = $(parseUri(githubUrl) / (dlArchive % reference))
+    display(
+      "Downloading", "Nim $1 from $2" % [reference, "GitHub"], priority = HighPriority
+    )
+    var outputPath: string
+    if not needsDownload(url, outputPath, options):
+      return outputPath
+
+    downloadFile(url, outputPath)
+    result = outputPath
+  else:
+    display(
+      "Downloading",
+      "Nim $1 from $2" % [$version, "nim-lang.org"],
+      priority = HighPriority,
+    )
+
+    var outputPath: string
+
+    # Use binary builds for Windows and Linux
+    when defined(Windows) or defined(linux):
+      let os = when defined(linux): "-linux" else: ""
+      let binUrl = binaryUrl % [$version, os, $arch]
+      if not needsDownload(binUrl, outputPath, options):
+        return outputPath
+      try:
+        downloadFile(binUrl, outputPath)
+        return outputPath
+      except HttpRequestError:
+        display(
+          "Info:",
+          "Binary build unavailable, building from source",
+          priority = HighPriority,
+        )
+
+    let hasUnxz = findExe("unxz") != ""
+    let url = (if hasUnxz: websiteUrlXz else: websiteUrlGz) % $version
+    # let url = binaryUrl % [$version, "-linux", $arch]
+      #Note for macOs its using x86 we need to update the binaries and then the macos url
+
+    if not needsDownload(url, outputPath, options):
+      return outputPath
+    echo "url: ", url
+    downloadFile(url, outputPath)
+    result = outputPath
+
+proc downloadNim*(version: Version, options: Options): string =
+  ## Returns the path of the downloaded .tar.(gz|xz) file.
+  try:
+    return downloadImpl(version, options)
+  except HttpRequestError:
+    raise newException(NimbleError, "Version $1 does not exist." % $version)
+
+proc downloadCSources*(options: Options): string =
+  let
+    commit = getLatestCommit(csourcesUrl, "master")
+    archive = if commit.len != 0: commit else: "master"
+    csourcesArchiveUrl = $(parseUri(csourcesUrl) / (dlArchive % archive))
+
+  var outputPath: string
+  if not needsDownload(csourcesArchiveUrl, outputPath, options):
+    return outputPath
+
+  display("Downloading", "Nim C sources from GitHub", priority = HighPriority)
+  downloadFile(csourcesArchiveUrl, outputPath)
+  return outputPath
+
+proc downloadMingw*(options: Options): string =
+  let
+    arch = getCpuArch()
+    url = mingwUrl % $arch
+  var outputPath: string
+  if not needsDownload(url, outputPath, options):
+    return outputPath
+
+  display("Downloading", "C compiler (Mingw$1)" % $arch, priority = HighPriority)
+  downloadFile(url, outputPath)
+  return outputPath
+
+proc downloadDLLs*(options: Options): string =
+  var outputPath: string
+  if not needsDownload(dllsUrl, outputPath, options):
+    return outputPath
+
+  display("Downloading", "DLLs (openssl, pcre, ...)", priority = HighPriority)
+  downloadFile(dllsUrl, outputPath)
+  return outputPath
+
+proc retrieveUrl*(url: string): string =
+  when defined(curl):
+    display("Curl", "Requesting " & url, priority = DebugPriority)
+    # Based on: https://curl.haxx.se/libcurl/c/simple.html
+    let curl = libcurl.easy_init()
+
+    # Set which URL to retrieve and tell curl to follow redirects.
+    checkCurl curl.easy_setopt(OPT_URL, url)
+    checkCurl curl.easy_setopt(OPT_FOLLOWLOCATION, 1)
+
+    var res = ""
+    # Set up write callback.
+    proc onWrite(data: ptr char, size: cint, nmemb: cint, userData: pointer): cint =
+      var res = cast[ptr string](userData)
+      var buffer = newString(size * nmemb)
+      copyMem(addr buffer[0], data, buffer.len)
+      res[].add(buffer)
+      result = buffer.len.cint
+
+    checkCurl curl.easy_setopt(OPT_WRITEFUNCTION, onWrite)
+    checkCurl curl.easy_setopt(OPT_WRITEDATA, addr res)
+
+    let usrAgentCopy = userAgent
+    checkCurl curl.easy_setopt(OPT_USERAGENT, unsafeAddr usrAgentCopy[0])
+
+    # Download the file.
+    checkCurl curl.easy_perform()
+
+    # Verify the response code.
+    var responseCode: int
+    checkCurl curl.easy_getinfo(INFO_RESPONSE_CODE, addr responseCode)
+
+    display("Curl", res, priority = DebugPriority)
+
+    if responseCode != 200:
+      raise newException(
+        HTTPRequestError,
+        "Expected HTTP code $1 got $2 for $3" % [$200, $responseCode, url],
+      )
+
+    return res
+  elif defined(windows):
+    return fetch(url, headers = @[Header(key: "User-Agent", value: userAgent)])
+  else:
+    display("Http", "Requesting " & url, priority = DebugPriority)
+    var client = newHttpClient(proxy = getProxy(), userAgent = userAgent)
+    return client.getContent(url)
+
+proc getOfficialReleases*(options: Options): seq[Version] =
+  let rawContents = retrieveUrl(githubTagReleasesUrl.addGithubAuthentication())
+  let parsedContents = parseJson(rawContents)
+  let cutOffVersion = newVersion("0.16.0")
+
+  var releases: seq[Version] = @[]
+  for release in parsedContents:
+    let name = release["name"].getStr().strip(true, false, {'v'})
+    let version = name.newVersion
+    if cutOffVersion <= version:
+      releases.add(version)
+  return releases
+
+template isDevel*(version: Version): bool =
+  $version in ["#head", "#devel"]
+
+proc gitUpdate*(version: Version, extractDir: string, options: Options): bool =
+  if version.isDevel(): # and options.latest:
+    let git = findExe("git")
+    if git.len != 0 and fileExists(extractDir / ".git" / "config"):
+      result = true
+
+      let lastDir = getCurrentDir()
+      setCurrentDir(extractDir)
+      defer:
+        setCurrentDir(lastDir)
+
+      display("Fetching", "latest changes", priority = HighPriority)
+      for cmd in [" fetch --all", " reset --hard origin/devel"]:
+        var (outp, errC) = execCmdEx(git.quoteShell & cmd)
+        if errC != QuitSuccess:
+          display(
+            "Warning:",
+            "git" & cmd & " failed: " & outp,
+            Warning,
+            priority = HighPriority,
+          )
+          return false
+
+proc gitInit*(version: Version, extractDir: string, options: Options) =
+  createDir(extractDir / ".git")
+  if version.isDevel():
+    let git = findExe("git")
+    if git.len != 0:
+      let lastDir = getCurrentDir()
+      setCurrentDir(extractDir)
+      defer:
+        setCurrentDir(lastDir)
+
+      var init = true
+      display("Setting", "up git repository", priority = HighPriority)
+      for cmd in [" init", " remote add origin https://github.com/nim-lang/nim"]:
+        var (outp, errC) = execCmdEx(git.quoteShell & cmd)
+        if errC != QuitSuccess:
+          display(
+            "Warning:",
+            "git" & cmd & " failed: " & outp,
+            Warning,
+            priority = HighPriority,
+          )
+          init = false
+          break
+
+      if init:
+        discard gitUpdate(version, extractDir, options)
+
+proc extract*(path: string, extractDir: string) =
+  display("Extracting", path.extractFilename(), priority = HighPriority)
+
+  if path.splitFile().ext == ".xz":
+    when defined(windows):
+      # We don't ship with `unxz` on Windows, instead assume that we get
+      # a .zip on this platform.
+      raise newException(
+        NimbleError, "Unable to extract. Tar.xz files are not supported on Windows."
+      )
+    else:
+      let tarFile = path.changeFileExt("")
+      removeFile(tarFile) # just in case it exists, if it does `unxz` fails.
+      if findExe("unxz") == "":
+        raise newException(
+          NimbleError,
+          "Unable to extract. Need `unxz` to extract .tar.xz file. See https://github.com/dom96/choosenim/issues/290.",
+        )
+      doCmdRaw("unxz " & quoteShell(path))
+      extract(tarFile, extractDir) # We remove the .xz extension
+      return
+
+  let tempDir = getTempDir() / "choosenim-extraction"
+  removeDir(tempDir)
+
+  try:
+    case path.splitFile.ext
+    of ".zip":
+      zippy_zips.extractAll(path, tempDir)
+    of ".tar", ".gz":
+      if findExe("tar") != "":
+        # TODO: Workaround for high mem usage of zippy (https://github.com/guzba/zippy/issues/31).
+        createDir(tempDir)
+        doCmdRaw("tar xf " & quoteShell(path) & " -C " & quoteShell(tempDir))
+      else:
+        zippy_tarballs.extractAll(path, tempDir)
+    else:
+      raise newException(ValueError, "Unsupported format for extraction: " & path)
+  except CatchableError as exc:
+    raise newException(NimbleError, "Unable to extract. Error was '$1'." % exc.msg)
+
+  # Skip outer directory.
+  # Same as: https://github.com/dom96/untar/blob/d21f7229b/src/untar.nim
+  #
+  # Determine which directory to copy.
+  var srcDir = tempDir
+  let contents = toSeq(walkDir(srcDir))
+  if contents.len == 1:
+    # Skip the outer directory.
+    srcDir = contents[0][1]
+
+  # Finally copy the directory to what the user specified.
+  copyDir(srcDir, extractDir)
+
+proc getNimInstallationDir*(options: Options, version: Version): string =
+  return getNimBinariesDir(options) / ("nim-$1" % $version)
+
+proc downloadAndExtractNim*(
+    version: Version, options: Options): Option[string] =
+  try:
+    let extractDir = options.getNimInstallationDir(version)
+    if extractDir.dirExists(): #TODO test if binary is valid?
+      display("Info:", "Nim $1 already installed" % $version)
+      return some extractDir
+    let path = downloadNim(version, options)
+    if not extractDir.dirExists():
+      extract(path, extractDir)
+    return some extractDir
+  except:
+    return none(string)
+
+proc downloadAndExtractNimMatchedVersion*(
+    ver: VersionRange, options: Options): Option[string] =
+  let releases = getOfficialReleases(options)
+    #TODO Use the cached make sure the order is correct
+  for releaseVer in releases:
+    if releaseVer.withinRange(ver):
+      return downloadAndExtractNim(releaseVer, options)
+  return none(string)
+
+type NimInstalled* = tuple[dir: string, ver: Version]
+proc getNimVersion(nimDir: string): Option[Version] =
+  let ver = getNimVersionFromBin(nimDir / "bin" / "nim")
+  if ver.isSome():
+    return ver
+
+proc installNimFromBinariesDir*(require: PkgTuple, options: Options): Option[NimInstalled] =
+  # Check if already installed
+  let nimBininstalledPkgs = getInstalledPkgsMin(options.nimBinariesDir, options)
+  var pkg = initPackageInfo()
+  if findPkg(nimBininstalledPkgs, require, pkg):
+    let ver = getNimVersion(pkg.getRealDir)
+    if ver.isSome():
+      return some (pkg.getRealDir, ver.get())
+
+  # Download if allowed
+  if not options.offline and
+      options.prompt("No nim version matching $1. Download it now?" % $require.ver):
+    let extractedDir = downloadAndExtractNimMatchedVersion(require.ver, options)
+    if extractedDir.isSome():
+      # Try using downloaded version
+      let ver = getNimVersion(extractedDir.get)
+      if ver.isSome():
+        return some (extractedDir.get, ver.get)
+        
+      # Rebuild if necessary
+      displayInfo "There is no nim binary in the downloaded directory or it is corrupted. Rebuilding it"
+      compileNim(options, extractedDir.get, require.ver)
+      let rebuiltVer = getNimVersion(extractedDir.get)
+      if rebuiltVer.isSome():
+        return some (extractedDir.get, rebuiltVer.get)
+
+  return none(NimInstalled)

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -343,12 +343,10 @@ proc downloadPkInfoForPv*(pv: PkgTuple, options: Options): PackageInfo  =
   return getPkgInfo(res.dir, options)
 
 proc getAllNimReleases(options: Options): seq[PackageMinimalInfo] =
-  #TODO cache the call in options
   let releases = getOfficialReleases(options)
   for release in releases:
     result.add PackageMinimalInfo(name: "nim", version: release)
   
-
 proc downloadMinimalPackage*(pv: PkgTuple, options: Options): seq[PackageMinimalInfo] =
   if pv.name == "": return newSeq[PackageMinimalInfo]()
   if pv.isNim and not options.disableNimBinaries: return getAllNimReleases(options)

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -387,7 +387,7 @@ proc collectAllVersions*(versions: var Table[string, PackageVersions], package: 
           versions[pv.name] = PackageVersions(pkgName: pv.name, versions: @[pkgMin])
         else:
           versions[pv.name].versions.addUnique pkgMin
-        #TODO do not enter in the loop until we have collected all the versions?
+        #TODO Note for when implementing "enumerate all versions": do not enter in the loop until we have collected all the versions
         collectAllVersions(versions, pkgMin, options, getMinimalPackage, preferredPackages)
 
 proc topologicalSort*(solvedPkgs: seq[SolvedPackage]): seq[SolvedPackage] =

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -351,7 +351,7 @@ proc getAllNimReleases(options: Options): seq[PackageMinimalInfo] =
 
 proc downloadMinimalPackage*(pv: PkgTuple, options: Options): seq[PackageMinimalInfo] =
   if pv.name == "": return newSeq[PackageMinimalInfo]()
-  if pv.isNim: return getAllNimReleases(options)
+  if pv.isNim and not options.disableNimBinaries: return getAllNimReleases(options)
 
   let pkgInfo = downloadPkInfoForPv(pv, options)
   return @[pkgInfo.getMinimalInfo(options)]

--- a/src/nimblepkg/nimenv.nim
+++ b/src/nimblepkg/nimenv.nim
@@ -1,5 +1,5 @@
 import std/[strscans, os, strutils, strformat, options]
-import version, nimblesat, cli, common, options
+import version, cli, common, options
 
 when defined(windows):
   const

--- a/src/nimblepkg/nimscriptexecutor.nim
+++ b/src/nimblepkg/nimscriptexecutor.nim
@@ -15,7 +15,7 @@ proc execHook*(options: Options, hookAction: ActionType, before: bool): bool =
 
   var nimbleFile = ""
   try:
-    nimbleFile = findNimbleFile(getCurrentDir(), true)
+    nimbleFile = findNimbleFile(getCurrentDir(), true, options)
   except NimbleError: return true
   # PackageInfos are cached so we can read them as many times as we want.
   let pkgInfo = getPkgInfoFromFile(nimbleFile, options)

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -62,6 +62,7 @@ type
     useSatSolver*: bool = true
     extraRequires*: seq[PkgTuple] # extra requires parsed from the command line
     nimBinariesDir*: string # Directory where nim binaries are stored. Separated from nimbleDir as it can be changed by the user/tests
+    disableNimBinaries*: bool # Whether to disable the use of nim binaries
 
   ActionType* = enum
     actionNil, actionRefresh, actionInit, actionDump, actionPublish, actionUpgrade
@@ -251,6 +252,7 @@ Nimble Options:
                                   file if any
       --solver:sat|legacy         Use the SAT solver or the legacy (default) for dependency resolution.
       --requires                  Add extra packages to the dependency resolution. Uses the same syntax as the Nimble file. Example: nimble install --requires "pkg1; pkg2 >= 1.2"
+      --disableNimBinaries        Disable the use of nim precompiled binaries. Note in some platforms precompiled binaries are not available but the flag can still be used to avoid compile the Nim version once and reuse it.
 
 For more information read the GitHub readme:
   https://github.com/nim-lang/nimble#readme
@@ -635,6 +637,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       raise nimbleError("Unknown solver option: " & val)
   of "requires":
     result.extraRequires = val.split(";").mapIt(it.strip.parseRequires())
+  of "disablenimbinaries":
+    result.disableNimBinaries = true
   else: isGlobalFlag = false
 
   var wasFlagHandled = true

--- a/src/nimblepkg/packagemetadatafile.nim
+++ b/src/nimblepkg/packagemetadatafile.nim
@@ -2,7 +2,7 @@
 # BSD License. Look at license.txt for more info.
 
 import json, os, strformat, sets, sequtils
-import common, version, packageinfotypes, cli, tools, sha1hashes
+import common, version, packageinfotypes, cli, tools, sha1hashes, options
 
 type
   MetaDataError* = object of NimbleError
@@ -53,7 +53,7 @@ proc saveMetaData*(metaData: PackageMetaData, dirName: string,
     $pmdjkMetaData: %metaDataWithChangedPaths}
   writeFile(dirName / packageMetaDataFileName, json.pretty)
 
-proc loadMetaData*(dirName: string, raiseIfNotFound: bool): PackageMetaData =
+proc loadMetaData*(dirName: string, raiseIfNotFound: bool, options: Options): PackageMetaData =
   ## Returns package meta data read from file in package installation directory
   result = initPackageMetaData()
   let fileName = dirName / packageMetaDataFileName
@@ -66,8 +66,9 @@ proc loadMetaData*(dirName: string, raiseIfNotFound: bool): PackageMetaData =
   elif raiseIfNotFound:
     raise metaDataError(&"No {packageMetaDataFileName} file found in {dirName}")
   else:
-    displayWarning(&"No {packageMetaDataFileName} file found in {dirName}")
+    if not dirName.isSubdirOf(options.nimBinariesDir):
+      displayWarning(&"No {packageMetaDataFileName} file found in {dirName}")
 
 proc fillMetaData*(packageInfo: var PackageInfo, dirName: string,
-                   raiseIfNotFound: bool) =
-  packageInfo.metaData = loadMetaData(dirName, raiseIfNotFound)
+                   raiseIfNotFound: bool, options: Options) =
+  packageInfo.metaData = loadMetaData(dirName, raiseIfNotFound, options)

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -386,7 +386,7 @@ proc getPkgInfoFromFile*(file: NimbleFile, options: Options,
 proc getPkgInfo*(dir: string, options: Options, forValidation = false):
     PackageInfo =
   ## Find the .nimble file in ``dir`` and parses it, returning a PackageInfo.
-  let nimbleFile = findNimbleFile(dir, true)
+  let nimbleFile = findNimbleFile(dir, true, options)
   result = getPkgInfoFromFile(nimbleFile, options, forValidation)
 
 proc getInstalledPkgs*(libsDir: string, options: Options): seq[PackageInfo] =
@@ -394,7 +394,7 @@ proc getInstalledPkgs*(libsDir: string, options: Options): seq[PackageInfo] =
   ##
   ## ``libsDir`` is in most cases: ~/.nimble/pkgs/
   const
-    readErrorMsg = "Installed package '$1@$2' is outdated or corrupt."
+    readErrorMsg = "Installed packaged '$1@$2' is outdated or corrupt."
     validationErrorMsg = readErrorMsg & "\nPackage did not pass validation: $3"
     hintMsg = "The corrupted package will need to be removed manually. To fix" &
               " this error message, remove $1."
@@ -413,12 +413,12 @@ proc getInstalledPkgs*(libsDir: string, options: Options): seq[PackageInfo] =
   result = @[]
   for kind, path in walkDir(libsDir):
     if kind == pcDir:
-      let nimbleFile = findNimbleFile(path, false)
+      let nimbleFile = findNimbleFile(path, false, options)
       if nimbleFile != "":
         var pkg = initPackageInfo()
         try:
           readPackageInfo(pkg, nimbleFile, options, onlyMinimalInfo=false)
-          fillMetaData(pkg, path, false)
+          fillMetaData(pkg, path, false, options)
         except ValidationError:
           let exc = (ref ValidationError)(getCurrentException())
           exc.msg = createErrorMsg(validationErrorMsg, path, exc.msg)

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -5,32 +5,32 @@ import testscommon
 
 # suits imports
 
-# import tinitcommand
-# import tcheckcommand
-# import tcleancommand
-# import tdevelopfeature
-# import tissues
-# import tlocaldeps
-# import tlockfile
-# import tmisctests
-# import tmoduletests
-# import tmultipkgs
-# import tnimbledump
-# import tnimblerefresh
-# import tnimbletasks
-# import tnimscript
-# import tshellenv
-# import tpathcommand
-# import treversedeps
-# import truncommand
-# import tsetupcommand
-# import ttestcommand
-# import ttwobinaryversions
-# import tuninstall
-# import ttaskdeps
-# import tsat
-# import tniminstall
-# import trequireflag
+import tinitcommand
+import tcheckcommand
+import tcleancommand
+import tdevelopfeature
+import tissues
+import tlocaldeps
+import tlockfile
+import tmisctests
+import tmoduletests
+import tmultipkgs
+import tnimbledump
+import tnimblerefresh
+import tnimbletasks
+import tnimscript
+import tshellenv
+import tpathcommand
+import treversedeps
+import truncommand
+import tsetupcommand
+import ttestcommand
+import ttwobinaryversions
+import tuninstall
+import ttaskdeps
+import tsat
+import tniminstall
+import trequireflag
 import tnimbinaries
 # nonim tests are very slow and (often) break the CI.
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -5,32 +5,33 @@ import testscommon
 
 # suits imports
 
-import tinitcommand
-import tcheckcommand
-import tcleancommand
-import tdevelopfeature
-import tissues
-import tlocaldeps
-import tlockfile
-import tmisctests
-import tmoduletests
-import tmultipkgs
-import tnimbledump
-import tnimblerefresh
-import tnimbletasks
-import tnimscript
-import tshellenv
-import tpathcommand
-import treversedeps
-import truncommand
-import tsetupcommand
-import ttestcommand
-import ttwobinaryversions
-import tuninstall
-import ttaskdeps
-import tsat
-import tniminstall
-import trequireflag
+# import tinitcommand
+# import tcheckcommand
+# import tcleancommand
+# import tdevelopfeature
+# import tissues
+# import tlocaldeps
+# import tlockfile
+# import tmisctests
+# import tmoduletests
+# import tmultipkgs
+# import tnimbledump
+# import tnimblerefresh
+# import tnimbletasks
+# import tnimscript
+# import tshellenv
+# import tpathcommand
+# import treversedeps
+# import truncommand
+# import tsetupcommand
+# import ttestcommand
+# import ttwobinaryversions
+# import tuninstall
+# import ttaskdeps
+# import tsat
+# import tniminstall
+# import trequireflag
+import tnimbinaries
 # nonim tests are very slow and (often) break the CI.
 
 # import tnonim

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -4,7 +4,7 @@
 import testscommon
 
 # suits imports
-
+import tnimbinaries
 import tinitcommand
 import tcheckcommand
 import tcleancommand
@@ -31,7 +31,6 @@ import ttaskdeps
 import tsat
 import tniminstall
 import trequireflag
-import tnimbinaries
 # nonim tests are very slow and (often) break the CI.
 
 # import tnonim

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -44,10 +44,10 @@ suite "Nim binaries":
   
   test "should be able to get the package info from the nim extracted folder":
     var options = initOptions()
-    let require: PkgTuple = (name: "nim", ver: parseVersionRange("2.0.4"))
+    let require: PkgTuple = (name: "nim", ver: parseVersionRange("2.2.0"))
     let nimInstalled = installNimFromBinariesDir(require, options)
     check nimInstalled.isSome
-    check nimInstalled.get().ver == newVersion("2.0.4")
+    check nimInstalled.get().ver == newVersion("2.2.0")
     options.nimBin = some options.makeNimBin("nim")
     let pkgInfo = getPkgInfo(nimInstalled.get().dir, options)    
     check pkgInfo.basicInfo.name == "nim"

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -75,8 +75,3 @@ suite "Nim binaries":
         check "iteration: 1" in lines
         check "iteration: 2" in lines
         check exitCode == QuitSuccess
-
-
-# Next steps:
-#   - Clean up downloadnim
-#   - Refactor the cache

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -1,0 +1,53 @@
+{.used.}
+import unittest
+import nimblepkg/[options, downloadnim, version, nimblesat]
+import std/[os, options]
+
+suite "Nim binaries":
+  test "can get all releases":
+    var options = initOptions()
+    let releases = getOfficialReleases(options)
+    check releases.len > 0
+    check releases[^1] == newVersion("1.2.8")
+
+  test "can download a concrete version":
+    var options = initOptions()
+    let version = newVersion("1.2.8")
+    let path = downloadNim(version, options)
+    check path.fileExists()
+
+  test "can download and unzip a version. Should also compile it if the prebinaries are not available for the current platform":
+    var options = initOptions()
+    let version = newVersion("2.0.4")
+    let extractDir = downloadAndExtractNim(version, options)
+    check extractDir.isSome
+    check fileExists(extractDir.get / "bin" / "nim")
+
+
+  test "Downloading minimal package with Nim should return all the versions":
+    var options = initOptions()
+    let pv = ("nim", VersionRange(kind: verAny))
+    let releases: seq[Version] = getOfficialReleases(options)
+    
+    let minimalPgks = downloadMinimalPackage(pv, options)
+    
+    check minimalPgks.len > 0
+    check minimalPgks.len == releases.len
+    for pkg in minimalPgks:
+      check pkg.version in releases
+  
+  test "installNimFromBinariesDir should return the installed version":
+    var options = initOptions()
+    let require: PkgTuple = (name: "nim", ver: parseVersionRange("2.0.4"))
+    let nimInstalled = installNimFromBinariesDir(require, options)
+    check nimInstalled.isSome
+    check nimInstalled.get().ver == newVersion("2.0.4")
+
+#Next steps:
+# - Install a package and test that the binary exists after the installation
+#   - Flag to opt-out 
+#   - Install deps as submodules
+#   - Windows 
+#   - Clean up downloadnim
+#   - Test that it only enters one per nim non special version in collectAllVersions
+#   - Full integration test

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -1,6 +1,6 @@
 {.used.}
 import unittest
-import nimblepkg/[options, downloadnim, version, nimblesat]
+import nimblepkg/[options, downloadnim, version, nimblesat, packageparser]
 import std/[os, options]
 
 suite "Nim binaries":
@@ -41,6 +41,15 @@ suite "Nim binaries":
     let nimInstalled = installNimFromBinariesDir(require, options)
     check nimInstalled.isSome
     check nimInstalled.get().ver == newVersion("2.0.4")
+  
+  test "should be able to get the package info from the nim extracted folder":
+    var options = initOptions()
+    let version = newVersion("2.2.0")
+    let extractDir = downloadAndExtractNim(version, options)    
+    options.nimBin = some options.makeNimBin("nim")
+    check extractDir.isSome
+    let pkgInfo = getPkgInfo(extractDir.get(), options)    
+    check pkgInfo.basicInfo.name == "nim"
 
 #Next steps:
 # - Install a package and test that the binary exists after the installation

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -21,7 +21,7 @@ suite "Nim binaries":
     let version = newVersion("2.0.4")
     let extractDir = downloadAndExtractNim(version, options)
     check extractDir.isSome
-    check fileExists(extractDir.get / "bin" / "nim")
+    check fileExists(extractDir.get / "bin" / "nim".addFileExt(ExeExt))
 
 
   test "Downloading minimal package with Nim should return all the versions":

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -2,6 +2,8 @@
 import unittest
 import nimblepkg/[options, downloadnim, version, nimblesat, packageparser]
 import std/[os, options]
+import testscommon
+from nimblepkg/common import cd
 
 suite "Nim binaries":
   test "can get all releases":
@@ -51,12 +53,30 @@ suite "Nim binaries":
     options.nimBin = some options.makeNimBin("nim")
     let pkgInfo = getPkgInfo(nimInstalled.get().dir, options)    
     check pkgInfo.basicInfo.name == "nim"
+  
+  test "Should be able to reuse -without compiling- a Nim version":
+    cd "nimnimble":
+      let nimVerDir = "nim2.0.4"
+      cd nimVerDir:
+        removeDir("nimbledeps")
+        let (output, exitCode) = execNimble("install", "-l")
+        var lines = output.processOutput
+        check "iteration: 1" notin lines
+        check "iteration: 2" notin lines
+        check exitCode == QuitSuccess
 
-#Next steps:
-# - Install a package and test that the binary exists after the installation
-#   - Flag to opt-out 
-#   - Install deps as submodules
-#   - Windows 
+  test "when disableNimBinaries is used should compile the Nim version":
+    cd "nimnimble":
+      let nimVerDir = "nim2.0.4"
+      cd nimVerDir:
+        removeDir("nimbledeps")
+        let (output, exitCode) = execNimble("install", "-l", "--disableNimBinaries")
+        var lines = output.processOutput
+        check "iteration: 1" in lines
+        check "iteration: 2" in lines
+        check exitCode == QuitSuccess
+
+
+# Next steps:
 #   - Clean up downloadnim
-#   - Test that it only enters one per nim non special version in collectAllVersions
-#   - Full integration test
+#   - Refactor the cache

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -16,12 +16,11 @@ suite "Nim binaries":
     let path = downloadNim(version, options)
     check path.fileExists()
 
-  test "can download and unzip a version. Should also compile it if the prebinaries are not available for the current platform":
+  test "can download and unzip a version. Should also compile it if the precompiled binaries are not available for the current platform":
     var options = initOptions()
     let version = newVersion("2.0.4")
     let extractDir = downloadAndExtractNim(version, options)
     check extractDir.isSome
-    check fileExists(extractDir.get / "bin" / "nim".addFileExt(ExeExt))
 
 
   test "Downloading minimal package with Nim should return all the versions":

--- a/tests/tnimbinaries.nim
+++ b/tests/tnimbinaries.nim
@@ -44,11 +44,12 @@ suite "Nim binaries":
   
   test "should be able to get the package info from the nim extracted folder":
     var options = initOptions()
-    let version = newVersion("2.2.0")
-    let extractDir = downloadAndExtractNim(version, options)    
+    let require: PkgTuple = (name: "nim", ver: parseVersionRange("2.0.4"))
+    let nimInstalled = installNimFromBinariesDir(require, options)
+    check nimInstalled.isSome
+    check nimInstalled.get().ver == newVersion("2.0.4")
     options.nimBin = some options.makeNimBin("nim")
-    check extractDir.isSome
-    let pkgInfo = getPkgInfo(extractDir.get(), options)    
+    let pkgInfo = getPkgInfo(nimInstalled.get().dir, options)    
     check pkgInfo.basicInfo.name == "nim"
 
 #Next steps:


### PR DESCRIPTION
Use precompiled Nim binaries if available for the current platform. Otherwise, compile them once for all packages. Only applies to non special versions. A flag will opt-out the process. 

Note tests are disabled