### PR TITLE
`dump` action now can dump `--collect` and `--solve`

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1279,8 +1279,16 @@ proc getEntryPoints(pkgInfo: PackageInfo, options: Options): seq[string] =
     result.add if entry.endsWith(".nim"): entry else: entry & ".nim"
   
 proc dump(options: Options) =
-  cli.setSuppressMessages(true)
   let p = getPackageByPattern(options.action.projName, options)
+  if options.action.collect or options.action.solve:
+    let pkgList = initPkgList(p, options).toSeq()
+    if options.action.collect:
+      dumpPackageVersionTable(p, pkgList.toSeq(), options)
+    else:
+      dumpSolvedPackages(p, pkgList, options)
+    quit()
+
+  cli.setSuppressMessages(true)
   var j: JsonNode
   var s: string
   let json = options.dumpMode == kdumpJson

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -769,7 +769,7 @@ proc dumpSolvedPackages*(pkgInfo: PackageInfo, pkgList: seq[PackageInfo], option
   var pkgToInstall: seq[(string, Version)] = @[]
   var output = ""
   var solvedPkgs: seq[SolvedPackage] = @[]
-  let result = solvePackages(pkgInfo, pkgList, pkgToInstall, options, output, solvedPkgs)
+  discard solvePackages(pkgInfo, pkgList, pkgToInstall, options, output, solvedPkgs)
 
   echo "PACKAGE".alignLeft(maxPkgNameDisplayWidth), "VERSION".alignLeft(maxVersionDisplayWidth), "REQUIREMENTS"
   echo "-".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 4)

--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -521,7 +521,7 @@ proc getTaggedVersions*(repoDir, pkgName: string, options: Options): Option[Tagg
         return none(TaggedPackageVersions)
       return some taggedVersions
     except CatchableError as e:
-      displayWarning(&"Error reading tagged versions: {e.msg}", HighPriority)
+      displayWarning(&"Error reading tagged versions: {e.msg} for {pkgName}", HighPriority)
       return none(TaggedPackageVersions)
   else:
     return none(TaggedPackageVersions)
@@ -740,3 +740,216 @@ proc getPackageInfo*(name: string, pkgs: seq[PackageInfo], version: Option[Versi
             return some pkg
         else: #No version passed over first match
           return some pkg
+
+proc getPkgVersionTable*(pkgInfo: PackageInfo, pkgList: seq[PackageInfo], options: Options): Table[string, PackageVersions] =
+  result = initTable[string, PackageVersions]()
+  var root = pkgInfo.getMinimalInfo(options)
+  root.isRoot = true
+  result[root.name] = PackageVersions(pkgName: root.name, versions: @[root])
+  collectAllVersions(result, root, options, downloadMinimalPackage, pkgList.mapIt(it.getMinimalInfo(options)))
+
+
+const maxPkgNameDisplayWidth = 40  # Cap package name width
+const maxVersionDisplayWidth = 10  # Cap version width
+
+proc formatPkgName(pkgName: string, maxWidth = maxPkgNameDisplayWidth): string =
+  result = pkgName
+  if result.startsWith("https:"):
+    let parts = result.split('/')
+    result = parts[^1]
+  # Handle git repo names with extension
+  if result.endsWith(".git"):
+    result = result[0..^5]  # Remove .git suffix
+  
+  # Truncate if still too long
+  if result.len > maxWidth - 3:
+    result = result[0..<(maxWidth - 3)] & "..."
+
+proc dumpSolvedPackages*(pkgInfo: PackageInfo, pkgList: seq[PackageInfo], options: Options) =
+  var pkgToInstall: seq[(string, Version)] = @[]
+  var output = ""
+  var solvedPkgs: seq[SolvedPackage] = @[]
+  let result = solvePackages(pkgInfo, pkgList, pkgToInstall, options, output, solvedPkgs)
+
+  echo "PACKAGE".alignLeft(maxPkgNameDisplayWidth), "VERSION".alignLeft(maxVersionDisplayWidth), "REQUIREMENTS"
+  echo "-".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 4)
+  
+  # Sort packages alphabetically
+  var sortedPackages = solvedPkgs
+  sortedPackages.sort(proc(a, b: SolvedPackage): int =
+    result = cmp(a.pkgName, b.pkgName)
+    if result == 0:
+      result = cmp(a.version, b.version)
+  )
+  
+  # Find the pkgInfo package in the solved packages and move it to the front
+  for i, pkg in sortedPackages:
+    if pkg.pkgName == pkgInfo.basicInfo.name:
+      let rootPkg = sortedPackages[i]
+      sortedPackages.delete(i)
+      sortedPackages.insert(rootPkg, 0)
+      break
+  
+  # Display each package
+  for i, pkg in sortedPackages:
+    var displayName = formatPkgName(pkg.pkgName)
+    
+    # Mark root package with an asterisk (either it's the first package after sorting, or it's pkgInfo)
+    let rootMarker = if pkg.pkgName == pkgInfo.basicInfo.name: "*" else: " "
+    
+    # Format requirements
+    var reqStr = ""
+    for i, req in pkg.requirements:
+      if i > 0: reqStr.add ", "
+      
+      var reqName = formatPkgName(req.name)
+      reqStr.add reqName
+      if req.ver.kind != verAny:
+        reqStr.add " " & $req.ver
+    
+    # Display package line
+    echo rootMarker, " ", 
+         displayName.alignLeft(maxPkgNameDisplayWidth - 1), 
+         $pkg.version.version.alignLeft(maxVersionDisplayWidth), 
+         if reqStr.len > 0: reqStr.splitLines()[0] else: ""
+    
+    # If requirements were long, display them on additional indented lines
+    if reqStr.len > 0 and (reqStr.contains('\n') or reqStr.len > 80):
+      let lines = reqStr.split(", ")
+      var currentLine = ""
+      for i, req in lines:
+        if currentLine.len + req.len + 2 > 80:  # +2 for ", "
+          if currentLine.len > 0:
+            echo " ".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 3), currentLine
+          currentLine = req
+        else:
+          if currentLine.len > 0:
+            currentLine.add ", "
+          currentLine.add req
+      
+      if currentLine.len > 0:
+        echo " ".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 3), currentLine
+    
+    # Show reverse dependencies indented underneath - UPDATED to group by package name
+    if pkg.reverseDependencies.len > 0:
+      var depStr = "Required by: "
+      
+      # Group dependencies by package name
+      var depGroups = initTable[string, seq[Version]]()
+      for revDep in pkg.reverseDependencies:
+        var depName = revDep[0].formatPkgName()
+        
+        if not depGroups.hasKey(depName):
+          depGroups[depName] = @[]
+        depGroups[depName].add(revDep[1])
+      
+      var depNames = toSeq(depGroups.keys)
+      depNames.sort()
+      
+      # Format each dependency group
+      var currentLine = depStr
+      var lineLen = depStr.len
+      
+      for i, depName in depNames:
+        var versions = depGroups[depName]
+        
+        # Sort versions in descending order
+        versions.sort(proc(a, b: Version): int = 
+          if a > b: -1
+          elif a < b: 1
+          else: 0
+        )
+        
+        # Format versions as a compact list
+        var versionStr = ""
+        if versions.len == 1:
+          versionStr = $versions[0].version
+        else:
+          versionStr = "v(" & versions.mapIt($it.version).join(", ") & ")"
+        
+        let depEntry = depName & " " & versionStr
+        
+        if i > 0:
+          if lineLen + 2 + depEntry.len > 80:
+            echo " ".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 3), currentLine
+            currentLine = "            " & depEntry
+            lineLen = 12 + depEntry.len
+          else:
+            currentLine.add ", " & depEntry
+            lineLen += 2 + depEntry.len
+        else:
+          currentLine.add depEntry
+          lineLen += depEntry.len
+      
+      echo " ".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 3), currentLine
+
+proc dumpPackageVersionTable*(pkg: PackageInfo, pkgList: seq[PackageInfo], options: Options) =
+  let pkgVersionTable = getPkgVersionTable(pkg, pkgList, options)
+
+  # Display header
+  echo "PACKAGE".alignLeft(maxPkgNameDisplayWidth), "VERSION".alignLeft(maxVersionDisplayWidth), "REQUIREMENTS"
+  echo "-".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 4)
+  
+  var sortedPackages = toSeq(pkgVersionTable.keys)
+  sortedPackages.sort()
+  
+  if pkg.basicInfo.name in sortedPackages:
+    sortedPackages.delete(sortedPackages.find(pkg.basicInfo.name))
+    sortedPackages.insert(pkg.basicInfo.name, 0)
+  
+  # Display each package and its versions
+  for pkgName in sortedPackages:
+    let pkgVersions = pkgVersionTable[pkgName]
+    var isFirstVersion = true
+    
+    # Sort versions in descending order (newest first)
+    var sortedVersions = pkgVersions.versions
+    sortedVersions.sort(proc(a, b: PackageMinimalInfo): int = 
+      if a.version > b.version: -1
+      elif a.version < b.version: 1
+      else: 0
+    )
+    
+    for version in sortedVersions:
+      # Format package name - extract repo name for GitHub URLs
+      var displayName = formatPkgName(pkgName)
+      
+      # Only show package name for first version
+      let name = if isFirstVersion: displayName else: ""
+      let rootMarker = if version.isRoot: "*" else: " "
+      
+      # Format requirements
+      var reqStr = ""
+      for i, req in version.requires:
+        if i > 0: reqStr.add ", "
+        
+        var reqName = formatPkgName(req.name)
+        
+        reqStr.add reqName
+        if req.ver.kind != verAny:
+          reqStr.add " " & $req.ver
+      
+      # Display version line
+      echo rootMarker, " ", 
+           name.alignLeft(maxPkgNameDisplayWidth - 1), 
+           $version.version.version.alignLeft(maxVersionDisplayWidth), 
+           if reqStr.len > 0: reqStr.splitLines()[0] else: ""
+      
+      # If requirements were long, display them on additional indented lines
+      if reqStr.len > 0 and (reqStr.contains('\n') or reqStr.len > 80):
+        let lines = reqStr.split(", ")
+        var currentLine = ""
+        for i, req in lines:
+          if currentLine.len + req.len + 2 > 80:  # +2 for ", "
+            if currentLine.len > 0:
+              echo " ".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 3), currentLine
+            currentLine = req
+          else:
+            if currentLine.len > 0:
+              currentLine.add ", "
+            currentLine.add req
+        
+        if currentLine.len > 0:
+          echo " ".repeat(maxPkgNameDisplayWidth + maxVersionDisplayWidth + 3), currentLine
+      
+      isFirstVersion = false

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -108,6 +108,8 @@ type
     of actionInit, actionDump:
       projName*: string
       vcsOption*: string
+      collect*: bool
+      solve*: bool
     of actionCompile, actionDoc, actionBuild:
       file*: string
       backend*: string
@@ -216,7 +218,9 @@ Commands:
                                   external tools. The argument can be a
                                   .nimble file, a project directory or
                                   the name of an installed package.
-               [--ini, --json]    Selects the output format (the default is --ini).
+               [--ini, --json]    Selects the output format (the default is --ini). Only applicable to package information.
+               [--collect]        Collects all the packages in the dependency tree of the given package and shows the result in the console.
+               [--solve]          Solves the dependency tree of the given package and shows the result in the console.
   lock                            Generates or updates a package lock file.
   upgrade      [pkgname, ...]     Upgrades a list of packages in the lock file.
   deps                            Outputs dependencies for current package.
@@ -683,6 +687,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     case f
     of "json": result.dumpMode = kdumpJson
     of "ini": result.dumpMode = kdumpIni
+    of "collect": result.action.collect = true
+    of "solve": result.action.solve = true
     else:
       wasFlagHandled = false
   of actionInstall:

--- a/src/nimblepkg/version.nim
+++ b/src/nimblepkg/version.nim
@@ -7,7 +7,7 @@ import common, strutils, tables, hashes, parseutils, forge_aliases
 import std/[strscans]
 type
   Version* = object
-    version: string
+    version*: string
 
   VersionRangeEnum* = enum
     verLater, # > V


### PR DESCRIPTION
Example package: 

```nim
version       = "0.1.0"
author        = "jmgomez"
description   = "A new awesome nimble package"
license       = "MIT"
srcDir        = "src"
bin           = @["nim_selection"]


# Dependencies

# Dependencies

requires "nim >= 2.0.12"
requires "https://github.com/status-im/nimbus-eth2.git#unstable"
requires "https://github.com/seaqt/nim-seaqt.git#qt-6.4"
requires "https://github.com/seaqt/nimqml-seaqt.git"
```

`nimble dump --collect`
Output:

```
PACKAGE                                 VERSION   REQUIREMENTS
------------------------------------------------------
* nim_selection                          0.1.0     nim >= 2.0.12, nimbus-eth2 #unstable, nim-seaqt #qt-6.4, nimqml-seaqt
  bearssl                                0.2.5     nim >= 1.6.0, unittest2
                                         0.2.4     nim >= 1.6.0, unittest2
                                         0.2.3     nim >= 1.6.0, unittest2
                                         0.2.2     nim >= 1.6.0, unittest2
  blscurve                               0.0.1     nim >= 1.6.0, nimcrypto, stew, results, taskpools >= 0.0.5
  chronicles                             0.10.3    nim >= 1.2.0, testutils, json_serialization
                                         0.10.2    nim >= 1.2.0, testutils, json_serialization
                                         0.10.1    nim >= 1.2.0, testutils, json_serialization
                                         0.10.0    nim >= 1.2.0, testutils, json_serialization
  chronos                                4.0.4     nim >= 1.6.16, results, stew, bearssl >= 0.2.5, httputils, unittest2
                                         4.0.3     nim >= 1.6.16, results, stew, bearssl >= 0.2.5, httputils, unittest2
                                         4.0.2     nim >= 1.6.16, results, stew, bearssl, httputils, unittest2
                                         4.0.1     nim >= 1.6.16, results, stew, bearssl, httputils, unittest2
  confutils                              0.1.0     nim >= 1.6.0, stew, serialization
  dnsclient                              0.3.4     nim >= 0.20.0
                                         0.3.3     nim >= 0.20.0
                                         0.3.2     nim >= 0.20.0
                                         0.3.1     nim >= 0.20.0
  eth                                    0.7.0     nim >= 2.0.10, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew, nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results, minilru, snappy
                                                     nim >= 2.0.10, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew
                                                     nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results
                                                     minilru, snappy
                                         0.6.0     nim >= 2.0.10, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew, nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results, minilru, snappy
                                                     nim >= 2.0.10, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew
                                                     nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results
                                                     minilru, snappy
                                         0.5.0     nim >= 1.6.0, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew, nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results, minilru, snappy
                                                     nim >= 1.6.0, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew
                                                     nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results
                                                     minilru, snappy
  faststreams                            0.3.0     nim >= 1.6.0, stew, unittest2
  nim-seaqt                              #qt-6.4   nim >= 2.0.0
  nimqml-seaqt                           0.9.2     nim >= 2.0.0, nim-seaqt
  NimYAML                                2.1.1     nim >= 2.0.0
                                         2.1.0     nim >= 2.0.0
                                         2.0.0     nim >= 2.0.0
                                         1.1.0     nim >= 1.4.0
  nim-kzg4844                            0.1.0     nim >= 1.6.0, stew >= 0.1.0, unittest2
  nim-mbedtls                            0.0.2     
  nim-quic                               #ddcb31ffb74b5460ab37fd13547eca90594248bcnim >= 1.6.0, stew #head, chronos >= 4.0.3 & < 5.0.0, nimcrypto >= 0.6.0 & < 0.7.0, ngtcp2 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fe, unittest2, chronicles >= 0.10.2
                                                     nim >= 1.6.0, stew #head, chronos >= 4.0.3 & < 5.0.0
                                                     nimcrypto >= 0.6.0 & < 0.7.0, ngtcp2 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fe
                                                     unittest2, chronicles >= 0.10.2
  nimbus-eth2                            #unstable nim 2.0.12, NimYAML, bearssl, blscurve, chronicles, chronos, confutils, eth, faststreams, httputils, json_rpc, json_serialization, libbacktrace, libp2p, metrics, nat_traversal, nimcrypto, normalize, presto, secp256k1, serialization, snappy, sqlite3_abi, ssz_serialization, stew, stint, taskpools, testutils, unicodedb >= 0.10, unittest2, web3, zlib, toml_serialization, nim-kzg4844, zxcvbn, nimbus-security-resources
                                                     nim 2.0.12, NimYAML, bearssl, blscurve, chronicles, chronos, confutils, eth
                                                     faststreams, httputils, json_rpc, json_serialization, libbacktrace, libp2p
                                                     metrics, nat_traversal, nimcrypto, normalize, presto, secp256k1, serialization
                                                     snappy, sqlite3_abi, ssz_serialization, stew, stint, taskpools, testutils
                                                     unicodedb >= 0.10, unittest2, web3, zlib, toml_serialization, nim-kzg4844
                                                     zxcvbn, nimbus-security-resources
  nimbus-security-resources              0.1.0     
  httputils                              0.3.0     nim >= 1.6.0, stew, results, unittest2
  json_rpc                               0.5.0     nim >= 1.6.0, stew, nimcrypto, stint, chronos >= 4.0.3 & < 4.1.0, httputils >= 0.3.0 & < 0.4.0, chronicles, websock >= 0.2.0 & < 0.3.0, json_serialization, unittest2
                                                     nim >= 1.6.0, stew, nimcrypto, stint, chronos >= 4.0.3 & < 4.1.0
                                                     httputils >= 0.3.0 & < 0.4.0, chronicles, websock >= 0.2.0 & < 0.3.0
                                                     json_serialization, unittest2
  json_serialization                     0.2.9     nim >= 1.6.0, serialization, stew, results
  libbacktrace                           0.0.8     
  libp2p                                 1.9.0     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0, bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1, stew #head, websock, unittest2, nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc, nim-mbedtls
                                                     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0
                                                     bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1
                                                     stew #head, websock, unittest2
                                                     nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc, nim-mbedtls
                                         1.8.0     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0, bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1, stew #head, websock, unittest2, nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0
                                                     bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1
                                                     stew #head, websock, unittest2
                                                     nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                         1.7.1     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0, bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1, stew #head, websock, unittest2, nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0
                                                     bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1
                                                     stew #head, websock, unittest2
                                                     nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                         1.7.0     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0, bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1, stew #head, websock, unittest2, nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0
                                                     bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1
                                                     stew #head, websock, unittest2
                                                     nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
  metrics                                0.1.2     nim >= 1.6.14, chronos >= 4.0.3, results, stew
  minilru                                0.1.0     nim >= 1.6.0, results, unittest2
  nat_traversal                          0.0.1     
  ngtcp2                                 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fenim >= 1.6.0
  nim                                    2.0.12    
  nimcrypto                              0.6.2     nim >= 1.6
                                         0.6.1     nim >= 1.6
                                         0.6.0     nim >= 1.6
  normalize                              0.9.0     nim >= 1.0.0, unicodedb >= 0.7
                                         0.8.0     nim >= 0.19.0, unicodedb >= 0.7
                                         0.6.0     nim >= 0.18.0, unicodedb >= 0.7
                                         0.5.0     nim >= 0.18.0, unicodedb >= 0.7
  presto                                 0.1.0     nim >= 1.6.0, chronos  ^= >= 4.0.3, chronicles, metrics, results, stew
  results                                0.5.1     
  secp256k1                              0.6.0.3.2 nim >= 1.6.0, stew, results, nimcrypto
  serialization                          0.2.6     nim >= 1.6.0, faststreams, unittest2, stew
                                         0.2.4     nim >= 1.6.0, faststreams, unittest2, stew
  snappy                                 0.1.0     nim >= 1.6.0, faststreams, unittest2, results, stew
  sqlite3_abi                            3.49.1.0  nim >= 0.18.1
                                         3.49.0.0  nim >= 0.18.1
                                         3.48.0.0  nim >= 0.18.1
                                         3.47.2.0  nim >= 0.18.1
  ssz_serialization                      0.1.0     nim >= 2.0.10, serialization, json_serialization, stew, stint, nimcrypto, blscurve, results, unittest2
                                                     nim >= 2.0.10, serialization, json_serialization, stew, stint, nimcrypto
                                                     blscurve, results, unittest2
  stew                                   0.2.0     nim >= 1.6.0, results, unittest2
  stint                                  0.8.1     nim >= 1.6.12, stew >= 0.2.0, unittest2 >= 0.2.3
                                         0.8.0     nim >= 1.6.12, stew >= 0.2.0, unittest2 >= 0.2.3
  taskpools                              0.1.0     nim >= 1.6.0
  testutils                              0.6.0     nim >= 1.6.0, unittest2
                                         0.5.3     nim >= 1.6.0, unittest2
                                         0.5.0     nim >= 1.6.0, unittest2
                                         0.5.0     nim >= 1.2.0, unittest2
  toml_serialization                     0.2.14    nim >= 1.6.0, serialization, stew
  unicodedb                              0.13.2    nim >= 1.0.0
                                         0.13.1    nim >= 1.0.0
                                         0.13.0    nim >= 1.0.0
                                         0.12.0    nim >= 1.0.0
  unittest2                              0.2.4     nim >= 1.6.0
                                         0.2.3     nim >= 1.6.0
                                         0.2.2     nim >= 1.6.0
                                         0.2.1     nim >= 1.6.0
  web3                                   0.6.0     nim >= 2.0.0, chronicles, chronos, bearssl, eth >= 0.7.0, faststreams, json_rpc, json_serialization, nimcrypto, stew, stint, results
                                                     nim >= 2.0.0, chronicles, chronos, bearssl, eth >= 0.7.0, faststreams, json_rpc
                                                     json_serialization, nimcrypto, stew, stint, results
                                         0.5.0     nim >= 2.0.0, chronicles, chronos, bearssl, eth, faststreams, json_rpc, json_serialization, nimcrypto, stew, stint, results
                                                     nim >= 2.0.0, chronicles, chronos, bearssl, eth, faststreams, json_rpc
                                                     json_serialization, nimcrypto, stew, stint, results
  websock                                0.2.0     nim >= 1.6.0, chronos >= 4.0.3 & < 4.1.0, httputils >= 0.2.0, chronicles >= 0.10.2, stew >= 0.1.0, nimcrypto, bearssl, zlib
                                                     nim >= 1.6.0, chronos >= 4.0.3 & < 4.1.0, httputils >= 0.2.0
                                                     chronicles >= 0.10.2, stew >= 0.1.0, nimcrypto, bearssl, zlib
  zlib                                   0.1.0     nim >= 1.6.0, stew >= 0.1.0, results >= 0.5.1
  zxcvbn                                 0.1.0     nim >= 1.6.0, testutils
  
```


`nimble dump --solve`

Output:

```
PACKAGE                                 VERSION   REQUIREMENTS
------------------------------------------------------
* nim_selection                          0.1.0     nim >= 2.0.12, nimbus-eth2 #unstable, nim-seaqt #qt-6.4, nimqml-seaqt
  bearssl                                0.2.5     nim >= 1.6.0, unittest2
                                                     Required by: chronos v(4.0.4, 4.0.3, 4.0.2, 4.0.1)
                                                                 libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0), nimbus-eth2 #unstable
                                                                 web3 v(0.6.0, 0.5.0), websock 0.2.0
  blscurve                               0.0.1     nim >= 1.6.0, nimcrypto, stew, results, taskpools >= 0.0.5
                                                     Required by: nimbus-eth2 #unstable, ssz_serialization 0.1.0
  chronicles                             0.10.3    nim >= 1.2.0, testutils, json_serialization
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), json_rpc 0.5.0
                                                                 libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
                                                                 nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                                 nimbus-eth2 #unstable, presto 0.1.0, web3 v(0.6.0, 0.5.0)
                                                                 websock 0.2.0
  chronos                                4.0.4     nim >= 1.6.16, results, stew, bearssl >= 0.2.5, httputils, unittest2
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), json_rpc 0.5.0
                                                                 libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0), metrics 0.1.2
                                                                 nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                                 nimbus-eth2 #unstable, presto 0.1.0, web3 v(0.6.0, 0.5.0)
                                                                 websock 0.2.0
  confutils                              0.1.0     nim >= 1.6.0, stew, serialization
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), nimbus-eth2 #unstable
  dnsclient                              0.3.4     nim >= 0.20.0
                                                     Required by: libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
  eth                                    0.7.0     nim >= 2.0.10, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew, nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results, minilru, snappy
                                                     nim >= 2.0.10, nimcrypto, stint >= 0.8.0, secp256k1, chronos, chronicles, stew
                                                     nat_traversal, metrics, sqlite3_abi, confutils, testutils, unittest2, results
                                                     minilru, snappy
                                                     Required by: nimbus-eth2 #unstable, web3 v(0.6.0, 0.5.0)
  faststreams                            0.3.0     nim >= 1.6.0, stew, unittest2
                                                     Required by: nimbus-eth2 #unstable, serialization v(0.2.6, 0.2.4), snappy 0.1.0
                                                                 web3 v(0.6.0, 0.5.0)
  nim-seaqt                              #qt-6.4   nim >= 2.0.0
                                                     Required by: nim_selection 0.1.0, nimqml-seaqt 0.9.2
  nimqml-seaqt                           0.9.2     nim >= 2.0.0, nim-seaqt
                                                     Required by: nim_selection 0.1.0
  NimYAML                                2.1.1     nim >= 2.0.0
                                                     Required by: nimbus-eth2 #unstable
  nim-kzg4844                            0.1.0     nim >= 1.6.0, stew >= 0.1.0, unittest2
                                                     Required by: nimbus-eth2 #unstable
  nim-mbedtls                            0.0.2     
                                                     Required by: libp2p 1.9.0
  nim-quic                               #ddcb31ffb74b5460ab37fd13547eca90594248bcnim >= 1.6.0, stew #head, chronos >= 4.0.3 & < 5.0.0, nimcrypto >= 0.6.0 & < 0.7.0, ngtcp2 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fe, unittest2, chronicles >= 0.10.2
                                                     nim >= 1.6.0, stew #head, chronos >= 4.0.3 & < 5.0.0
                                                     nimcrypto >= 0.6.0 & < 0.7.0, ngtcp2 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fe
                                                     unittest2, chronicles >= 0.10.2
                                                     Required by: libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
  nimbus-eth2                            #unstable nim 2.0.12, NimYAML, bearssl, blscurve, chronicles, chronos, confutils, eth, faststreams, httputils, json_rpc, json_serialization, libbacktrace, libp2p, metrics, nat_traversal, nimcrypto, normalize, presto, secp256k1, serialization, snappy, sqlite3_abi, ssz_serialization, stew, stint, taskpools, testutils, unicodedb >= 0.10, unittest2, web3, zlib, toml_serialization, nim-kzg4844, zxcvbn, nimbus-security-resources
                                                     nim 2.0.12, NimYAML, bearssl, blscurve, chronicles, chronos, confutils, eth
                                                     faststreams, httputils, json_rpc, json_serialization, libbacktrace, libp2p
                                                     metrics, nat_traversal, nimcrypto, normalize, presto, secp256k1, serialization
                                                     snappy, sqlite3_abi, ssz_serialization, stew, stint, taskpools, testutils
                                                     unicodedb >= 0.10, unittest2, web3, zlib, toml_serialization, nim-kzg4844
                                                     zxcvbn, nimbus-security-resources
                                                     Required by: nim_selection 0.1.0
  nimbus-security-resources              0.1.0     
                                                     Required by: nimbus-eth2 #unstable
  httputils                              0.3.0     nim >= 1.6.0, stew, results, unittest2
                                                     Required by: chronos v(4.0.4, 4.0.3, 4.0.2, 4.0.1), json_rpc 0.5.0
                                                                 nimbus-eth2 #unstable, websock 0.2.0
  json_rpc                               0.5.0     nim >= 1.6.0, stew, nimcrypto, stint, chronos >= 4.0.3 & < 4.1.0, httputils >= 0.3.0 & < 0.4.0, chronicles, websock >= 0.2.0 & < 0.3.0, json_serialization, unittest2
                                                     nim >= 1.6.0, stew, nimcrypto, stint, chronos >= 4.0.3 & < 4.1.0
                                                     httputils >= 0.3.0 & < 0.4.0, chronicles, websock >= 0.2.0 & < 0.3.0
                                                     json_serialization, unittest2
                                                     Required by: nimbus-eth2 #unstable, web3 v(0.6.0, 0.5.0)
  json_serialization                     0.2.9     nim >= 1.6.0, serialization, stew, results
                                                     Required by: chronicles v(0.10.3, 0.10.2, 0.10.1, 0.10.0), json_rpc 0.5.0
                                                                 nimbus-eth2 #unstable, ssz_serialization 0.1.0, web3 v(0.6.0, 0.5.0)
  libbacktrace                           0.0.8     
                                                     Required by: nimbus-eth2 #unstable
  libp2p                                 1.9.0     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0, bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1, stew #head, websock, unittest2, nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc, nim-mbedtls
                                                     nim >= 1.6.0, nimcrypto >= 0.6.0 & < 0.7.0, dnsclient >= 0.3.0 & < 0.4.0
                                                     bearssl >= 0.2.5, chronicles >= 0.10.2, chronos >= 4.0.3, metrics, secp256k1
                                                     stew #head, websock, unittest2
                                                     nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc, nim-mbedtls
                                                     Required by: nimbus-eth2 #unstable
  metrics                                0.1.2     nim >= 1.6.14, chronos >= 4.0.3, results, stew
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
                                                                 nimbus-eth2 #unstable, presto 0.1.0
  minilru                                0.1.0     nim >= 1.6.0, results, unittest2
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0)
  nat_traversal                          0.0.1     
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), nimbus-eth2 #unstable
  ngtcp2                                 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fenim >= 1.6.0
                                                     Required by: nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
  nim                                    2.0.12    
                                                     Required by: NimYAML v(2.1.1, 2.1.0, 2.0.0, 1.1.0)
                                                                 bearssl v(0.2.5, 0.2.4, 0.2.3, 0.2.2), blscurve 0.0.1
                                                                 chronicles v(0.10.3, 0.10.2, 0.10.1, 0.10.0)
                                                                 chronos v(4.0.4, 4.0.3, 4.0.2, 4.0.1), confutils 0.1.0
                                                                 dnsclient v(0.3.4, 0.3.3, 0.3.2, 0.3.1), eth v(0.7.0, 0.6.0, 0.5.0)
                                                                 faststreams 0.3.0, httputils 0.3.0, json_rpc 0.5.0
                                                                 json_serialization 0.2.9, libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
                                                                 metrics 0.1.2, minilru 0.1.0
                                                                 ngtcp2 #6834f4756b6af58356ac9c4fef3d71db3c3ae5fe, nim-kzg4844 0.1.0
                                                                 nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                                 nim-seaqt #qt-6.4, nim_selection 0.1.0, nimbus-eth2 #unstable
                                                                 nimcrypto v(0.6.2, 0.6.1, 0.6.0), nimqml-seaqt 0.9.2
                                                                 normalize v(0.9.0, 0.8.0, 0.6.0, 0.5.0), presto 0.1.0
                                                                 secp256k1 0.6.0.3.2, serialization v(0.2.6, 0.2.4), snappy 0.1.0
                                                                 sqlite3_abi v(3.49.1.0, 3.49.0.0, 3.48.0.0, 3.47.2.0)
                                                                 ssz_serialization 0.1.0, stew 0.2.0, stint v(0.8.1, 0.8.0)
                                                                 taskpools 0.1.0, testutils v(0.6.0, 0.5.3, 0.5.0)
                                                                 toml_serialization 0.2.14
                                                                 unicodedb v(0.13.2, 0.13.1, 0.13.0, 0.12.0)
                                                                 unittest2 v(0.2.4, 0.2.3, 0.2.2, 0.2.1), web3 v(0.6.0, 0.5.0)
                                                                 websock 0.2.0, zlib 0.1.0, zxcvbn 0.1.0
  nimcrypto                              0.6.2     nim >= 1.6
                                                     Required by: blscurve 0.0.1, eth v(0.7.0, 0.6.0, 0.5.0), json_rpc 0.5.0
                                                                 libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
                                                                 nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                                 nimbus-eth2 #unstable, secp256k1 0.6.0.3.2, ssz_serialization 0.1.0
                                                                 web3 v(0.6.0, 0.5.0), websock 0.2.0
  normalize                              0.9.0     nim >= 1.0.0, unicodedb >= 0.7
                                                     Required by: nimbus-eth2 #unstable
  presto                                 0.1.0     nim >= 1.6.0, chronos  ^= >= 4.0.3, chronicles, metrics, results, stew
                                                     Required by: nimbus-eth2 #unstable
  results                                0.5.1     
                                                     Required by: blscurve 0.0.1, chronos v(4.0.4, 4.0.3, 4.0.2, 4.0.1)
                                                                 eth v(0.7.0, 0.6.0, 0.5.0), httputils 0.3.0
                                                                 json_serialization 0.2.9, metrics 0.1.2, minilru 0.1.0, presto 0.1.0
                                                                 secp256k1 0.6.0.3.2, snappy 0.1.0, ssz_serialization 0.1.0
                                                                 stew 0.2.0, web3 v(0.6.0, 0.5.0), zlib 0.1.0
  secp256k1                              0.6.0.3.2 nim >= 1.6.0, stew, results, nimcrypto
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
                                                                 nimbus-eth2 #unstable
  serialization                          0.2.6     nim >= 1.6.0, faststreams, unittest2, stew
                                                     Required by: confutils 0.1.0, json_serialization 0.2.9, nimbus-eth2 #unstable
                                                                 ssz_serialization 0.1.0, toml_serialization 0.2.14
  snappy                                 0.1.0     nim >= 1.6.0, faststreams, unittest2, results, stew
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), nimbus-eth2 #unstable
  sqlite3_abi                            3.49.1.0  nim >= 0.18.1
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), nimbus-eth2 #unstable
  ssz_serialization                      0.1.0     nim >= 2.0.10, serialization, json_serialization, stew, stint, nimcrypto, blscurve, results, unittest2
                                                     nim >= 2.0.10, serialization, json_serialization, stew, stint, nimcrypto
                                                     blscurve, results, unittest2
                                                     Required by: nimbus-eth2 #unstable
  stew                                   0.2.0     nim >= 1.6.0, results, unittest2
                                                     Required by: blscurve 0.0.1, chronos v(4.0.4, 4.0.3, 4.0.2, 4.0.1)
                                                                 confutils 0.1.0, eth v(0.7.0, 0.6.0, 0.5.0), faststreams 0.3.0
                                                                 httputils 0.3.0, json_rpc 0.5.0, json_serialization 0.2.9
                                                                 libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0), metrics 0.1.2
                                                                 nim-kzg4844 0.1.0
                                                                 nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                                 nimbus-eth2 #unstable, presto 0.1.0, secp256k1 0.6.0.3.2
                                                                 serialization v(0.2.6, 0.2.4), snappy 0.1.0, ssz_serialization 0.1.0
                                                                 stint v(0.8.1, 0.8.0), toml_serialization 0.2.14
                                                                 web3 v(0.6.0, 0.5.0), websock 0.2.0, zlib 0.1.0
  stint                                  0.8.1     nim >= 1.6.12, stew >= 0.2.0, unittest2 >= 0.2.3
                                                     Required by: eth v(0.7.0, 0.6.0, 0.5.0), json_rpc 0.5.0, nimbus-eth2 #unstable
                                                                 ssz_serialization 0.1.0, web3 v(0.6.0, 0.5.0)
  taskpools                              0.1.0     nim >= 1.6.0
                                                     Required by: blscurve 0.0.1, nimbus-eth2 #unstable
  testutils                              0.6.0     nim >= 1.6.0, unittest2
                                                     Required by: chronicles v(0.10.3, 0.10.2, 0.10.1, 0.10.0)
                                                                 eth v(0.7.0, 0.6.0, 0.5.0), nimbus-eth2 #unstable, zxcvbn 0.1.0
  toml_serialization                     0.2.14    nim >= 1.6.0, serialization, stew
                                                     Required by: nimbus-eth2 #unstable
  unicodedb                              0.13.2    nim >= 1.0.0
                                                     Required by: nimbus-eth2 #unstable, normalize v(0.9.0, 0.8.0, 0.6.0, 0.5.0)
  unittest2                              0.2.4     nim >= 1.6.0
                                                     Required by: bearssl v(0.2.5, 0.2.4, 0.2.3, 0.2.2)
                                                                 chronos v(4.0.4, 4.0.3, 4.0.2, 4.0.1), eth v(0.7.0, 0.6.0, 0.5.0)
                                                                 faststreams 0.3.0, httputils 0.3.0, json_rpc 0.5.0
                                                                 libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0), minilru 0.1.0
                                                                 nim-kzg4844 0.1.0
                                                                 nim-quic #ddcb31ffb74b5460ab37fd13547eca90594248bc
                                                                 nimbus-eth2 #unstable, serialization v(0.2.6, 0.2.4), snappy 0.1.0
                                                                 ssz_serialization 0.1.0, stew 0.2.0, stint v(0.8.1, 0.8.0)
                                                                 testutils v(0.6.0, 0.5.3, 0.5.0)
  web3                                   0.6.0     nim >= 2.0.0, chronicles, chronos, bearssl, eth >= 0.7.0, faststreams, json_rpc, json_serialization, nimcrypto, stew, stint, results
                                                     nim >= 2.0.0, chronicles, chronos, bearssl, eth >= 0.7.0, faststreams, json_rpc
                                                     json_serialization, nimcrypto, stew, stint, results
                                                     Required by: nimbus-eth2 #unstable
  websock                                0.2.0     nim >= 1.6.0, chronos >= 4.0.3 & < 4.1.0, httputils >= 0.2.0, chronicles >= 0.10.2, stew >= 0.1.0, nimcrypto, bearssl, zlib
                                                     nim >= 1.6.0, chronos >= 4.0.3 & < 4.1.0, httputils >= 0.2.0
                                                     chronicles >= 0.10.2, stew >= 0.1.0, nimcrypto, bearssl, zlib
                                                     Required by: json_rpc 0.5.0, libp2p v(1.9.0, 1.8.0, 1.7.1, 1.7.0)
  zlib                                   0.1.0     nim >= 1.6.0, stew >= 0.1.0, results >= 0.5.1
                                                     Required by: nimbus-eth2 #unstable, websock 0.2.0
  zxcvbn                                 0.1.0     nim >= 1.6.0, testutils
                                                     Required by: nimbus-eth2 #unstable

```
                                                     
                                                     