### PR TITLE
Fix 'nimble develop -g'

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1588,7 +1588,7 @@ proc saveLinkFile(pkgInfo: PackageInfo, options: Options) =
     pkgName = pkgInfo.basicInfo.name
     pkgLinkDir = options.getPkgsLinksDir / pkgName.getLinkFileDir
     pkgLinkFilePath = pkgLinkDir / pkgName.getLinkFileName
-    pkgLinkFileContent = pkgInfo.myPath & "\n" & pkgInfo.getNimbleFileDir
+    pkgLinkFileContent = pkgInfo.myPath & "\n" & pkgInfo.getRealDir()
 
   if pkgLinkDir.dirExists and not options.prompt(
     &"The link file for {pkgName} already exists. Overwrite?"):


### PR DESCRIPTION
If you add this line to your system or user `nim.cfg`

`nimblepath="$home/.nimble/links/"`

(as referred to in [nim issue 1124](https://github.com/nim-lang/nimble/issues/1124#issuecomment-1936917094)

And you apply this patch to your nimble, then

`nimble develop -g` works as intended to put packages that have a `srcDir` defined in development mode. Packages without a srcdir continue to work.