### PR TITLE
Enumerate tagged versions upfront

### DIFF
--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -19,7 +19,7 @@ proc updateSubmodules(dir: string) =
   discard tryDoCmdEx(
     &"git -C {dir} submodule update --init --recursive --depth 1")
 
-proc doCheckout(meth: DownloadMethod, downloadDir, branch: string) =
+proc doCheckout*(meth: DownloadMethod, downloadDir, branch: string) =
   case meth
   of DownloadMethod.git:
     # Force is used here because local changes may appear straight after a clone
@@ -46,7 +46,15 @@ proc doClone(meth: DownloadMethod, url, downloadDir: string, branch = "",
       branchArg = if branch == "": "" else: &"-b {branch}"
     discard tryDoCmdEx(&"hg clone {tipArg} {branchArg} {url} {downloadDir}")
 
-proc getTagsList(dir: string, meth: DownloadMethod): seq[string] =
+proc gitFetchTags*(repoDir: string, downloadMethod: DownloadMethod) =
+  case downloadMethod:
+    of DownloadMethod.git:
+      tryDoCmdEx(&"git -C {repoDir} fetch --tags")
+    of DownloadMethod.hg:
+      assert false, "hg not supported"
+
+
+proc getTagsList*(dir: string, meth: DownloadMethod): seq[string] =
   var output: string
   cd dir:
     case meth

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -470,7 +470,7 @@ proc getPackageMinimalVersionsFromRepo*(repoDir, pkgName: string, downloadMethod
 proc downloadMinimalPackage*(pv: PkgTuple, options: Options): seq[PackageMinimalInfo] =
   if pv.name == "": return newSeq[PackageMinimalInfo]()
   if pv.isNim and not options.disableNimBinaries: return getAllNimReleases(options)
-  if pv.ver.kind == verSpecial:
+  if pv.ver.kind in [verSpecial, verEq]: #if special or equal, we dont retrieve more versions as we only need one.
     result = @[downloadPkInfoForPv(pv, options).getMinimalInfo(options)]
   else:
     let (downloadRes, downloadMeth) = downloadPkgFromUrl(pv, options)

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -63,6 +63,7 @@ type
     extraRequires*: seq[PkgTuple] # extra requires parsed from the command line
     nimBinariesDir*: string # Directory where nim binaries are stored. Separated from nimbleDir as it can be changed by the user/tests
     disableNimBinaries*: bool # Whether to disable the use of nim binaries
+    maxTaggedVersions*: int # Maximum number of tags to check for a package when discovering versions in a local repo
 
   ActionType* = enum
     actionNil, actionRefresh, actionInit, actionDump, actionPublish, actionUpgrade
@@ -747,7 +748,8 @@ proc initOptions*(): Options =
     verbosity: HighPriority,
     noColor: not isatty(stdout),
     startDir: getCurrentDir(),
-    nimBinariesDir: getHomeDir() / ".nimble" / "nimbinaries"
+    nimBinariesDir: getHomeDir() / ".nimble" / "nimbinaries", 
+    maxTaggedVersions: 2 #TODO increase once we have a cache
   )
 
 proc handleUnknownFlags(options: var Options) =

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -749,7 +749,7 @@ proc initOptions*(): Options =
     noColor: not isatty(stdout),
     startDir: getCurrentDir(),
     nimBinariesDir: getHomeDir() / ".nimble" / "nimbinaries", 
-    maxTaggedVersions: 2 #TODO increase once we have a cache
+    maxTaggedVersions: 0 #TODO increase once we have a cache
   )
 
 proc handleUnknownFlags(options: var Options) =

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -749,7 +749,7 @@ proc initOptions*(): Options =
     noColor: not isatty(stdout),
     startDir: getCurrentDir(),
     nimBinariesDir: getHomeDir() / ".nimble" / "nimbinaries", 
-    maxTaggedVersions: 0 #TODO increase once we have a cache
+    maxTaggedVersions: 2 #TODO increase once we have a cache
   )
 
 proc handleUnknownFlags(options: var Options) =

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -272,7 +272,7 @@ proc inferInstallRules(pkgInfo: var PackageInfo, options: Options) =
     if fileExists(pkgInfo.getRealDir() / pkgInfo.basicInfo.name.addFileExt("nim")):
       pkgInfo.installFiles.add(pkgInfo.basicInfo.name.addFileExt("nim"))
 
-proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options, onlyMinimalInfo=false) =
+proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options, onlyMinimalInfo=false, useCache=true) =
   ## Reads package info from the specified Nimble file.
   ##
   ## Attempts to read it using the "old" Nimble ini format first, if that
@@ -289,7 +289,7 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
   assert fileExists(nf)
 
   # Check the cache.
-  if options.pkgInfoCache.hasKey(nf):
+  if useCache and options.pkgInfoCache.hasKey(nf):
     pkgInfo = options.pkgInfoCache[nf]
     return
   pkgInfo = initPackageInfo(options, nf)
@@ -369,12 +369,12 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
     validatePackageInfo(pkgInfo, options)
 
 proc getPkgInfoFromFile*(file: NimbleFile, options: Options,
-                         forValidation = false): PackageInfo =
+                         forValidation = false, useCache = true): PackageInfo =
   ## Reads the specified .nimble file and returns its data as a PackageInfo
   ## object. Any validation errors are handled and displayed as warnings.
   result = initPackageInfo()
   try:
-    readPackageInfo(result, file, options)
+    readPackageInfo(result, file, options, useCache= useCache)
   except ValidationError:
     let exc = (ref ValidationError)(getCurrentException())
     if exc.warnAll and not forValidation:

--- a/tests/oldnimble/oldnimble.nimble
+++ b/tests/oldnimble/oldnimble.nimble
@@ -1,0 +1,13 @@
+# Package
+
+version       = "0.1.0"
+author        = "jmgomez"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+
+# Dependencies
+
+requires "nim >= 2.0.11"
+requires "nimble <= 0.16.2" #We know this nimble version has additional requirements (new nimble use submodules)

--- a/tests/oldnimble/src/oldnimble.nim
+++ b/tests/oldnimble/src/oldnimble.nim
@@ -1,0 +1,7 @@
+# This is just an example to get you started. A typical library package
+# exports the main API in this file. Note that you cannot rename this file
+# but you can remove it if you wish.
+
+proc add*(x, y: int): int =
+  ## Adds two numbers together.
+  return x + y

--- a/tests/oldnimble/src/oldnimble/submodule.nim
+++ b/tests/oldnimble/src/oldnimble/submodule.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. Users of your library will
+# import this file by writing ``import oldnimble/submodule``. Feel free to rename or
+# remove this file altogether. You may create additional modules alongside
+# this file as required.
+
+type
+  Submodule* = object
+    name*: string
+
+proc initSubmodule*(): Submodule =
+  ## Initialises a new ``Submodule`` object.
+  Submodule(name: "Anonymous")

--- a/tests/oldnimble/tests/test1.nim
+++ b/tests/oldnimble/tests/test1.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. You may wish to put all of your
+# tests into a single file, or separate them into multiple `test1`, `test2`
+# etc. files (better names are recommended, just make sure the name starts with
+# the letter 't').
+#
+# To run these tests, simply execute `nimble test`.
+
+import unittest
+
+import oldnimble
+test "can add":
+  check add(5, 5) == 10

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -297,6 +297,7 @@ suite "SAT solver":
 
   test "should be able to get all the released PackageVersions from a git local repository":
     var options = initOptions()
+    options.maxTaggedVersions = 0 #all
     options.nimBin = some options.makeNimBin("nim")
     options.config.packageLists["official"] = PackageList(name: "Official", urls: @[
     "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json",

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -91,7 +91,6 @@ suite "SAT solver":
     check packages["a"] == newVersion "3.0"
     check packages["b"] == newVersion "0.1.0"
 
-
   test "solves 'Conflicting dependency resolution' #1162":
     let pkgVersionTable = {
       "a": PackageVersions(pkgName: "a", versions: @[
@@ -367,7 +366,10 @@ suite "SAT solver":
       let (_, exitCode) = execNimble("install", "-l")
       check exitCode == QuitSuccess
 
-
-#[
-  - TODO make sure all collected version requires are enumerated (they need to be taken into account in collectAllVersions after the getPackageMinimalVersionsFromRepo call)
-]#
+  test "should be able to collect all requires from old versions":
+    #We know this nimble version has additional requirements (new nimble use submodules)
+    #so if the requires are not collected we will not be able solve the package
+    cd "oldnimble": #0.16.2
+      removeDir("nimbledeps")
+      let (_, exitCode) = execNimbleYes("install", "-l")
+      check exitCode == QuitSuccess

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -357,11 +357,11 @@ suite "SAT solver":
         check v.versions.len <= options.maxTaggedVersions
       echo &"{k} versions {v.versions.len}"
   
-  test "when disableNimBinaries is used should compile the Nim version": 
+  test "should fallback to a previous version of a dependency when is unsatisfable": 
     #version 0.4.5 of nimfp requires nim as `nim 0.18.0` and other deps require `nim > 0.18.0`
     #version 0.4.4 tags it properly, so we test thats the one used
     #i.e when maxTaggedVersions is 1 it would fail as it would use 0.4.5
     cd "wronglytaggednim": 
       removeDir("nimbledeps")
-      let (output, exitCode) = execNimble("install", "-l")
+      let (_, exitCode) = execNimble("install", "-l")
       check exitCode == QuitSuccess

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -303,10 +303,10 @@ suite "SAT solver":
     "https://nim-lang.org/nimble/packages.json"
     ])
     let pv = parseRequires("nimfp >= 0.3.4")
-    let repoDir = pv.downloadPkgFromUrl(options).dir #This is just to setup the test. We need a git dir to work on
+    let repoDir = pv.downloadPkgFromUrl(options)[0].dir #This is just to setup the test. We need a git dir to work on
     let downloadMethod = DownloadMethod git
     
-    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv[0], downloadMethod, true, options)
+    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv[0], downloadMethod, options)
     
     #we know these versions are available
     let availableVersions = @["0.3.4", "0.3.5", "0.3.6", "0.4.5", "0.4.4"].mapIt(newVersion(it))

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -3,7 +3,7 @@ import unittest, os
 import testscommon
 # from nimblepkg/common import cd Used in the commented tests
 import std/[tables, sequtils, json, jsonutils, strutils, times, options, strformat]
-import nimblepkg/[version, nimblesat, options, config, download, packageparser, packageinfotypes, tools, packageinfo, cli]
+import nimblepkg/[version, nimblesat, options, config, download, packageinfotypes, packageinfo]
 from nimblepkg/common import cd
 
 proc initFromJson*(dst: var PkgTuple, jsonNode: JsonNode, jsonPath: var string) =
@@ -365,3 +365,8 @@ suite "SAT solver":
       removeDir("nimbledeps")
       let (_, exitCode) = execNimble("install", "-l")
       check exitCode == QuitSuccess
+
+
+#[
+  - TODO make sure all collected version requires are enumerated (they need to be taken into account in collectAllVersions after the getPackageMinimalVersionsFromRepo call)
+]#

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -2,10 +2,9 @@
 import unittest, os
 import testscommon
 # from nimblepkg/common import cd Used in the commented tests
-import std/[tables, sequtils, json, jsonutils, strutils, times, options]
-import nimblepkg/[version, nimblesat, options, config]
+import std/[tables, sequtils, json, jsonutils, strutils, times, options, strformat]
+import nimblepkg/[version, nimblesat, options, config, download, packageparser, packageinfotypes, tools, packageinfo, cli]
 from nimblepkg/common import cd
-
 
 proc initFromJson*(dst: var PkgTuple, jsonNode: JsonNode, jsonPath: var string) =
   dst = parseRequires(jsonNode.str)
@@ -295,3 +294,74 @@ suite "SAT solver":
     check packages.len == 2
     check packages["a"] == newVersion "3.0"
     check packages["b"] == newVersion "1.0.0"  # Should pick exact version 1.0.0 despite 2.0.0 being available
+
+  test "should be able to get all the released PackageVersions from a git local repository":
+    var options = initOptions()
+    options.nimBin = some options.makeNimBin("nim")
+    options.config.packageLists["official"] = PackageList(name: "Official", urls: @[
+    "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json",
+    "https://nim-lang.org/nimble/packages.json"
+    ])
+    let pv = parseRequires("nimfp >= 0.3.4")
+    let repoDir = pv.downloadPkgFromUrl(options).dir #This is just to setup the test. We need a git dir to work on
+    let downloadMethod = DownloadMethod git
+    
+    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv[0], downloadMethod, true, options)
+    
+    #we know these versions are available
+    let availableVersions = @["0.3.4", "0.3.5", "0.3.6", "0.4.5", "0.4.4"].mapIt(newVersion(it))
+    for version in availableVersions:
+      check version in packageVersions.mapIt(it.version)
+
+  test "if a dependency is unsatisfable, it should fallback to the previous version of the depency when available":
+    let pkgVersionTable = {
+      "a": PackageVersions(pkgName: "a", versions: @[
+        PackageMinimalInfo(name: "a", version: newVersion "3.0", requires: @[
+          (name:"b", ver: parseVersionRange ">= 0.5.0")
+        ], isRoot: true),       
+      ]),
+      "b": PackageVersions(pkgName: "b", versions: @[
+        PackageMinimalInfo(name: "b", version: newVersion "0.6.0", requires: @[
+          (name:"c", ver: parseVersionRange ">= 0.0.5")
+        ]),
+        PackageMinimalInfo(name: "b", version: newVersion "0.5.0", requires: @[
+         
+        ]),
+      ]),
+      "c": PackageVersions(pkgName: "c", versions: @[
+        PackageMinimalInfo(name: "c", version: newVersion "0.0.4"),
+      ])
+    }.toTable()
+
+    var graph = pkgVersionTable.toDepGraph()
+    let form = toFormular(graph)
+    var packages = initTable[string, Version]()
+    var output = ""
+    check solve(graph, form, packages, output)
+   
+  test "collectAllVersions should retrieve all releases of a given package":
+    var options = initOptions()
+    options.nimBin = some options.makeNimBin("nim")
+    options.config.packageLists["official"] = PackageList(name: "Official", urls: @[
+    "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json",
+    "https://nim-lang.org/nimble/packages.json"
+    ])
+    let pv = parseRequires("chronos >= 4.0.0")
+    var pkgInfo = downloadPkInfoForPv(pv, options)
+    var root = pkgInfo.getMinimalInfo(options)
+    root.isRoot = true
+    var pkgVersionTable = initTable[string, PackageVersions]()
+    collectAllVersions(pkgVersionTable, root, options, downloadMinimalPackage)
+    for k, v in pkgVersionTable:
+      if not k.isNim:
+        check v.versions.len <= options.maxTaggedVersions
+      echo &"{k} versions {v.versions.len}"
+  
+  test "when disableNimBinaries is used should compile the Nim version": 
+    #version 0.4.5 of nimfp requires nim as `nim 0.18.0` and other deps require `nim > 0.18.0`
+    #version 0.4.4 tags it properly, so we test thats the one used
+    #i.e when maxTaggedVersions is 1 it would fail as it would use 0.4.5
+    cd "wronglytaggednim": 
+      removeDir("nimbledeps")
+      let (output, exitCode) = execNimble("install", "-l")
+      check exitCode == QuitSuccess

--- a/tests/wronglytaggednim/src/wronglytaggednim.nim
+++ b/tests/wronglytaggednim/src/wronglytaggednim.nim
@@ -1,0 +1,7 @@
+# This is just an example to get you started. A typical library package
+# exports the main API in this file. Note that you cannot rename this file
+# but you can remove it if you wish.
+
+proc add*(x, y: int): int =
+  ## Adds two numbers together.
+  return x + y

--- a/tests/wronglytaggednim/src/wronglytaggednim/submodule.nim
+++ b/tests/wronglytaggednim/src/wronglytaggednim/submodule.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. Users of your library will
+# import this file by writing ``import wronglytaggednim/submodule``. Feel free to rename or
+# remove this file altogether. You may create additional modules alongside
+# this file as required.
+
+type
+  Submodule* = object
+    name*: string
+
+proc initSubmodule*(): Submodule =
+  ## Initialises a new ``Submodule`` object.
+  Submodule(name: "Anonymous")

--- a/tests/wronglytaggednim/tests/test1.nim
+++ b/tests/wronglytaggednim/tests/test1.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. You may wish to put all of your
+# tests into a single file, or separate them into multiple `test1`, `test2`
+# etc. files (better names are recommended, just make sure the name starts with
+# the letter 't').
+#
+# To run these tests, simply execute `nimble test`.
+
+import unittest
+
+import wronglytaggednim
+test "can add":
+  check add(5, 5) == 10

--- a/tests/wronglytaggednim/wronglytaggednim.nimble
+++ b/tests/wronglytaggednim/wronglytaggednim.nimble
@@ -1,0 +1,12 @@
+# Package
+
+version       = "0.1.0"
+author        = "jmgomez"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+
+
+# Dependencies
+
+requires "nim >= 0.18.0", "random >= 0.5.6", "nimfp <= 0.4.5"


### PR DESCRIPTION
The PR does mainly two things: 
 - Navigate to a package repo and extracts n tagged versions
 - The SAT solver now can fallback to a previous version of a package if the latest version is unsatisfable 
 
 In another PR a cache for tagged versions will be introduced 