### PR TITLE
Suppress progress output in tests

### DIFF
--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -6,6 +6,7 @@
 import sequtils, strutils, strformat, os, osproc, sugar, unittest, macros
 import pkg/checksums/sha1
 
+import nimblepkg/cli
 from nimblepkg/common import cd, nimblePackagesDirName, ProcessOutput
 from nimblepkg/developfile import developFileVersion
 
@@ -70,7 +71,8 @@ template verify*(res: (string, int)) =
   check r[1] == QuitSuccess
 
 proc processOutput*(output: string): seq[string] =
-  output.strip.splitLines().filter(
+  checkpoint(output)
+  result = output.strip.splitLines().filter(
     (x: string) => (
       x.len > 0 and
       "Using env var NIM_LIB_PREFIX" notin x
@@ -206,6 +208,9 @@ proc writeDevelopFile*(path: string, includes: seq[string],
 
 # Set env var to propagate nimble binary path
 putEnv("NIMBLE_TEST_BINARY_PATH", nimblePath)
+
+setVerbosity(MediumPriority)
+setShowColor(false)
 
 # Always recompile.
 block:


### PR DESCRIPTION
- turns on `--nocolor` for all tests
- sets logging level to medium (`--info`)
- adds `checkpoint(output)` for `nimbleExec` commands in tests which will print the output if the checks fail which avoids re-running tests to print the nimble command output
