### PR TITLE
fix(#1381): revert spinner

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2693,5 +2693,4 @@ when isMainModule:
       displayError(&"Couldn't save \"{nimbleDataFileName}\".")
       displayDetails(error)
 
-  displayLineReset()
   quit(exitCode)

--- a/src/nimblepkg/deps.nim
+++ b/src/nimblepkg/deps.nim
@@ -41,7 +41,6 @@ proc printDepsHumanReadable*(pkgInfo: PackageInfo,
   ## print human readable tree deps
   ## 
   if levelInfos.len() == 0:
-    displayLineReset()
     displayInfo("Dependency tree format: {PackageName} {Requirements} (@{Resolved Version})")
     displayFormatted(Hint, "\n")
     displayFormatted(Message, pkgInfo.basicInfo.name, " ")


### PR DESCRIPTION
Closes #1381.

This removes the added spinner and line resets introduced in #1314.

Long-term it would be worthwhile to add back an interactive spinner particularly in a non-debug setting where `nimble` is performing several tasks and the user might think that it's hanging.
