### PR TITLE
Cli ux improvements docs

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2381,10 +2381,10 @@ proc doAction(options: var Options) =
     init(options)
   of actionPublish:
     var pkgInfo = getPkgInfo(getCurrentDir(), options)
-    if options.action.publishAction == "tags":
-      publishTags(pkgInfo, options)
-    else:
-      publish(pkgInfo, options)
+    publish(pkgInfo, options)
+  of actionPublishTags:
+    var pkgInfo = getPkgInfo(getCurrentDir(), options)
+    publishTags(pkgInfo, options)
   of actionDump:
     dump(options)
   of actionTasks:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -338,7 +338,7 @@ proc parseActionType*(action: string): ActionType =
     result = actionUninstall
   of "publish":
     result = actionPublish
-  of "publishTags":
+  of "publishtags":
     result = actionPublishTags
   of "upgrade":
     result = actionUpgrade

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -70,7 +70,8 @@ type
     actionInstall, actionSearch, actionList, actionBuild, actionPath,
     actionUninstall, actionCompile, actionDoc, actionCustom, actionTasks,
     actionDevelop, actionCheck, actionLock, actionRun, actionSync, actionSetup,
-    actionClean, actionDeps, actionShellEnv, actionShell, actionAdd, actionManual
+    actionClean, actionDeps, actionShellEnv, actionShell, actionAdd, actionManual,
+    actionPublishTags
 
   DevelopActionType* = enum
     datAdd, datRemoveByPath, datRemoveByName, datInclude, datExclude
@@ -177,6 +178,8 @@ Commands:
   publish                         Publishes a package on nim-lang/packages.
                                   The current working directory needs to be the
                                   top level directory of the Nimble package.
+  publishTags                     Finds and publishes new tags based on the
+                                  commits where the packages Nimble file changed.
   uninstall    [pkgname, ...]     Uninstalls a list of packages.
                [-i, --inclDeps]   Uninstalls package and dependent package(s).
   build        [opts, ...] [bin]  Builds a package. Passes options to the Nim
@@ -216,9 +219,11 @@ Commands:
                [--ini, --json]    Selects the output format (the default is --ini).
   lock                            Generates or updates a package lock file.
   upgrade      [pkgname, ...]     Upgrades a list of packages in the lock file.
-  deps                            Outputs dependency tree
+  deps                            Outputs dependencies for current package.
+               [--tree]           Outputs dependency tree.
+               [--inverted]       Outputs inverted (reversed) dependency tree.
                [--format type]    Specify the output format. Json is the only supported
-                                  format
+                                  format. Only some commands support it.
   sync                            Synchronizes develop mode dependencies with
                                   the content of the lock file.
                [-l, --listOnly]   Only lists the packages which are not synced

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -338,6 +338,8 @@ proc parseActionType*(action: string): ActionType =
     result = actionUninstall
   of "publish":
     result = actionPublish
+  of "publishTags":
+    result = actionPublishTags
   of "upgrade":
     result = actionUpgrade
   of "tasks":

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -125,6 +125,8 @@ type
       depsAction*: string
     of actionPublish:
       publishAction*: string
+    of actionPublishTags:
+      onlyListTags*: bool
     of actionShellEnv, actionShell:
       discard
 
@@ -180,6 +182,8 @@ Commands:
                                   top level directory of the Nimble package.
   publishTags                     Finds and publishes new tags based on the
                                   commits where the packages Nimble file changed.
+               [-l, --listOnly]   Only list the tags and versions which are found without
+                                  actually performing tag or publishing them.
   uninstall    [pkgname, ...]     Uninstalls a list of packages.
                [-i, --inclDeps]   Uninstalls package and dependent package(s).
   build        [opts, ...] [bin]  Builds a package. Passes options to the Nim
@@ -765,6 +769,12 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     case f
     of "tags":
       result.action.publishAction = "tags"
+    else:
+      wasFlagHandled = false
+  of actionPublishTags:
+    case f
+    of "l", "listonly":
+      result.action.onlyListTags = true
     else:
       wasFlagHandled = false
   of actionDeps:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -181,7 +181,7 @@ Commands:
                                   The current working directory needs to be the
                                   top level directory of the Nimble package.
   publishTags                     Finds and publishes new tags based on the
-                                  commits where the packages Nimble file changed.
+                                  commits where a package's Nimble file changed.
                [-l, --listOnly]   Only list the tags and versions which are found without
                                   actually performing tag or publishing them.
   uninstall    [pkgname, ...]     Uninstalls a list of packages.

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -305,11 +305,11 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         if version notin versions: 
           versions.incl(version)
           if version in existingTags:
-            displayInfo(&"Found existing tag for version {version}", HighPriority)
+            displayInfo(&"Found existing tag for version {version} at commit {commit}", HighPriority)
           else:
             displayInfo(&"Found new version {version} at {commit}", HighPriority)
             if not options.action.onlyListTags:
-              displayInfo(&"Creating tag for new version {version} at {commit}", HighPriority)
+              displayWarning(&"Creating tag for new version {version} at {commit}", HighPriority)
               let res = createTag(&"v{version}", commit, message, projdir, nimbleFile, downloadMethod)
               if not res:
                 displayError(&"Unable to create tag {version}", HighPriority)

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -305,23 +305,18 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         if version notin versions: 
           versions.incl(version)
           if version in existingTags:
-            displayInfo(&"Found existing tag for version {version}", MediumPriority)
+            displayInfo(&"Found existing tag for version {version}", HighPriority)
           else:
-            displayInfo(&"Found new version {version} at {commit}", MediumPriority)
+            displayInfo(&"Found new version {version} at {commit}", HighPriority)
             let res = createTag(&"v{version}", commit, message, projdir, nimbleFile, downloadMethod)
             if not res:
-              displayError(&"Unable to create tag {version}")
+              displayError(&"Unable to create tag {version}", HighPriority)
 
 proc publishTags*(p: PackageInfo, o: Options) =
-  discard
-  echo "publishTags:myPath: ", $p.myPath
-  echo "publishTags:basic: ", $p.basicInfo
-  # echo "publishTags: ", $p
+  displayInfo(&"Searcing for new tags for {$p.basicInfo.name} @{$p.basicInfo.version}", HighPriority)
   let (projdir, file, ext) = p.myPath.splitFile()
   let nimblefile = file & ext
   let dlmethod = p.metadata.downloadMethod
   let commits = vcsFindCommits(projdir, nimbleFile, dlmethod)
-  echo "publishTags:commits: ", $commits.len()
 
   findVersions(commits, projdir, nimbleFile, dlmethod)
-  echo ""


### PR DESCRIPTION
Ooops, forgot to update some of the help docs for my last PR. The new commands aren't helpful if folks can't find them!

Also decided to change `nimble publish --tags` to `nimble publishTags`. It helps split out options for the commands and their options, while still grouping similar actions for discoverability.
