### PR TITLE
First iteration of the `features` feature for the declarative parser

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -89,11 +89,11 @@ proc processFreeDependenciesSAT(rootPkgInfo: PackageInfo, options: Options): Has
   rootPkgInfo.requires &= options.extraRequires
   if options.useDeclarativeParser:
     rootPkgInfo = rootPkgInfo.toRequiresInfo(options)
-    displayInfo(&"Features: options: {options.features} pkg: {rootPkgInfo.features}", HighPriority)
+    # displayInfo(&"Features: options: {options.features} pkg: {rootPkgInfo.features}", HighPriority)
     for feature in options.features:
       if feature in rootPkgInfo.features:
         rootPkgInfo.requires &= rootPkgInfo.features[feature]
-        displayInfo(&"Feature {feature} activated", HighPriority)
+        # displayInfo(&"Feature {feature} activated", LowPriority)
     
   var pkgList = initPkgList(rootPkgInfo, options)
   if options.useDeclarativeParser:

--- a/src/nimblepkg/nimscriptapi.nim
+++ b/src/nimblepkg/nimscriptapi.nim
@@ -255,3 +255,6 @@ proc getPaths*(): seq[string] =
 proc getPathsClause*(): string =
   ## Returns the paths to the dependencies as consumed by the nim compiler.
   return getPaths().mapIt("--path:" & it).join(" ")
+
+template feature*(name: string, body: untyped): untyped =
+  discard

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -65,6 +65,7 @@ type
     disableNimBinaries*: bool # Whether to disable the use of nim binaries
     maxTaggedVersions*: int # Maximum number of tags to check for a package when discovering versions in a local repo
     useDeclarativeParser*: bool # Whether to use the declarative parser for parsing nimble files (only when solver is SAT)
+    features*: seq[string] # Features to be activated. Only used when using the declarative parser
 
   ActionType* = enum
     actionNil, actionRefresh, actionInit, actionDump, actionPublish, actionUpgrade
@@ -278,6 +279,7 @@ Nimble Options:
       --disableNimBinaries        Disable the use of nim precompiled binaries. Note in some platforms precompiled binaries are not available but the flag can still be used to avoid compile the Nim version once and reuse it.
       --maximumTaggedVersions     Maximum number of tags to check for a package when discovering versions for the SAT solver. 0 means all.
       --parser:declarative|nimvm  Use the declarative parser or the nimvm parser (default).
+      --features                  Activate features. Only used when using the declarative parser.
 For more information read the GitHub readme:
   https://github.com/nim-lang/nimble#readme
 """
@@ -680,6 +682,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.maxTaggedVersions = parseUInt(val).int
     except ValueError:
       raise nimbleError(&"{val} is not a valid value")
+  of "features":
+    result.features = val.split(";").mapIt(it.strip)
   else: isGlobalFlag = false
 
   var wasFlagHandled = true

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -77,6 +77,7 @@ type
     isLink*: bool
     paths*: seq[string] 
     entryPoints*: seq[string] #useful for tools like the lsp.
+    features*: Table[string, seq[PkgTuple]] #features requires defined in the nimble file. Declarative parser + SAT solver only
     
   Package* = object ## Definition of package from packages.json.
     # Required fields in a package.

--- a/tests/features/features.nimble
+++ b/tests/features/features.nimble
@@ -1,0 +1,15 @@
+# Package
+
+version       = "0.1.0"
+author        = "jmgomez"
+description   = "A new awesome nimble package"
+license       = "MIT"
+srcDir        = "src"
+bin = @["features"]
+
+# Dependencies
+
+requires "nim >= 2.3.1"
+
+feature "feature1":
+  requires "stew"

--- a/tests/features/features.nimble
+++ b/tests/features/features.nimble
@@ -9,7 +9,7 @@ bin = @["features"]
 
 # Dependencies
 
-requires "nim >= 2.3.1"
+requires "nim"
 
 feature "feature1":
   requires "stew"

--- a/tests/features/src/features.nim
+++ b/tests/features/src/features.nim
@@ -1,0 +1,18 @@
+# This is just an example to get you started. A typical library package
+# exports the main API in this file. Note that you cannot rename this file
+# but you can remove it if you wish.
+
+proc add*(x, y: int): int =
+  ## Adds two numbers together.
+  return x + y
+
+
+
+when defined(features.features.feature1):
+  echo "feature1 is enabled"
+  import stew/byteutils #we should be able to import stew here as is its part of the feature1
+  
+else:
+  echo "feature1 is disabled"
+
+echo ""

--- a/tests/features/src/features/submodule.nim
+++ b/tests/features/src/features/submodule.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. Users of your library will
+# import this file by writing ``import features/submodule``. Feel free to rename or
+# remove this file altogether. You may create additional modules alongside
+# this file as required.
+
+type
+  Submodule* = object
+    name*: string
+
+proc initSubmodule*(): Submodule =
+  ## Initialises a new ``Submodule`` object.
+  Submodule(name: "Anonymous")

--- a/tests/features/tests/test1.nim
+++ b/tests/features/tests/test1.nim
@@ -1,0 +1,12 @@
+# This is just an example to get you started. You may wish to put all of your
+# tests into a single file, or separate them into multiple `test1`, `test2`
+# etc. files (better names are recommended, just make sure the name starts with
+# the letter 't').
+#
+# To run these tests, simply execute `nimble test`.
+
+import unittest
+
+import features
+test "can add":
+  check add(5, 5) == 10


### PR DESCRIPTION
There are a few things left to implement. Like adding a special syntax to requires. 

This PR handles the scenarios for root packages.
See the `tdeclarativeparser` tests over the `features` packages. Nimble file
```nim
# Dependencies

feature "feature1":
  requires "stew"
```

```nim

when defined(features.features.feature1):
  echo "feature1 is enabled"
  import stew/byteutils #we should be able to import stew here as is its part of the feature1

else:
  echo "feature1 is disabled"
```