### PR TITLE
Road to `nimble 1.0.` New code path where `parser:declarative` and `sat` is assumed

### DIFF
--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -498,7 +498,11 @@ proc downloadPkgFromUrl*(pv: PkgTuple, options: Options): (DownloadPkgResult, Do
   (downloadRes, meth)
         
 proc downloadPkInfoForPv*(pv: PkgTuple, options: Options): PackageInfo  =
-  downloadPkgFromUrl(pv, options)[0].dir.getPkgInfo(options)
+  let downloadRes = downloadPkgFromUrl(pv, options)
+  if options.firstSatPass:
+    getPkgInfoFromDirWithDeclarativeParser(downloadRes[0].dir, options, forceDeclarativeOnly = true)
+  else:
+    downloadRes[0].dir.getPkgInfo(options)
 
 proc getAllNimReleases(options: Options): seq[PackageMinimalInfo] =
   let releases = getOfficialReleases(options)  

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -68,6 +68,8 @@ type
     useDeclarativeParser*: bool # Whether to use the declarative parser for parsing nimble files (only when solver is SAT)
     features*: seq[string] # Features to be activated. Only used when using the declarative parser
     ignoreSubmodules*: bool # Whether to ignore submodules when cloning a repository
+    useVNext*: bool # Whether to use the vnext code path
+    firstSatPass*: bool #Are we in the first sat pass (aka solving the nim version)?
 
   ActionType* = enum
     actionNil, actionRefresh, actionInit, actionDump, actionPublish, actionUpgrade
@@ -280,6 +282,7 @@ Nimble Options:
       --parser:declarative|nimvm  Use the declarative parser or the nimvm parser (default).
       --features                  Activate features. Only used when using the declarative parser.
       --ignoreSubmodules          Ignore submodules when cloning a repository.
+      --vnext                     Temporary flag (not shipped) to use the new code path where we assume solver is SAT and declarative parser are enabled. Later on, when both are enabled `vnext` code path will be used.
 For more information read the GitHub readme:
   https://github.com/nim-lang/nimble#readme
 """
@@ -663,6 +666,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     result.features = val.split(";").mapIt(it.strip)
   of "ignoresubmodules":
     result.ignoreSubmodules = true
+  of "vnext":
+    result.useVNext = true
   else: isGlobalFlag = false
 
   var wasFlagHandled = true
@@ -963,3 +968,6 @@ proc isDevelopment*(pkg: PackageInfo, options: Options): bool =
   ### Returns true if the package is a development package. 
   ### A development package is a root package that is not installed.
   not pkg.myPath.parentDir.startsWith(options.getPkgsDir())
+
+proc isVNext*(options: Options): bool =
+  options.useVNext

--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -371,12 +371,12 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
     validatePackageInfo(pkgInfo, options)
 
 proc getPkgInfoFromFile*(file: NimbleFile, options: Options,
-                         forValidation = false, useCache = true): PackageInfo =
+                         forValidation = false, useCache = true, onlyMinimalInfo = false): PackageInfo =
   ## Reads the specified .nimble file and returns its data as a PackageInfo
   ## object. Any validation errors are handled and displayed as warnings.
   result = initPackageInfo()
   try:
-    readPackageInfo(result, file, options, useCache= useCache)
+    readPackageInfo(result, file, options, onlyMinimalInfo = onlyMinimalInfo, useCache= useCache)
   except ValidationError:
     let exc = (ref ValidationError)(getCurrentException())
     if exc.warnAll and not forValidation:
@@ -385,11 +385,11 @@ proc getPkgInfoFromFile*(file: NimbleFile, options: Options,
     else:
       raise
 
-proc getPkgInfo*(dir: string, options: Options, forValidation = false):
+proc getPkgInfo*(dir: string, options: Options, forValidation = false, onlyMinimalInfo = false):
     PackageInfo =
   ## Find the .nimble file in ``dir`` and parses it, returning a PackageInfo.
   let nimbleFile = findNimbleFile(dir, true, options)
-  result = getPkgInfoFromFile(nimbleFile, options, forValidation)
+  result = getPkgInfoFromFile(nimbleFile, options, forValidation, onlyMinimalInfo = onlyMinimalInfo)
 
 proc getInstalledPkgs*(libsDir: string, options: Options): seq[PackageInfo] =
   ## Gets a list of installed packages.

--- a/tests/tdeclarativeparser.nim
+++ b/tests/tdeclarativeparser.nim
@@ -5,8 +5,8 @@ import std/[options, tables, sequtils, os]
 import
   nimblepkg/[packageinfotypes, version, options, config, nimblesat, declarativeparser, cli, common]
 
-proc getNimbleFileFromPkgNameHelper(pkgName: string): string =
-  let pv: PkgTuple = (pkgName, VersionRange(kind: verAny))
+proc getNimbleFileFromPkgNameHelper(pkgName: string, ver = VersionRange(kind: verAny)): string =
+  let pv: PkgTuple = (pkgName, ver)
   var options = initOptions()
   options.nimBin = some options.makeNimBin("nim")
   options.config.packageLists["official"] = PackageList(
@@ -81,6 +81,12 @@ suite "Declarative parsing":
     echo output
     check exitCode == QuitSuccess
 
+  test "should be able to retrieve the nim info from a nim directory":
+    let versions = @["1.6.12", "2.2.0"]
+    for ver in versions:
+      let nimbleFile = getNimbleFileFromPkgNameHelper("nim", parseVersionRange(ver))
+      check extractNimVersion(nimbleFile) == ver
+    echo ""
 
 suite "Declarative parser features":
   test "should be able to parse features from a nimble file":
@@ -136,7 +142,6 @@ suite "Declarative parser features":
       let (output, exitCode) = execNimble("--parser:declarative", "run")
       check exitCode == QuitSuccess
       check output.processOutput.inLines("dev is enabled")
-
 
   #[NEXT Tests:
 


### PR DESCRIPTION
WIP
- Parses nimble version from `compilation.nim`
- Partially implements nim selection (need to take into account user's nim)
- Introduces vnext as a temporary flag to enable the new code path, once all actions work it will be assumed when both `sat` and declarative parser are enabled.