### PR TITLE
Ignore AppleDouble files (._*) when scanning for nimble file

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -457,7 +457,10 @@ proc findNimbleFile*(dir: string; error: bool, options: Options, warn = true): s
   var hits = 0
   for kind, path in walkDir(dir):
     if kind in {pcFile, pcLinkToFile}:
-      let ext = path.splitFile.ext
+      let (_, fileName, ext) = splitFile(path)
+      # Ignore macOS AppleDouble files like `._filename.nimble`
+      if fileName.startsWith("._"):
+        continue
       case ext
       of ".babel", ".nimble":
         result = path


### PR DESCRIPTION
Fix build error on Mac OS non native file system.

On non native file system, mac os creates metadata files starting with `._*`

Avoids treating macOS metadata files like `._*.nimble` as valid candidates in `findNimbleFile` preventing false positives in directories with AppleDouble files.

e.g. I have my `project.nimble` file, mac os will create a `._project.nimble` file with meta data. But nimble will failed with 

> Error:  Binary 'dev' is not defined in 'project' package.
