### PR TITLE
Expand forge aliases when requirement is parsed

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -18,7 +18,7 @@ import nimblepkg/packageinfotypes, nimblepkg/packageinfo, nimblepkg/version,
        nimblepkg/nimscriptwrapper, nimblepkg/developfile, nimblepkg/paths,
        nimblepkg/nimbledatafile, nimblepkg/packagemetadatafile,
        nimblepkg/displaymessages, nimblepkg/sha1hashes, nimblepkg/syncfile,
-       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/forge_aliases, nimblepkg/nimenv,
+       nimblepkg/deps, nimblepkg/nimblesat, nimblepkg/nimenv,
        nimblepkg/downloadnim, nimblepkg/declarativeparser
 
 const
@@ -958,26 +958,22 @@ proc addPackages(packages: seq[PkgTuple], options: var Options) =
       exists = false
       version: string
 
-    let 
-      isValidUrl = isURL(apkg.name)
-      isValidAlias = isForgeAlias(apkg.name)
+    let isValidUrl = isURL(apkg.name)
     
-    if not isValidAlias:
-      for pkg in pkgList:
-        if pkg.name == apkg.name:
-          exists = true
-          version = case apkg.ver.kind
-          of verAny:
-            ""
-          else:
-            $apkg.ver
-          break
+    for pkg in pkgList:
+      if pkg.name == apkg.name:
+        exists = true
+        version = case apkg.ver.kind
+        of verAny:
+          ""
+        else:
+          $apkg.ver
+        break
     
-      if not exists and
-        not isValidUrl:
-        raise nimbleError(
-          "No such package \"$1\" was found in the package list." % [apkg.name]
-        )
+    if not exists and not isValidUrl:
+      raise nimbleError(
+        "No such package \"$1\" was found in the package list." % [apkg.name]
+      )
     
     var doAppend = true
     for dep in deps:

--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -877,13 +877,7 @@ proc install(packages: seq[PkgTuple], options: Options,
   else:
     # Install each package.
     for pv in packages:
-      let isAlias = isForgeAlias(pv.name)
-
-      let (meth, url, metadata) = 
-        if not isAlias:
-          getDownloadInfo(pv, options, doPrompt) #TODO dont download if its nim
-        else:
-          (git, newForge(pv.name).expand(), initTable[string, string]())
+      let (meth, url, metadata) = getDownloadInfo(pv, options, doPrompt) #TODO dont download if its nim
 
       let subdir = metadata.getOrDefault("subdir")
       var downloadPath = ""
@@ -896,15 +890,9 @@ proc install(packages: seq[PkgTuple], options: Options,
       let (downloadDir, downloadVersion, vcsRevision) =
         if nimInstalled.isSome():
           (nimInstalled.get().dir, nimInstalled.get().ver, notSetSha1Hash)
-        elif not isAlias:
+        else:
           downloadPkg(url, pv.ver, meth, subdir, options,
                     downloadPath = downloadPath, vcsRevision = notSetSha1Hash)
-        else:
-          downloadPkg(
-            newForge(pv.name).expand(),
-            pv.ver, meth, subdir, options,
-            downloadPath = downloadPath, vcsRevision = notSetSha1Hash
-          )
       try:
         var opt = options
         if pv.name.isNim:

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -2,7 +2,7 @@
 # BSD License. Look at license.txt for more info.
 
 import parseutils, os, osproc, strutils, tables, uri, strformat,
-       httpclient, json, sequtils, forge_aliases, urls
+       httpclient, json, sequtils, urls
 
 from algorithm import SortOrder, sorted
 
@@ -620,9 +620,6 @@ proc getDownloadInfo*(
     result = (checkUrlType(url), url, metadata)
     # echo "getDownloadInfo:isURL: ", $result
     return
-  elif pv.name.isForgeAlias:
-    let url = newForge(pv.name).expand()
-    return (checkUrlType(url), url, default(Table[string, string]))
   else:
     # If package is not found give the user a chance to refresh
     # package.json

--- a/src/nimblepkg/version.nim
+++ b/src/nimblepkg/version.nim
@@ -3,7 +3,7 @@
 
 ## Module for handling versions and version ranges such as ``>= 1.0 & <= 1.5``
 import json, sets
-import common, strutils, tables, hashes, parseutils
+import common, strutils, tables, hashes, parseutils, forge_aliases
 import std/[strscans]
 type
   Version* = object
@@ -303,6 +303,10 @@ proc parseRequires*(req: string): PkgTuple =
   except ParseVersionError:
     raise nimbleError(
         "Unable to parse dependency version range: " & getCurrentExceptionMsg())
+
+  # Expand forge aliases here
+  if result.name.isForgeAlias:
+    result.name = newForge(result.name).expand()
 
 proc `$`*(verRange: VersionRange): string =
   case verRange.kind

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -33,6 +33,7 @@ import tniminstall
 import trequireflag
 import tdeclarativeparser
 import tforgeinstall
+import tforgeparser
 # nonim tests are very slow and (often) break the CI.
 
 # import tnonim

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -32,6 +32,7 @@ import tsat
 import tniminstall
 import trequireflag
 import tdeclarativeparser
+import tforgeinstall
 # nonim tests are very slow and (often) break the CI.
 
 # import tnonim

--- a/tests/tforgeinstall.nim
+++ b/tests/tforgeinstall.nim
@@ -9,4 +9,4 @@ test "can install packages via a forge alias":
   cd "forgealias001":
     let (_, exitCode) = execNimbleYes(["build"])
     check exitCode == QuitSuccess
-    check fileExists("forgealias001")
+    check fileExists("forgealias001".addFileExt(ExeExt))

--- a/tests/tforgeparser.nim
+++ b/tests/tforgeparser.nim
@@ -2,7 +2,7 @@
 # BSD License. Look at license.txt for more info.
 
 {.used.}
-import std/[unittest, os]
+import std/unittest
 import nimblepkg/forge_aliases
 
 let 

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -696,7 +696,8 @@ requires "nim >= 1.5.1"
         check exitCode == QuitSuccess
   test "Forge alias is generated inside lockfile":
     cleanup()
-    cd "forgealias001":
-      testLockFile(@{
-        "librng": "librng"
-      },isNew=true)
+    withPkgListFile:
+      cd "forgealias001":
+        testLockFile(@{
+          "librng": "librng"
+        },isNew=true)

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -694,3 +694,9 @@ requires "nim >= 1.5.1"
 
         let exitCode = execNimbleYes("lock", "--developFile=" & "other-name.develop").exitCode
         check exitCode == QuitSuccess
+  test "Forge alias is generated inside lockfile":
+    cleanup()
+    cd "forgealias001":
+      testLockFile(@{
+        "librng": "librng"
+      },isNew=true)

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -696,8 +696,16 @@ requires "nim >= 1.5.1"
         check exitCode == QuitSuccess
   test "Forge alias is generated inside lockfile":
     cleanup()
+
     withPkgListFile:
       cd "forgealias001":
-        testLockFile(@{
-          "librng": "librng"
-        },isNew=true)
+        removeFile defaultLockFileName
+
+        let (_, exitCode) = execNimbleYes("lock")
+        check exitCode == QuitSuccess
+
+        # Check the dependency appears in the lock file, and its expanded
+        check defaultLockFileName.fileExists
+        let json = defaultLockFileName.readFile.parseJson
+        check json{$lfjkPackages, "librng", "url"}.str == "https://github.com/xTrayambak/librng"
+


### PR DESCRIPTION
Fixes #1341

This moves the expansion step to when the requirement is parsed (meaning a `PkgTuple` now again only refers to a URL or a package). This removes the need to have special handling for the SAT solver/lock files.

