### PR TITLE
UX Change to show checksums and git commits in deps output

### DIFF
--- a/src/nimblepkg/deps.nim
+++ b/src/nimblepkg/deps.nim
@@ -1,5 +1,5 @@
 import tables, strformat, sequtils, algorithm, cli
-import packageinfotypes, developfile, packageinfo, version
+import packageinfotypes, developfile, packageinfo, sha1hashes, version
 
 type
   DependencyNode = ref object of RootObj
@@ -42,10 +42,11 @@ proc printDepsHumanReadable*(pkgInfo: PackageInfo,
   ## 
   if levelInfos.len() == 0:
     displayLineReset()
-    displayInfo("Dependency tree format: {PackageName} {Requirements} (@{Resolved Version})")
+    displayInfo("Dependency tree format: {PackageName} {Requirements} (@{Resolved Version} commit {short-hash-id})")
     displayFormatted(Hint, "\n")
     displayFormatted(Message, pkgInfo.basicInfo.name, " ")
     displayFormatted(Success, "(@", $pkgInfo.basicInfo.version, ")")
+    displayFormatted(Details, " [", pkgInfo.metaData.vcsRevision.shortId(), "]")
 
   var requires: seq[(string, VersionRange, bool, PackageInfo)]
   for idx, (name, ver) in pkgInfo.requires.sorted():
@@ -78,6 +79,7 @@ proc printDepsHumanReadable*(pkgInfo: PackageInfo,
     displayFormatted(Hint, " ")
     if found:
       displayFormatted(Success, fmt"(@{depPkgInfo.basicInfo.version})")
+      displayFormatted(Details, " [", pkgInfo.metaData.vcsRevision.shortId(), "]")
     if errors.contains(packageName):
       let errMsg = getValidationErrorMessage(packageName, errors.getOrDefault packageName)
       displayFormatted(Error, fmt" - error: {errMsg}")
@@ -100,11 +102,12 @@ proc printDepsHumanReadableInverted*(pkgInfo: PackageInfo,
     isRoot = pkgs.len() == 0
 
   if isRoot:
-    displayInfo("Dependency tree format: {PackageName} (@{Resolved Version})")
+    displayInfo("Dependency tree format: {PackageName} (@{Resolved Version} commit {short-hash-id})")
     displayInfo("Dependency tree format:    {Source Package} {Source Requirements}")
     displayFormatted(Hint, "\n")
     displayFormatted(Message, pkgInfo.basicInfo.name, " ")
     displayFormatted(Success, "(@", $pkgInfo.basicInfo.version, ")")
+    displayFormatted(Details, " [#", pkgInfo.metaData.vcsRevision.shortId(), "]")
     displayFormatted(Hint, "\n")
 
   for (name, ver) in pkgInfo.requires:
@@ -130,6 +133,7 @@ proc printDepsHumanReadableInverted*(pkgInfo: PackageInfo,
         displayFormatted(Hint, "└── ")
       displayFormatted(Message, name, " ")
       displayFormatted(Success, "(@", $pkgInfo.basicInfo.version, ")")
+      displayFormatted(Details, " [", pkgInfo.metaData.vcsRevision.shortId(), "]")
       displayFormatted(Hint, "\n")
       # echo "name: ", pkg, " info: ", $info
       # for idx, (source, ver) in info.pairs().toSeq():

--- a/src/nimblepkg/deps.nim
+++ b/src/nimblepkg/deps.nim
@@ -46,7 +46,8 @@ proc printDepsHumanReadable*(pkgInfo: PackageInfo,
     displayFormatted(Hint, "\n")
     displayFormatted(Message, pkgInfo.basicInfo.name, " ")
     displayFormatted(Success, "(@", $pkgInfo.basicInfo.version, ")")
-    displayFormatted(Details, " [", pkgInfo.metaData.vcsRevision.shortId(), "]")
+    displayFormatted(Details, " [vcs: ", pkgInfo.metaData.vcsRevision.shortId(),
+                              " checksum: ", pkgInfo.basicInfo.checksum.shortId(), "]")
 
   var requires: seq[(string, VersionRange, bool, PackageInfo)]
   for idx, (name, ver) in pkgInfo.requires.sorted():
@@ -79,7 +80,8 @@ proc printDepsHumanReadable*(pkgInfo: PackageInfo,
     displayFormatted(Hint, " ")
     if found:
       displayFormatted(Success, fmt"(@{depPkgInfo.basicInfo.version})")
-      displayFormatted(Details, " [", pkgInfo.metaData.vcsRevision.shortId(), "]")
+      displayFormatted(Details, " [vcs: ", depPkgInfo.metaData.vcsRevision.shortId(),
+                                " checksum: ", depPkgInfo.basicInfo.checksum.shortId(), "]")
     if errors.contains(packageName):
       let errMsg = getValidationErrorMessage(packageName, errors.getOrDefault packageName)
       displayFormatted(Error, fmt" - error: {errMsg}")
@@ -107,7 +109,8 @@ proc printDepsHumanReadableInverted*(pkgInfo: PackageInfo,
     displayFormatted(Hint, "\n")
     displayFormatted(Message, pkgInfo.basicInfo.name, " ")
     displayFormatted(Success, "(@", $pkgInfo.basicInfo.version, ")")
-    displayFormatted(Details, " [#", pkgInfo.metaData.vcsRevision.shortId(), "]")
+    displayFormatted(Details, " [vcs: ", pkgInfo.metaData.vcsRevision.shortId(),
+                              " checksum: ", pkgInfo.basicInfo.checksum.shortId(), "]")
     displayFormatted(Hint, "\n")
 
   for (name, ver) in pkgInfo.requires:
@@ -131,9 +134,7 @@ proc printDepsHumanReadableInverted*(pkgInfo: PackageInfo,
         displayFormatted(Hint, "├── ")
       else:
         displayFormatted(Hint, "└── ")
-      displayFormatted(Message, name, " ")
-      displayFormatted(Success, "(@", $pkgInfo.basicInfo.version, ")")
-      displayFormatted(Details, " [", pkgInfo.metaData.vcsRevision.shortId(), "]")
+      displayFormatted(Message, name)
       displayFormatted(Hint, "\n")
       # echo "name: ", pkg, " info: ", $info
       # for idx, (source, ver) in info.pairs().toSeq():

--- a/src/nimblepkg/sha1hashes.nim
+++ b/src/nimblepkg/sha1hashes.nim
@@ -21,6 +21,7 @@ template `$`*(sha1Hash: Sha1Hash): string = sha1Hash.hashValue
 template `%`*(sha1Hash: Sha1Hash): JsonNode = %sha1Hash.hashValue
 template `==`*(lhs, rhs: Sha1Hash): bool = lhs.hashValue == rhs.hashValue
 template hash*(sha1Hash: Sha1Hash): Hash = sha1Hash.hashValue.hash
+template shortId*(sha1Hash: Sha1Hash): string = sha1Hash.hashValue[0..8]
 
 proc invalidSha1Hash(value: string): ref InvalidSha1HashError =
   ## Creates a new exception object for an invalid sha1 hash value.


### PR DESCRIPTION
Useful for seeing what version and checksum combo is actually used. 

Example output. 

![image](https://github.com/user-attachments/assets/e8d58372-40b6-48a3-8a00-70a1a1a9a02a)

