### PR TITLE
Implements cache expansion.

### DIFF
--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -677,6 +677,10 @@ proc getPackageMinimalVersionsFromRepo*(repoDir: string, pkg: PkgTuple, version:
         else:
           let pkgInfo = getPkgInfoFromFile(nimbleFile, options, useCache=false)
           result.addUnique pkgInfo.getMinimalInfo(options)
+        #here we copy the directory to its own folder so we have it cached for future usage
+        let downloadInfo = getPackageDownloadInfo((name, tagVersion.toVersionRange()), options)
+        copyDir(tempDir, downloadInfo.downloadDir)
+
       except CatchableError as e:
         displayWarning(
           &"Error reading tag {tag}: for package {name}. This may not be relevant as it could be an old version of the package. \n {e.msg}",

--- a/src/nimblepkg/vnext.nim
+++ b/src/nimblepkg/vnext.nim
@@ -976,6 +976,7 @@ proc installPkgs*(satResult: var SATResult, options: Options) =
         if pv.name.isFileURL:
           downloadDir = dlInfo.url.extractFilePathFromURL()
         else:
+          #Since cache expansion is implemented, this point shouldnt be reached anymore.
           discard downloadFromDownloadInfo(dlInfo, options)
         # dlInfo.downloadDir = downloadPkgResult.dir 
       assert dirExists(downloadDir)


### PR DESCRIPTION
 When enumerating the packages the packages, it creates an actual dir entry with the package version. This prevents redownloads later on the pipeline and in future usages of the other versions.