### PR TITLE
Fix global flags not being added to runFlags after runFile

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -843,7 +843,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
       result.action.compileOptions.add(getFlagString(kind, flag, val))
   of actionRun:
     result.showHelp = false
-    if not isGlobalFlag:
+    # After runFile all flags should be added to runFlags, even if global
+    if not isGlobalFlag or result.action.runFile.isSome():
       result.setRunOptions(flag, getFlagString(kind, flag, val), false)
   of actionCustom:
     if not isGlobalFlag:

--- a/tests/truncommand.nim
+++ b/tests/truncommand.nim
@@ -28,12 +28,13 @@ suite "nimble run":
         "run", # Run command invocation
         "run", # The command to run
         "--test", # First argument passed to the executed command
-        "check" # Second argument passed to the executed command.
+        "--help", # Second argument passed to the executed command (nimble global flag)
+        "check" # Third argument passed to the executed command.
       )
       check exitCode == QuitSuccess
-      check output.contains("tests$1run$1$2 --test check" %
+      check output.contains("tests$1run$1$2 --test --help check" %
                             [$DirSep, "run".changeFileExt(ExeExt)])
-      check output.contains("""Testing `nimble run`: @["--test", "check"]""")
+      check output.contains("""Testing `nimble run`: @["--test", "--help", "check"]""")
 
   test "Parameters not passed to single executable":
     cd "run":
@@ -55,12 +56,13 @@ suite "nimble run":
         "run", # Run command invocation
         "--", # Flag to set run file to "" before next argument
         "--test", # First argument passed to the executed command
-        "check" # Second argument passed to the executed command.
+        "--help", # Second argument passed to the executed command (nimble global flag)
+        "check" # Third argument passed to the executed command.
       )
       check exitCode == QuitSuccess
-      check output.contains("tests$1run$1$2 --test check" %
+      check output.contains("tests$1run$1$2 --test --help check" %
                             [$DirSep, "run".changeFileExt(ExeExt)])
-      check output.contains("""Testing `nimble run`: @["--test", "check"]""")
+      check output.contains("""Testing `nimble run`: @["--test", "--help", "check"]""")
 
   test "Executable output is shown even when not debugging":
     cd "run":


### PR DESCRIPTION
In commit e6bb09d13, a change was made for adding flags to `actionRun`. It prevented global flags from being added to `compileFlags`, but also prevented global flags from being added to `runFlags`. This commit fixes this issue, and users can now test their CLI programs that use the same flags as nimble, for example `nimble run -- --help`.

fixes issue: #1098 (even tho the user did not specify `--`, it still would have failed, since `--help` is a global flag)