### PR TITLE
add haiku to os options

### DIFF
--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -142,6 +142,8 @@ proc getNightliesUrl*(parsedContents: JsonNode, arch: int): (string, string) =
       "freebsd"
     elif defined(openbsd):
       "openbsd"
+    elif defined(haiku):
+      "haiku"
   for jn in parsedContents.getElems():
     if jn["name"].getStr().contains("devel"):
       let tagName = jn{"tag_name"}.getStr("")


### PR DESCRIPTION
this also fixes the following error that occurs when trying to compile nim on a haiku host

```
> ./build_all.sh
bin/nim_csources_86742fb02c6606ab01a532a0085784effb2e753e exists.

cmd: rm -f bin/nim

cmd: cp bin/nim_csources_86742fb02c6606ab01a532a0085784effb2e753e bin/nim

cmd: bin/nim_csources_86742fb02c6606ab01a532a0085784effb2e753e -v
Nim Compiler Version 1.9.1 [Haiku: amd64]
Compiled at 2023-01-02
Copyright (c) 2006-2022 by Andreas Rumpf

git hash: 7f6681b4c4ccc0dc43fd256280be4c3ad3c773e5
active boot switches: -d:release -d:danger

cmd: bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --hints:off koch
/boot/home/src/git/Nim/tools/deps.nim(1, 11) Warning: imported and not used: 'strutils' [UnusedImport]

cmd: ./koch boot -d:release --skipUserCfg --skipParentCfg --hints:off
deps.cmd: git checkout -q f8f6bd34bfa3fe12c64b919059ad856a96efcba0
iteration: 1
bin/nim c  --skipUserCfg --skipParentCfg -d:nimKochBootstrap --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off --noNimblePath --compileOnly compiler/nim.nim
/boot/home/src/git/Nim/compiler/modulegraphs.nim(14, 11) Warning: imported and not used: 'algorithm' [UnusedImport]
/boot/home/src/git/Nim/compiler/layeredtable.nim(1, 11) Warning: imported and not used: 'tables' [UnusedImport]
/boot/home/src/git/Nim/compiler/concepts.nim(14, 13) Warning: imported and not used: 'astalgo' [UnusedImport]
/boot/home/src/git/Nim/compiler/sempass2.nim(14, 49) Warning: imported and not used: 'lowerings' [UnusedImport]
bin/nim jsonscript --noNimblePath --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
iteration: 2
compiler/nim1 c  --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off --noNimblePath --compileOnly compiler/nim.nim
/boot/home/src/git/Nim/compiler/modulegraphs.nim(14, 47) Warning: imported and not used: 'algorithm' [UnusedImport]
/boot/home/src/git/Nim/compiler/layeredtable.nim(1, 13) Warning: imported and not used: 'tables' [UnusedImport]
/boot/home/src/git/Nim/compiler/concepts.nim(14, 13) Warning: imported and not used: 'astalgo' [UnusedImport]
/boot/home/src/git/Nim/compiler/sempass2.nim(14, 49) Warning: imported and not used: 'lowerings' [UnusedImport]
compiler/nim1 jsonscript --noNimblePath --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
iteration: 3
compiler/nim2 c  --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off --noNimblePath --compileOnly compiler/nim.nim
/boot/home/src/git/Nim/compiler/modulegraphs.nim(14, 47) Warning: imported and not used: 'algorithm' [UnusedImport]
/boot/home/src/git/Nim/compiler/layeredtable.nim(1, 13) Warning: imported and not used: 'tables' [UnusedImport]
/boot/home/src/git/Nim/compiler/concepts.nim(14, 13) Warning: imported and not used: 'astalgo' [UnusedImport]
/boot/home/src/git/Nim/compiler/sempass2.nim(14, 49) Warning: imported and not used: 'lowerings' [UnusedImport]
compiler/nim2 jsonscript --noNimblePath --nimcache:nimcache/r_haiku_amd64 -d:release --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
executables are equal: SUCCESS!

cmd: ./koch tools --skipUserCfg --skipParentCfg --hints:off
deps.cmd: git checkout -q f8f6bd34bfa3fe12c64b919059ad856a96efcba0
bin/nim c -o:bin/nimsuggest -d:danger --skipUserCfg --skipParentCfg --hints:off nimsuggest/nimsuggest.nim
nimsuggest.nim(13, 17) Warning: imported and not used: 'wordrecg' [UnusedImport]
nimsuggest.nim(12, 17) Warning: imported and not used: 'trees' [UnusedImport]
bin/nim c -o:bin/nimgrep -d:release --skipUserCfg --skipParentCfg --hints:off tools/nimgrep.nim
bin/nim c -o:bin/nimpretty -d:release --skipUserCfg --skipParentCfg --hints:off nimpretty/nimpretty.nim
bin/nim c -o:bin/testament -d:release --skipUserCfg --skipParentCfg --hints:off testament/testament.nim
bin/nim c -o:bin/nim_dbg --opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
/boot/home/src/git/Nim/compiler/modulegraphs.nim(14, 47) Warning: imported and not used: 'algorithm' [UnusedImport]
/boot/home/src/git/Nim/compiler/layeredtable.nim(1, 13) Warning: imported and not used: 'tables' [UnusedImport]
/boot/home/src/git/Nim/compiler/concepts.nim(14, 13) Warning: imported and not used: 'astalgo' [UnusedImport]
/boot/home/src/git/Nim/compiler/sempass2.nim(14, 49) Warning: imported and not used: 'lowerings' [UnusedImport]
deps.cmd: git checkout -q b1dc28450f028aead0b7cf5da8adf2267db65f89
deps.cmd: git submodule update --init
bin/nim c -o:bin/nimble -d:release --noNimblePath --skipUserCfg --skipParentCfg --hints:off dist/nimble/src/nimble.nim
/boot/home/src/git/Nim/dist/nimble/src/nimblepkg/downloadnim.nim(135, 5) Error: expression '' has no type (or is ambiguous)
FAILURE

> uname -a
Haiku shredder 1 hrev58867 May 18 2025 06:24:28 x86_64 x86_64 Haiku
```
