### PR TITLE
Add error checking for `publishTags` command and rename to `versions`

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2382,9 +2382,9 @@ proc doAction(options: var Options) =
   of actionPublish:
     var pkgInfo = getPkgInfo(getCurrentDir(), options)
     publish(pkgInfo, options)
-  of actionPublishTags:
+  of actionPublishVersions:
     var pkgInfo = getPkgInfo(getCurrentDir(), options)
-    publishTags(pkgInfo, options)
+    publishVersions(pkgInfo, options)
   of actionDump:
     dump(options)
   of actionTasks:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -97,7 +97,7 @@ proc getTagsListRemote*(url: string, meth: DownloadMethod): seq[string] =
   case meth
   of DownloadMethod.git:
     var output = tryDoCmdEx(&"git ls-remote {url}")
-    for item in output.gitTagsFromRefs(derefTags = false).pairs:
+    for item in output.gitTagsFromRefs().pairs:
       result.add item[0]
 
   of DownloadMethod.hg:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -64,7 +64,7 @@ proc gitTagsFromRefs(output: string, derefTags = true): OrderedTable[string, Sha
     let tag = line[start .. line.len-1]
     let hash = initSha1Hash(hashStr)
     if tag.endswith("^{}") and derefTags:
-      result[tag] = hash
+      result[tag[0..^4]] = hash
     elif not tag.endswith("^{}"):
       result[tag] = hash
 
@@ -97,7 +97,7 @@ proc getTagsListRemote*(url: string, meth: DownloadMethod): seq[string] =
   case meth
   of DownloadMethod.git:
     var output = tryDoCmdEx(&"git ls-remote {url}")
-    for item in output.gitTagsFromRefs().pairs:
+    for item in output.gitTagsFromRefs(derefTags = false).pairs:
       result.add item[0]
 
   of DownloadMethod.hg:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -65,7 +65,7 @@ proc gitTagsFromRefs(output: string, derefTags = true): OrderedTable[string, Sha
     let hash = initSha1Hash(hashStr)
     if tag.endswith("^{}") and derefTags:
       result[tag] = hash
-    else:
+    elif not tag.endswith("^{}"):
       result[tag] = hash
 
 proc getTagsList*(dir: string, meth: DownloadMethod): seq[string] =

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -73,7 +73,7 @@ proc getTagsList*(dir: string, meth: DownloadMethod): seq[string] =
   cd dir:
     case meth
     of DownloadMethod.git:
-      output = tryDoCmdEx("git tag")
+      output = tryDoCmdEx(&"git show-ref --dereference")
     of DownloadMethod.hg:
       output = tryDoCmdEx("hg tags")
   if output.len > 0:
@@ -124,7 +124,7 @@ proc gitTagCommits*(repoDir: string, downloadMethod: DownloadMethod): Table[stri
   ## Return a table of tag -> commit
   case downloadMethod:
     of DownloadMethod.git:
-      let output = tryDoCmdEx(&"git -C {repoDir} show-ref")
+      let output = tryDoCmdEx(&"git -C {repoDir} show-ref --dereference")
       for item in output.gitTagsFromRefs().pairs:
         result[item[0]] = item[1]
     of DownloadMethod.hg:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -181,10 +181,10 @@ Commands:
   publish                         Publishes a package on nim-lang/packages.
                                   The current working directory needs to be the
                                   top level directory of the Nimble package.
-  publishVersions                 Finds package versions based on commits
+  publishVersions                 Lists package versions based on commits
                                   where the package's Nimble version changed.
-               [-c, --create]     Only list the tags and versions which are found without
-                                  actually performing tag or publishing them.
+               [-c, --create]     Creates tags for missing versions.
+               [-p, --push]       Push only tagged versions (tags) to VCS.
   uninstall    [pkgname, ...]     Uninstalls a list of packages.
                [-i, --inclDeps]   Uninstalls package and dependent package(s).
   build        [opts, ...] [bin]  Builds a package. Passes options to the Nim

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -71,7 +71,7 @@ type
     actionUninstall, actionCompile, actionDoc, actionCustom, actionTasks,
     actionDevelop, actionCheck, actionLock, actionRun, actionSync, actionSetup,
     actionClean, actionDeps, actionShellEnv, actionShell, actionAdd, actionManual,
-    actionPublishTags
+    actionPublishVersions
 
   DevelopActionType* = enum
     datAdd, datRemoveByPath, datRemoveByName, datInclude, datExclude
@@ -125,8 +125,8 @@ type
       depsAction*: string
     of actionPublish:
       publishAction*: string
-    of actionPublishTags:
-      onlyListTags*: bool
+    of actionPublishVersions:
+      createTags*: bool
     of actionShellEnv, actionShell:
       discard
 
@@ -180,9 +180,9 @@ Commands:
   publish                         Publishes a package on nim-lang/packages.
                                   The current working directory needs to be the
                                   top level directory of the Nimble package.
-  publishTags                     Finds and publishes new tags based on the
-                                  commits where a package's Nimble file changed.
-               [-l, --listOnly]   Only list the tags and versions which are found without
+  publishVersions                 Finds package versions based on commits
+                                  where the package's Nimble version changed.
+               [-c, --create]     Only list the tags and versions which are found without
                                   actually performing tag or publishing them.
   uninstall    [pkgname, ...]     Uninstalls a list of packages.
                [-i, --inclDeps]   Uninstalls package and dependent package(s).
@@ -338,8 +338,8 @@ proc parseActionType*(action: string): ActionType =
     result = actionUninstall
   of "publish":
     result = actionPublish
-  of "publishtags":
-    result = actionPublishTags
+  of "publishversions":
+    result = actionPublishVersions
   of "upgrade":
     result = actionUpgrade
   of "tasks":
@@ -773,10 +773,10 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.action.publishAction = "tags"
     else:
       wasFlagHandled = false
-  of actionPublishTags:
+  of actionPublishVersions:
     case f
-    of "l", "listonly":
-      result.action.onlyListTags = true
+    of "c", "create":
+      result.action.createTags = true
     else:
       wasFlagHandled = false
   of actionDeps:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -127,6 +127,7 @@ type
       publishAction*: string
     of actionPublishVersions:
       createTags*: bool
+      pushTags*: bool
     of actionShellEnv, actionShell:
       discard
 
@@ -777,6 +778,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     case f
     of "c", "create":
       result.action.createTags = true
+    of "p", "push":
+      result.action.pushTags = true
     else:
       wasFlagHandled = false
   of actionDeps:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -182,8 +182,9 @@ Commands:
   publish                         Publishes a package on nim-lang/packages.
                                   The current working directory needs to be the
                                   top level directory of the Nimble package.
-  publishVersions                 Lists package versions based on commits
-                                  where the package's Nimble version changed.
+  versions                        Lists package versions based on commits in the
+                                  current branch where the package's Nimble version
+                                  was changed.
                [-c, --create]     Creates tags for missing versions.
                [-p, --push]       Push only tagged versions (tags) to VCS.
   uninstall    [pkgname, ...]     Uninstalls a list of packages.
@@ -340,7 +341,7 @@ proc parseActionType*(action: string): ActionType =
     result = actionUninstall
   of "publish":
     result = actionPublish
-  of "publishversions":
+  of "versions", "publishversions":
     result = actionPublishVersions
   of "upgrade":
     result = actionUpgrade

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -128,7 +128,7 @@ type
     of actionPublishVersions:
       createTags*: bool
       pushTags*: bool
-      all*: bool
+      allTags*: bool
     of actionShellEnv, actionShell:
       discard
 
@@ -781,6 +781,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.action.createTags = true
     of "p", "push":
       result.action.pushTags = true
+    of "a", "all":
+      result.action.allTags = true
     else:
       wasFlagHandled = false
   of actionDeps:

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -128,6 +128,7 @@ type
     of actionPublishVersions:
       createTags*: bool
       pushTags*: bool
+      all*: bool
     of actionShellEnv, actionShell:
       discard
 

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -334,7 +334,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
   if options.action.createTags:
     for (version, info) in versions.pairs:
       if version in nonMonotonicVers:
-        displayWarning(&"Skipping creating tag for new version {version} at {info.commit}", HighPriority)
+        displayWarning(&"Skipping creating tag for non-monotonic {version} at {info.commit}", HighPriority)
       else:
         displayWarning(&"Creating tag for new version {version} at {info.commit}", HighPriority)
         let res = createTag(&"v{version}", info.commit, info.message, projdir, nimbleFile, downloadMethod)

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -320,7 +320,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         prevMonotonicsOk = monotonics.mapIt(ver < it).all(proc (x: bool): bool = x)
 
       if ver < prev[0] and prevMonotonicsOk:
-        displayDetails(&"versions ok at tags {ver}@{info.commit} and previous tag of {prev[0]}@{prev[1]}", HighPriority)
+        displaySuccess(&"versions ok at tags {ver}@{info.commit} and previous tag of {prev[0]}@{prev[1]}", HighPriority)
       else:
         if prev[0] notin nonMonotonicVers:
           monotonics.add(prev[0]) # track last largest monotonic so we can check, e.g. 0.2, 3.0, 0.3 and not 0.2, 3.0, 0.2 

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -320,15 +320,14 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         if line.find(peg"'+version' \s* '=' \s* {[\34\39]} {@} $1", matches) > -1:
           let ver = newVersion(matches[1])
           if ver notin versions:
-            versions[ver] = (commit: commit, message: message)
             if ver in existingTags:
-              if not options.action.allTags:
-                break outer
-              else:
+              if options.action.allTags:
                 displayInfo(&"Found existing tag for version {ver} at commit {commit}", HighPriority)
+              else:
+                break outer
             else:
               displayInfo(&"Found new version {ver} at {commit}", HighPriority)
-  echo "FIRST TAG DONE "
+              versions[ver] = (commit: commit, message: message)
 
   var nonMonotonicVers: Table[Version, Sha1Hash]
   if versions.len() >= 2:
@@ -351,7 +350,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
                      &" and the previous tag {TagVersionFmt % $prev[0]}@{prev[1].commit}", HighPriority)
         displayWarning(&"Version {ver} will be skipped. Please tag it manually if the version is correct." , HighPriority)
         displayHint(&"Note that versions are checked from larget to smallest" , HighPriority)
-        displayHint(&"Note later smaller versions are always peferred. Please manually review your tags before pushing." , HighPriority)
+        displayHint(&"Note smaller versions later in history are always peferred. Please manually review your tags before pushing." , HighPriority)
 
   var newTags: HashSet[string]
   if options.action.createTags:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -294,7 +294,7 @@ proc pushTags*(tags: seq[string], repoDir: string, downloadMethod: DownloadMetho
     of DownloadMethod.hg:
       assert false, "hg not supported"
   
-const tagVersionFmt = "v$1"
+const TagVersionFmt = "v$1"
 
 proc findExistingTags(projdir: string, downloadMethod: DownloadMethod): HashSet[Version] =
   for tag in getTagsList(projdir, downloadMethod):
@@ -345,14 +345,14 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         prevMonotonicsOk = monotonics.mapIt(ver < it).all(proc (x: bool): bool = x)
 
       if ver < prev[0] and prevMonotonicsOk:
-        displayHint(&"Versions monotonic between tag {ver}@{info.commit} " &
-                      &" and previous tag of {prev[0]}@{prev[1].commit}", MediumPriority)
+        displayHint(&"Versions monotonic between tag {TagVersionFmt % $ver}@{info.commit} " &
+                      &" and previous tag of {TagVersionFmt % $prev[0]}@{prev[1].commit}", MediumPriority)
       else:
         if prev[0] notin nonMonotonicVers:
           monotonics.add(prev[0]) # track last largest monotonic so we can check, e.g. 0.2, 3.0, 0.3 and not 0.2, 3.0, 0.2 
         nonMonotonicVers[ver] = info.commit
-        displayError(&"Non-monotonic (decreasing) version found between tag {ver}@{info.commit}" &
-                     &" and the previous tag {prev[0]}@{prev[1].commit}", HighPriority)
+        displayError(&"Non-monotonic (decreasing) version found between tag {TagVersionFmt % $ver}@{info.commit}" &
+                     &" and the previous tag {TagVersionFmt % $prev[0]}@{prev[1].commit}", HighPriority)
         displayWarning(&"Version {ver} will be skipped. Please tag it manually if the version is correct." , HighPriority)
         displayHint(&"Note that versions are checked from larget to smallest" , HighPriority)
         displayHint(&"Note later smaller versions are always peferred. Please manually review your tags before pushing." , HighPriority)
@@ -363,11 +363,11 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
       if version in nonMonotonicVers:
         displayWarning(&"Skipping creating tag for non-monotonic {version} at {info.commit}", HighPriority)
       else:
-        let tag = tagVersionFmt % [$version]
+        let tag = TagVersionFmt % [$version]
         displayWarning(&"Creating tag for new version {version} at {info.commit}", HighPriority)
         let res = createTag(tag, info.commit, info.message, projdir, nimbleFile, downloadMethod)
         if not res:
-          displayError(&"Unable to create tag {version}", HighPriority)
+          displayError(&"Unable to create tag {TagVersionFmt % $version}", HighPriority)
         else:
           newTags.incl(tag)
 

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -330,6 +330,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
                      &" and the previous tag {prev[0]}@{prev[1].commit}", HighPriority)
         displayWarning(&"Version {ver} will be skipped. Please tag it manually if the version is correct." , HighPriority)
         displayHint(&"Note that versions are checked from larget to smallest" , HighPriority)
+        displayHint(&"Note later smaller versions are always peferred. Please manually review your tags before pushing." , HighPriority)
 
   if options.action.createTags:
     for (version, info) in versions.pairs:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -348,22 +348,22 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         displayHint(&"Note that versions are checked from larget to smallest" , HighPriority)
         displayHint(&"Note later smaller versions are always peferred. Please manually review your tags before pushing." , HighPriority)
 
+  var newTags: HashSet[string]
   if options.action.createTags:
     for (version, info) in versions.pairs:
       if version in nonMonotonicVers:
         displayWarning(&"Skipping creating tag for non-monotonic {version} at {info.commit}", HighPriority)
       else:
+        let tag = tagVersionFmt % [$version]
         displayWarning(&"Creating tag for new version {version} at {info.commit}", HighPriority)
-        let res = createTag(tagVersionFmt % [$version], info.commit, info.message, projdir, nimbleFile, downloadMethod)
+        let res = createTag(tag, info.commit, info.message, projdir, nimbleFile, downloadMethod)
         if not res:
           displayError(&"Unable to create tag {version}", HighPriority)
+        else:
+          newTags.add(tag)
 
   if options.action.pushTags:
-    var tags: seq[string]
-    for (version, info) in versions.pairs:
-      if version in nonMonotonicVers:
-        tags.add(tagVersionFmt % [$version])
-    let res = pushTags(tags, projdir, downloadMethod)
+    let res = pushTags(tags.toSeq(), projdir, downloadMethod)
 
 proc publishVersions*(p: PackageInfo, options: Options) =
   displayInfo(&"Searcing for new tags for {$p.basicInfo.name} @{$p.basicInfo.version}", HighPriority)

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -320,7 +320,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         prevMonotonicsOk = monotonics.mapIt(ver < it).all(proc (x: bool): bool = x)
 
       if ver < prev[0] and prevMonotonicsOk:
-        displaySuccess(&"versions ok at tags {ver}@{info.commit} and previous tag of {prev[0]}@{prev[1]}", HighPriority)
+        displayWarning(&"versions ok at tags {ver}@{info.commit} and previous tag of {prev[0]}@{prev[1]}", HighPriority)
       else:
         if prev[0] notin nonMonotonicVers:
           monotonics.add(prev[0]) # track last largest monotonic so we can check, e.g. 0.2, 3.0, 0.3 and not 0.2, 3.0, 0.2 

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -308,8 +308,8 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
     displayWarning(&"Note runnig this command on a non-standard primary branch `{currBranch}` may have unintened consequences", HighPriority)
 
   for tag in existingTags.keys().toSeq().sorted():
-    # let commit = getVersionList(tag)
-    displayInfo(&"Existing version {tag} ", HighPriority)
+    let commit = existingTags[tag]
+    displayInfo(&"Existing version {tag}@{$commit} ", HighPriority)
 
   # adapted from @beef331's algorithm https://github.com/beef331/graffiti/blob/master/src/graffiti.nim
   block outer:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -299,7 +299,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
           if ver notin versions:
             if ver in existingVers:
               if options.action.allTags:
-                displayInfo(&"Skipping historical version {ver} at commit {commit} that has an existing tag", HighPriority)
+                displayWarning(&"Skipping historical version {ver} at commit {commit} that has an existing tag", HighPriority)
               else:
                 break outer
             else:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -6,7 +6,7 @@
 
 import system except TResult
 import httpclient, strutils, json, os, browsers, times, uri
-import common, tools, cli, config, options, packageinfotypes, sha1hashes, version, download
+import common, tools, cli, config, options, packageinfotypes, vcstools, sha1hashes, version, download
 import strformat, sequtils, pegs, sets, tables, algorithm
 {.warning[UnusedImport]: off.}
 from net import SslCVerifyMode, newContext
@@ -309,6 +309,13 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
   var
     versions: OrderedTable[Version, tuple[commit: Sha1Hash, message: string]]
     existingTags = findExistingTags(projdir, downloadMethod)
+
+  let currBranch = getCurrentBranch(projdir)
+  if currBranch notin ["main", "master"]:
+    displayWarning(&"Note runnig this command on a non-standard primary branch `{currBranch}` may have unintened consequences", HighPriority)
+
+  for ver in existingTags.toSeq().sorted():
+    displayInfo(&"Existing tag for version {ver} ", HighPriority)
 
   # adapted from @beef331's algorithm https://github.com/beef331/graffiti/blob/master/src/graffiti.nim
   block outer:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -248,30 +248,6 @@ proc publish*(p: PackageInfo, o: Options) =
     let prUrl = createPullRequest(auth, p, url, branchName)
     display("Success:", "Pull request successful, check at " & prUrl , Success, HighPriority)
 
-proc vcsFindCommits*(repoDir, nimbleFile: string, downloadMethod: DownloadMethod): seq[(Sha1Hash, string)] =
-  var output: string
-  case downloadMethod:
-    of DownloadMethod.git:
-      output = tryDoCmdEx(&"git -C {repoDir} log --format=\"%H %s\" -- $2")
-    of DownloadMethod.hg:
-      assert false, "hg not supported"
-  
-  for line in output.splitLines():
-    let line = line.strip()
-    if line != "":
-      result.add((line[0..39].initSha1Hash(), line[40..^1]))
-
-proc vcsDiff*(commit: Sha1Hash, repoDir, nimbleFile: string, downloadMethod: DownloadMethod): seq[string] =
-  case downloadMethod:
-    of DownloadMethod.git:
-      let (output, exitCode) = doCmdEx(&"git -C {repoDir} diff {commit}~ {commit} {nimbleFile}")
-      if exitCode != QuitSuccess:
-        return @[]
-      else:
-        return output.splitLines()
-    of DownloadMethod.hg:
-      assert false, "hg not supported"
-  
 proc createTag*(tag: string, commit: Sha1Hash, message, repoDir, nimbleFile: string, downloadMethod: DownloadMethod): bool =
   case downloadMethod:
     of DownloadMethod.git:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -299,7 +299,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
           if ver notin versions:
             if ver in existingVers:
               if options.action.allTags:
-                displayInfo(&"Found existing tag for version {ver} at commit {commit}", HighPriority)
+                displayInfo(&"Skipping historical version {ver} at commit {commit} that has an existing tag", HighPriority)
               else:
                 break outer
             else:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -331,12 +331,15 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         displayWarning(&"Version {ver} will be skipped. Please tag it manually if the version is correct." , HighPriority)
         displayHint(&"Note that versions are checked from larget to smallest" , HighPriority)
 
-  for (version, info) in versions.pairs:
-    if options.action.createTags:
-      displayWarning(&"Creating tag for new version {version} at {info.commit}", HighPriority)
-      let res = createTag(&"v{version}", info.commit, info.message, projdir, nimbleFile, downloadMethod)
-      if not res:
-        displayError(&"Unable to create tag {version}", HighPriority)
+  if options.action.createTags:
+    for (version, info) in versions.pairs:
+      if version in nonMonotonicVers:
+        displayWarning(&"Skipping creating tag for new version {version} at {info.commit}", HighPriority)
+      else:
+        displayWarning(&"Creating tag for new version {version} at {info.commit}", HighPriority)
+        let res = createTag(&"v{version}", info.commit, info.message, projdir, nimbleFile, downloadMethod)
+        if not res:
+          displayError(&"Unable to create tag {version}", HighPriority)
 
 proc publishVersions*(p: PackageInfo, options: Options) =
   displayInfo(&"Searcing for new tags for {$p.basicInfo.name} @{$p.basicInfo.version}", HighPriority)

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -320,12 +320,16 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         prevMonotonicsOk = monotonics.mapIt(ver < it).all(proc (x: bool): bool = x)
 
       if ver < prev[0] and prevMonotonicsOk:
-        displayWarning(&"versions ok at tags {ver}@{info.commit} and previous tag of {prev[0]}@{prev[1]}", HighPriority)
+        displayHint(&"Versions monotonic between tag {ver}@{info.commit} " &
+                      &" and previous tag of {prev[0]}@{prev[1].commit}", MediumPriority)
       else:
         if prev[0] notin nonMonotonicVers:
           monotonics.add(prev[0]) # track last largest monotonic so we can check, e.g. 0.2, 3.0, 0.3 and not 0.2, 3.0, 0.2 
         nonMonotonicVers[ver] = info.commit
-        displayError(&"bad version found with tag {ver}@{info.commit} and previous tag at {prev[0]}@{prev[1]}", HighPriority)
+        displayError(&"Non-monotonic (decreasing) version found between tag {ver}@{info.commit}" &
+                     &" and the previous tag {prev[0]}@{prev[1].commit}", HighPriority)
+        displayWarning(&"Version {ver} will be skipped. Please tag it manually if the version is correct." , HighPriority)
+        displayHint(&"Note that versions are checked from larget to smallest" , HighPriority)
 
   for (version, info) in versions.pairs:
     if options.action.createTags:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -307,9 +307,9 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
   if currBranch notin ["main", "master"]:
     displayWarning(&"Note runnig this command on a non-standard primary branch `{currBranch}` may have unintened consequences", HighPriority)
 
-  for tag in existingTags.keys().toSeq().sorted():
+  for ver, tag in existingVers.pairs():
     let commit = existingTags[tag]
-    displayInfo(&"Existing version {tag}@{$commit} ", HighPriority)
+    displayInfo(&"Existing version {ver} with tag {tag} at commit {$commit} ", HighPriority)
 
   # adapted from @beef331's algorithm https://github.com/beef331/graffiti/blob/master/src/graffiti.nim
   block outer:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -309,11 +309,7 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
   var
     versions: OrderedTable[Version, tuple[commit: Sha1Hash, message: string]]
     existingTags = findExistingTags(projdir, downloadMethod)
-    firstTag = newVersion("0.0.0")
-  if existingTags.len() > 0:
-    firstTag = existingTags.toSeq().sorted()[0]
 
-  echo "FIRST TAG: ", firstTag
   # adapted from @beef331's algorithm https://github.com/beef331/graffiti/blob/master/src/graffiti.nim
   block outer:
     for (commit, message) in commits:
@@ -323,13 +319,13 @@ proc findVersions(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string,
         var matches: array[0..MaxSubpatterns, string]
         if line.find(peg"'+version' \s* '=' \s* {[\34\39]} {@} $1", matches) > -1:
           let ver = newVersion(matches[1])
-          if ver <= firstTag:
-            echo "FIRST TAG PASSED "
-            break outer
           if ver notin versions:
             versions[ver] = (commit: commit, message: message)
             if ver in existingTags:
-              displayInfo(&"Found existing tag for version {ver} at commit {commit}", HighPriority)
+              if not options.action.allTags:
+                break outer
+              else:
+                displayInfo(&"Found existing tag for version {ver} at commit {commit}", HighPriority)
             else:
               displayInfo(&"Found new version {ver} at {commit}", HighPriority)
   echo "FIRST TAG DONE "

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -12,6 +12,7 @@ import tdevelopfeature
 import tissues
 import tlocaldeps
 import tlockfile
+import tpublish
 import tmisctests
 import tmoduletests
 import tmultipkgs

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -6,6 +6,7 @@
 import sequtils, strutils, strformat, os, osproc, sugar, unittest, macros
 import pkg/checksums/sha1
 
+import nimblepkg/cli
 from nimblepkg/common import cd, nimblePackagesDirName, ProcessOutput
 from nimblepkg/developfile import developFileVersion
 
@@ -70,7 +71,8 @@ template verify*(res: (string, int)) =
   check r[1] == QuitSuccess
 
 proc processOutput*(output: string): seq[string] =
-  output.strip.splitLines().filter(
+  checkpoint(output)
+  result = output.strip.splitLines().filter(
     (x: string) => (
       x.len > 0 and
       "Using env var NIM_LIB_PREFIX" notin x
@@ -206,6 +208,9 @@ proc writeDevelopFile*(path: string, includes: seq[string],
 
 # Set env var to propagate nimble binary path
 putEnv("NIMBLE_TEST_BINARY_PATH", nimblePath)
+
+setVerbosity(MediumPriority)
+setShowColor(false)
 
 # Always recompile.
 block:

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -276,8 +276,6 @@ requires "nim >= 1.5.1"
       check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
       check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
 
-      for line in output.splitLines():
-        echo ">>> ", line
       check exitCode == QuitSuccess
       for version in versions[1..^1]:
         if version in ["2.1.0", "0.2.3"]:
@@ -286,21 +284,24 @@ requires "nim >= 1.5.1"
 
   test "test non-all ":
     # cleanUp()
-    let versions = @["0.1.0", "0.2.3", "2.1.0", "0.2.2", "0.2.3", "0.2.4", "0.2.5"]
-    initNewNimblePackage(nonAllPkgRepoPath, versions, tags = @["0.2.3"])
+    let versions = @["0.1.0", "0.2.3", "2.1.0", "0.3.2", "0.3.3", "0.3.4", "0.3.5"]
+    initNewNimblePackage(nonAllPkgRepoPath, versions, tags = @["0.3.3"])
     cd nonAllPkgRepoPath:
       echo "mainPkgRepoPath: ", nonAllPkgRepoPath
       echo "getCurrentDir: ", getCurrentDir()
 
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
-      check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
-      check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
+      # check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
+      # check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
 
-      for line in output.splitLines():
-        echo ">>> ", line
+      # for line in output.splitLines():
+      #   echo ">>> ", line
       check exitCode == QuitSuccess
-      for version in versions[1..^1]:
-        if version in ["2.1.0", "0.2.3"]:
-          continue
-        check output.contains("Creating tag for new version $1" % version)
+      for version in versions:
+        if version in @["0.3.4", "0.3.5"]:
+          checkpoint("Checking for version $1" % version)
+          check output.contains("Creating tag for new version $1" % version)
+          # else:
+          checkpoint("Checking version $1 is not found" % version)
+          check not output.contains("Creating tag for new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -268,7 +268,7 @@ requires "nim >= 1.5.1"
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
       check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
-      check output.contains("Non-monotonic (decreasing) version found between tag 0.2.2")
+      check output.contains("Non-monotonic (decreasing) version found between tag 0.2.3")
 
       check exitCode == QuitSuccess
       for version in versions[1..^1]:

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -262,3 +262,25 @@ requires "nim >= 1.5.1"
         if version == "2.1.0":
           continue
         check output.contains("Creating tag for new version $1" % version)
+
+  test "test skipping publishVersions non-monotonic versions 2 ":
+    # cleanUp()
+    let versions = @["0.1.0", "0.1.1", "0.2.3", "2.1.0", "0.2.2", "0.2.4"]
+    initNewNimblePackage(bad2PkgRepoPath, versions)
+    cd bad2PkgRepoPath:
+      echo "mainPkgRepoPath: ", bad2PkgRepoPath
+      echo "getCurrentDir: ", getCurrentDir()
+
+      let (output, exitCode) = execNimbleYes("publishVersions", "--create")
+
+      echo "output: "
+      for line in output.splitLines():
+        echo line
+      check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
+      check output.contains("Non-monotonic (decreasing) version found between tag 0.2.2")
+
+      check exitCode == QuitSuccess
+      for version in versions[1..^1]:
+        if version in ["2.1.0", "0.2.2"]:
+          continue
+        check output.contains("Creating tag for new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -164,7 +164,7 @@ requires "nim >= 1.5.1"
         let nimbleFileName = dir.initNewNimbleFile(version)
         addFiles(nimbleFileName)
         commit("commit $1" % version)
-        echo "created package version ", version
+        # echo "created package version ", version
         let commit = getRepoRevision()
         if version in tags:
           echo "tagging version ", version, " tag ", commit

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -207,9 +207,23 @@ requires "nim >= 1.5.1"
       # Push it to the newly added remote to be able to lock.
       push(remoteName)
 
-  test "test publishVersions":
+  test "test publishVersions basic find versions":
     # cleanUp()
     let versions = @["0.1.0", "0.1.1", "0.1.2", "0.2.1", "1.0.0"]
+    initNewNimblePackage(mainPkgRepoPath, versions)
+    cd mainPkgRepoPath:
+      echo "mainPkgRepoPath: ", mainPkgRepoPath
+      echo "getCurrentDir: ", getCurrentDir()
+
+      let (output, exitCode) = execNimbleYes("-y", "publishVersions")
+
+      check exitCode == QuitSuccess
+      for version in versions[1..^1]:
+        check output.contains("Found new version $1" % version)
+
+  test "test publishVersions basic find versions":
+    # cleanUp()
+    let versions = @["0.1.0", "0.1.1", "2.1.0", "0.2.1", "1.0.0"]
     initNewNimblePackage(mainPkgRepoPath, versions)
     cd mainPkgRepoPath:
       echo "mainPkgRepoPath: ", mainPkgRepoPath
@@ -218,6 +232,5 @@ requires "nim >= 1.5.1"
       let (output, res) = execNimbleYes("-y", "publishVersions")
 
       # check exitCodeInstall == QuitSuccess
-      for version in versions[1..^1]:
-        check output.contains("Found new version $1" % version)
-
+      # for version in versions[1..^1]:
+      #   check output.contains("Found new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -292,16 +292,35 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
-      # check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
-      # check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
+      check not output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
+      check not output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
 
-      # for line in output.splitLines():
-      #   echo ">>> ", line
       check exitCode == QuitSuccess
       for version in versions:
         if version in @["0.3.4", "0.3.5"]:
           checkpoint("Checking for version $1" % version)
           check output.contains("Creating tag for new version $1" % version)
-          # else:
+        else:
           checkpoint("Checking version $1 is not found" % version)
           check not output.contains("Creating tag for new version $1" % version)
+
+  test "test all":
+    # cleanUp()
+    let versions = @["0.1.0", "0.2.3", "2.1.0", "0.3.2", "0.3.3", "0.3.4", "0.3.5"]
+    cd nonAllPkgRepoPath:
+      echo "mainPkgRepoPath: ", nonAllPkgRepoPath
+      echo "getCurrentDir: ", getCurrentDir()
+
+      let (output, exitCode) = execNimbleYes("publishVersions", "--create", "--all")
+
+      check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
+      check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
+
+      check exitCode == QuitSuccess
+      for version in versions:
+        if version in @["0.3.4", "0.3.5"]:
+          checkpoint("Checking version $1 is not found" % version)
+          check not output.contains("Creating tag for new version $1" % version)
+        else:
+          checkpoint("Checking for version $1" % version)
+          check output.contains("Creating tag for new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -1,0 +1,237 @@
+# Copyright (C) Dominik Picheta. All rights reserved.
+# BSD License. Look at license.txt for more info.
+
+{.used.}
+
+import unittest, os, strformat, json, strutils, sequtils
+
+import testscommon
+
+import nimblepkg/displaymessages
+import nimblepkg/sha1hashes
+import nimblepkg/paths
+import nimblepkg/vcstools
+
+from nimblepkg/common import cd, dump, cdNewDir
+from nimblepkg/tools import tryDoCmdEx, doCmdEx
+from nimblepkg/packageinfotypes import DownloadMethod
+from nimblepkg/lockfile import LockFileJsonKeys
+from nimblepkg/options import defaultLockFileName
+from nimblepkg/developfile import ValidationError, ValidationErrorKind,
+  developFileName, getValidationErrorMessage
+
+suite "publish":
+  const
+    tempDir = getTempDir() / "tpublish"
+
+    originsDirName = "origins"
+    originsDirPath = tempDir / originsDirName
+
+    nimbleFileTemplate = """
+
+version       = "$1"
+author        = "Ivan Bobev"
+description   = "A new awesome nimble package"
+license       = "MIT"
+requires "nim >= 1.5.1"
+"""
+
+  proc newNimbleFileContent(pkgName, fileTemplate: string,
+                            deps: seq[string]): string =
+    result = fileTemplate % pkgName
+    if deps.len == 0:
+      return
+    result &= "requires "
+    for i, dep in deps:
+      result &= &"\"{dep}\""
+      if i != deps.len - 1:
+        result &= ","
+
+  proc addFiles(files: varargs[string]) =
+    var filesStr = ""
+    for file in files:
+      filesStr &= file & " "
+    tryDoCmdEx("git add " & filesStr)
+
+  proc commit(msg: string) =
+    tryDoCmdEx("git commit -am " & msg.quoteShell)
+
+  proc push(remote: string) =
+    tryDoCmdEx(
+      &"git push --set-upstream {remote} {vcsTypeGit.getVcsDefaultBranchName}")
+
+  proc pull(remote: string) =
+    tryDoCmdEx("git pull " & remote)
+
+  proc addRemote(remoteName, remoteUrl: string) =
+    tryDoCmdEx(&"git remote add {remoteName} {remoteUrl}")
+
+  proc configUserAndEmail =
+    tryDoCmdEx("git config user.name \"John Doe\"")
+    tryDoCmdEx("git config user.email \"john.doe@example.com\"")
+
+  proc initRepo(isBare = false) =
+    let bare = if isBare: "--bare" else: ""
+    tryDoCmdEx("git init " & bare)
+    configUserAndEmail()
+
+  proc clone(urlFrom, pathTo: string) =
+    tryDoCmdEx(&"git clone {urlFrom} {pathTo}")
+    cd pathTo: configUserAndEmail()
+
+  proc branch(branchName: string) =
+    tryDoCmdEx(&"git branch {branchName}")
+
+  proc checkout(what: string) =
+    tryDoCmdEx(&"git checkout {what}")
+
+  proc createBranchAndSwitchToIt(branchName: string) =
+    if branchName.len > 0:
+      branch(branchName)
+      checkout(branchName)
+
+  proc initNewNimbleFile(dir: string, deps: seq[string] = @[]): string =
+    let pkgName = dir.splitPath.tail
+    let nimbleFileName = pkgName & ".nimble"
+    let nimbleFileContent = newNimbleFileContent(
+      pkgName, nimbleFileTemplate, deps)
+    writeFile(nimbleFileName, nimbleFileContent)
+    return nimbleFileName
+
+  proc initNewNimblePackage(dir, clonePath: string, deps: seq[string] = @[]) =
+    cdNewDir dir:
+      initRepo()
+      let nimbleFileName = dir.initNewNimbleFile(deps)
+      addFiles(nimbleFileName)
+      commit("Initial commit")
+
+    clone(dir, clonePath)
+
+  proc addAdditionalFileToTheRepo(fileName, fileContent: string) =
+    writeFile(fileName, fileContent)
+    addFiles(fileName)
+    commit("Add additional file")
+
+  proc testLockedVcsRevisions(deps: seq[tuple[name, path: string]], lockFileName = defaultLockFileName) =
+    check lockFileName.fileExists
+
+    let json = lockFileName.readFile.parseJson
+    for (depName, depPath) in deps:
+      let expectedVcsRevision = depPath.getVcsRevision
+      check depName in json{$lfjkPackages}
+      let lockedVcsRevision =
+        json{$lfjkPackages}{depName}{$lfjkPkgVcsRevision}.str.initSha1Hash
+      check lockedVcsRevision == expectedVcsRevision
+
+  proc testLockFile(deps: seq[tuple[name, path: string]], isNew: bool, lockFileName = defaultLockFileName) =
+    ## Generates or updates a lock file and tests whether it contains
+    ## dependencies with given names at given repository paths and whether their
+    ## VCS revisions match the written in the lock file ones.
+    ##
+    ## `isNew` - indicates whether it is expected a new lock file to be
+    ## generated if its value is `true` or already existing lock file to be
+    ## updated otherwise.
+
+    if isNew:
+      check not fileExists(lockFileName)
+    else:
+      check fileExists(lockFileName)
+
+    let (output, exitCode) = if lockFileName == defaultLockFileName:
+        execNimbleYes("lock")
+      else:
+        execNimbleYes("--lock-file=" & lockFileName, "lock")
+
+    check exitCode == QuitSuccess
+
+    var lines = output.processOutput
+    if isNew:
+      check lines.inLinesOrdered(generatingTheLockFileMsg)
+      check lines.inLinesOrdered(lockFileIsGeneratedMsg)
+    else:
+      check lines.inLinesOrdered(updatingTheLockFileMsg)
+      check lines.inLinesOrdered(lockFileIsUpdatedMsg)
+
+    testLockedVcsRevisions(deps, lockFileName)
+
+  template filesAndDirsToRemove() =
+    removeFile pkgListFilePath
+    removeDir installDir
+    removeDir tempDir
+
+  template cleanUp() =
+    filesAndDirsToRemove()
+    defer: filesAndDirsToRemove()
+
+  proc writePackageListFile(path: string, content: PackagesListFileContent) =
+    let dir = path.splitPath.head
+    createDir dir
+    writeFile(path, (%content).pretty)
+
+  template withPkgListFile(body: untyped) =
+    writePackageListFile(
+      pkgListFilePath, @[dep1PkgListFileRecord, dep2PkgListFileRecord])
+    usePackageListFile pkgListFilePath:
+      body
+
+  proc getRepoRevision: string =
+    result = tryDoCmdEx("git rev-parse HEAD").replace("\n", "")
+
+  proc getRevision(dep: string, lockFileName = defaultLockFileName): string =
+    result = lockFileName.readFile.parseJson{$lfjkPackages}{dep}{$lfjkPkgVcsRevision}.str
+
+  proc addAdditionalFileAndPushToRemote(
+      repoPath, remoteName, remotePath, fileContent: string) =
+    cdNewDir remotePath:
+      initRepo(isBare = true)
+    cd repoPath:
+      # Add commit to the dependency.
+      addAdditionalFileToTheRepo("dep1.nim", fileContent)
+      addRemote(remoteName, remotePath)
+      # Push it to the newly added remote to be able to lock.
+      push(remoteName)
+
+  proc testDepsSync =
+    let (output, exitCode) = execNimbleYes("sync")
+    check exitCode == QuitSuccess
+    let lines = output.processOutput
+    check lines.inLines(
+      pkgWorkingCopyIsSyncedMsg(dep1PkgName, dep1PkgRepoPath))
+    check lines.inLines(
+      pkgWorkingCopyIsSyncedMsg(dep2PkgName, dep2PkgRepoPath))
+
+    cd mainPkgRepoPath:
+      # After successful sync the revisions written in the lock file must
+      # match those in the lock file.
+      testLockedVcsRevisions(@[(dep1PkgName, dep1PkgRepoPath),
+                                (dep2PkgName, dep2PkgRepoPath)])
+
+  test "test publishVersions":
+    cleanUp()
+    cd "nimdep":
+      removeFile "nimble.develop"
+      removeFile "nimble.lock"
+      removeDir "Nim"
+
+      check execNimbleYes("-y", "develop", "nim").exitCode == QuitSuccess
+      cd "Nim":
+        let (_, exitCode) = execNimbleYes("-y", "install")
+        check exitCode == QuitSuccess
+
+      # check if the compiler version will be used when doing build
+      testLockFile(@[("nim", "Nim")], isNew = true)
+      removeFile "nimble.develop"
+      removeDir "Nim"
+
+      let (output, exitCodeInstall) = execNimbleYes("-y", "build")
+      check exitCodeInstall == QuitSuccess
+      let usingNim = when defined(Windows): "nim.exe for compilation" else: "bin/nim for compilation"
+      check output.contains(usingNim)
+
+      # check the nim version
+      let (outputVersion, _) = execNimble("version")
+      check outputVersion.contains(getRevision("nim"))
+
+      let (outputGlobalNim, exitCodeGlobalNim) = execNimbleYes("-y", "--use-system-nim", "build")
+      check exitCodeGlobalNim == QuitSuccess
+      check not outputGlobalNim.contains(usingNim)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -229,11 +229,13 @@ requires "nim >= 1.5.1"
       echo "mainPkgRepoPath: ", bad1PkgRepoPath
       echo "getCurrentDir: ", getCurrentDir()
 
-      let (output, res) = execNimbleYes("-y", "publishVersions")
+      let (output, exitCode) = execNimbleYes("-y", "publishVersions")
 
       echo "output: "
       for line in output.splitLines():
         echo line
-      # check exitCodeInstall == QuitSuccess
-      # for version in versions[1..^1]:
-      #   check output.contains("Found new version $1" % version)
+      check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
+
+      check exitCode == QuitSuccess
+      for version in versions[1..^1]:
+        check output.contains("Found new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -314,13 +314,15 @@ requires "nim >= 1.5.1"
       let (output, exitCode) = execNimbleYes("publishVersions", "--create", "--all")
 
       check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
-      check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
+      check output.contains("Skipping creating tag for non-monotonic 2.1.0")
 
       check exitCode == QuitSuccess
-      for version in versions:
-        if version in @["0.3.4", "0.3.5"]:
+      for version in versions[1..^1]:
+        if version in ["0.3.3", "0.3.4", "0.3.5"]:
           checkpoint("Checking version $1 is not found" % version)
           check not output.contains("Creating tag for new version $1" % version)
+        elif version in ["2.1.0"]:
+          discard
         else:
           checkpoint("Checking for version $1" % version)
           check output.contains("Creating tag for new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -269,6 +269,8 @@ requires "nim >= 1.5.1"
       check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
       check output.contains("Non-monotonic (decreasing) version found between tag 0.2.3")
 
+      for line in output.splitLines():
+        echo ">>> ", line
       check exitCode == QuitSuccess
       for version in versions[1..^1]:
         if version in ["2.1.0", "0.2.3"]:

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -233,9 +233,6 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("-y", "publishVersions")
 
-      echo "output: "
-      for line in output.splitLines():
-        echo line
       check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
 
       check exitCode == QuitSuccess
@@ -252,9 +249,6 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
-      echo "output: "
-      for line in output.splitLines():
-        echo line
       check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
 
       check exitCode == QuitSuccess
@@ -273,14 +267,11 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
-      echo "output: "
-      for line in output.splitLines():
-        echo line
       check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
       check output.contains("Non-monotonic (decreasing) version found between tag 0.2.2")
 
       check exitCode == QuitSuccess
       for version in versions[1..^1]:
-        if version in ["2.1.0", "0.2.2"]:
+        if version in ["2.1.0", "0.2.3"]:
           continue
         check output.contains("Creating tag for new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -146,11 +146,11 @@ requires "nim >= 1.5.1"
   proc initNewNimblePackage(dir: string, versions: seq[string] = @[]) =
     cdNewDir dir:
       initRepo()
-      echo "created repo at: ", dir, " cwd: ", getCurrentDir()
+      echo "created repo at: ", dir
       for version in versions:
         let nimbleFileName = dir.initNewNimbleFile(version)
         addFiles(nimbleFileName)
-        commit("Initial commit")
+        commit("commit $1" % version)
         echo "created package version ", version
         echo ""
 
@@ -231,6 +231,9 @@ requires "nim >= 1.5.1"
 
       let (output, res) = execNimbleYes("-y", "publishVersions")
 
+      echo "output: "
+      for line in output.splitLines():
+        echo line
       # check exitCodeInstall == QuitSuccess
       # for version in versions[1..^1]:
       #   check output.contains("Found new version $1" % version)

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -143,7 +143,7 @@ requires "nim >= 1.5.1"
     writeFile(nimbleFileName, nimbleFileContent)
     return nimbleFileName
 
-  proc initNewNimblePackage(dir, clonePath: string, versions: seq[string] = @[]) =
+  proc initNewNimblePackage(dir: string, versions: seq[string] = @[]) =
     cdNewDir dir:
       initRepo()
       echo "created repo at: ", getCurrentDir()
@@ -209,8 +209,8 @@ requires "nim >= 1.5.1"
 
   test "test publishVersions":
     # cleanUp()
-    initNewNimblePackage(mainPkgOriginRepoPath, mainPkgRepoPath,
-                          @["0.1.0", "0.1.1", "0.1.2", "0.2.1", "1.0"])
+    let versions = @["0.1.0", "0.1.1", "0.1.2", "0.2.1", "1.0.0"]
+    initNewNimblePackage(mainPkgRepoPath, versions)
     cd mainPkgRepoPath:
       echo "mainPkgRepoPath: ", mainPkgRepoPath
       echo "getCurrentDir: ", getCurrentDir()
@@ -218,5 +218,6 @@ requires "nim >= 1.5.1"
       let (output, res) = execNimbleYes("-y", "publishVersions")
 
       # check exitCodeInstall == QuitSuccess
-      check output.contains("something...")
+      for version in versions[1..^1]:
+        check output.contains("Found new version $1" % version)
 

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -157,7 +157,6 @@ requires "nim >= 1.5.1"
         addFiles(nimbleFileName)
         commit("commit $1" % version)
         echo "created package version ", version
-        echo ""
         if idx in [0, 1, versions.len() - 2]:
           addAdditionalFileToTheRepo("test.txt", $idx)
 

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -34,7 +34,7 @@ suite "publish":
 
     PkgIdent {.pure.} = enum
       main = "main"
-      dep1 = "dep1"
+      bad1 = "bad1"
       dep2 = "dep2"
 
   template definePackageConstants(pkgName: PkgIdent) =
@@ -86,7 +86,7 @@ requires "nim >= 1.5.1"
 """
 
   definePackageConstants(PkgIdent.main)
-  definePackageConstants(PkgIdent.dep1)
+  definePackageConstants(PkgIdent.bad1)
   definePackageConstants(PkgIdent.dep2)
 
   proc newNimbleFileContent(fileTemplate: string,
@@ -146,7 +146,7 @@ requires "nim >= 1.5.1"
   proc initNewNimblePackage(dir: string, versions: seq[string] = @[]) =
     cdNewDir dir:
       initRepo()
-      echo "created repo at: ", getCurrentDir()
+      echo "created repo at: ", dir, " cwd: ", getCurrentDir()
       for version in versions:
         let nimbleFileName = dir.initNewNimbleFile(version)
         addFiles(nimbleFileName)
@@ -186,7 +186,7 @@ requires "nim >= 1.5.1"
 
   template withPkgListFile(body: untyped) =
     writePackageListFile(
-      pkgListFilePath, @[dep1PkgListFileRecord, dep2PkgListFileRecord])
+      pkgListFilePath, @[bad1PkgListFileRecord, dep2PkgListFileRecord])
     usePackageListFile pkgListFilePath:
       body
 
@@ -224,9 +224,9 @@ requires "nim >= 1.5.1"
   test "test publishVersions basic find versions":
     # cleanUp()
     let versions = @["0.1.0", "0.1.1", "2.1.0", "0.2.1", "1.0.0"]
-    initNewNimblePackage(mainPkgRepoPath, versions)
-    cd mainPkgRepoPath:
-      echo "mainPkgRepoPath: ", mainPkgRepoPath
+    initNewNimblePackage(bad1PkgRepoPath, versions)
+    cd bad1PkgRepoPath:
+      echo "mainPkgRepoPath: ", bad1PkgRepoPath
       echo "getCurrentDir: ", getCurrentDir()
 
       let (output, res) = execNimbleYes("-y", "publishVersions")

--- a/tests/tpublish.nim
+++ b/tests/tpublish.nim
@@ -232,7 +232,7 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("-y", "publishVersions")
 
-      check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
+      check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
 
       check exitCode == QuitSuccess
       for version in versions[1..^1]:
@@ -248,7 +248,7 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
-      check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
+      check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
 
       check exitCode == QuitSuccess
       for version in versions[1..^1]:
@@ -266,8 +266,8 @@ requires "nim >= 1.5.1"
 
       let (output, exitCode) = execNimbleYes("publishVersions", "--create")
 
-      check output.contains("Non-monotonic (decreasing) version found between tag 2.1.0")
-      check output.contains("Non-monotonic (decreasing) version found between tag 0.2.3")
+      check output.contains("Non-monotonic (decreasing) version found between tag v2.1.0")
+      check output.contains("Non-monotonic (decreasing) version found between tag v0.2.3")
 
       for line in output.splitLines():
         echo ">>> ", line


### PR DESCRIPTION
- Changed default behavior of command to print out new versions not yet published.
- Renamed from `publishTags` to `versions` since the commands intent is to find and then publish versions – tags are an implementation detail.
- Creating tags is done by `nimble versions --create` (or `-c`).
- Tags can be pushed by `nimble versions --create --push` (or `-c -p`).
- Only tags which were created are pushed with `nimble cersions -c -p`.
- All tags can be found, created, published with `nimble versions --all` (or `-a`).
- Non-monotonic historical versions are ignored and print an error. 
- More with more recent versions historical versions take precedence over older versions. Older versions are marked as non-monotonic.
