### PR TITLE
Fetch only tags within the range

### DIFF
--- a/tests/tdeclarativeparser.nim
+++ b/tests/tdeclarativeparser.nim
@@ -56,7 +56,7 @@ suite "Declarative parsing":
     let repoDir = downloadRes.dir
     let downloadMethod = DownloadMethod git
     let packageVersions = getPackageMinimalVersionsFromRepo(
-      repoDir, pv[0], downloadRes.version, downloadMethod, options
+      repoDir, pv, downloadRes.version, downloadMethod, options
     )
 
     #we know these versions are available

--- a/tests/tsat.nim
+++ b/tests/tsat.nim
@@ -305,7 +305,7 @@ suite "SAT solver":
     let downloadRes = pv.downloadPkgFromUrl(options)[0] #This is just to setup the test. We need a git dir to work on
     let repoDir = downloadRes.dir
     let downloadMethod = DownloadMethod git
-    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv[0], downloadRes.version, downloadMethod, options)
+    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv, downloadRes.version, downloadMethod, options)
     
     #we know these versions are available
     let availableVersions = @["0.3.4", "0.3.5", "0.3.6", "0.4.5", "0.4.4"].mapIt(newVersion(it))
@@ -329,7 +329,7 @@ suite "SAT solver":
     let pvPrev = parseRequires("nimfp >= 0.3.4")
     let downloadResPrev = pvPrev.downloadPkgFromUrl(options)[0]
     let repoDirPrev = downloadResPrev.dir
-    discard getPackageMinimalVersionsFromRepo(repoDirPrev, pvPrev[0], downloadResPrev.version,  DownloadMethod.git, options)
+    discard getPackageMinimalVersionsFromRepo(repoDirPrev, pvPrev, downloadResPrev.version,  DownloadMethod.git, options)
     check fileExists(repoDirPrev / TaggedVersionsFileName)
     
     let pv = parseRequires("nimfp >= 0.4.4")
@@ -337,7 +337,7 @@ suite "SAT solver":
     let repoDir = downloadRes.dir 
     check not fileExists(repoDir / TaggedVersionsFileName)
 
-    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv[0], downloadRes.version, DownloadMethod.git, options)
+    let packageVersions = getPackageMinimalVersionsFromRepo(repoDir, pv, downloadRes.version, DownloadMethod.git, options)
     #we know these versions are available
     let availableVersions = @["0.4.5", "0.4.4"].mapIt(newVersion(it))
     for version in availableVersions:
@@ -363,7 +363,7 @@ suite "SAT solver":
     let pvPrev = parseRequires("nimfp >= 0.3.4")
     let downloadResPrev = pvPrev.downloadPkgFromUrl(options)[0]
     let repoDirPrev = downloadResPrev.dir
-    discard getPackageMinimalVersionsFromRepo(repoDirPrev, pvPrev[0], downloadResPrev.version,  DownloadMethod.git, options)
+    discard getPackageMinimalVersionsFromRepo(repoDirPrev, pvPrev, downloadResPrev.version,  DownloadMethod.git, options)
     check not fileExists(repoDirPrev / TaggedVersionsFileName)
 
     check fileExists("nimbledeps" / "pkgcache" / "tagged" / "nimfp.json")


### PR DESCRIPTION
This PR restricts the fetched `maxTaggedVersions` to those that match the constraints defined in the Nimble file.

Explanation: 

When installing, Nimble retrieves the `maxTaggedVersions` (default: 4) tags from each dependency, but it does not consider the version constraints specified in the Nimble file. For example, consider the repository: : https://github.com/codex-storage/nim-ethers. 

When we attempt to install the dependencies using the following command:

```
nimble install
``` 

The installation process ends with [an error](https://github.com/codex-storage/nim-ethers/actions/runs/13309816273/job/37169277948): 

`Error:  Downloaded package's version does not satisfy requested version range: wanted >= 0.5.4 & < 0.6.0 got 0.6.2.`. 

This error occurs because one of our dependencies, [contractabi](https://github.com/codex-storage/nim-contract-abi) requires "nimcrypto >= 0.5.4 & < 0.6.0" for version 0.5.0, which is one of our last four tags.

The issue is that `contractabi` version 0.5.0 should not be retrieved, as it does not match our new requirement in `nim-ethers`: `"contractabi >= 0.7.0 & < 0.8.0"`.

This PR addresses this issue by retrieving the last `maxTaggedVersions` only if they match the specified version constraints.

Note: Our current workaround is to set `maxTaggedVersions` to 2.