### PR TITLE
Introduce compat/ to work around nim bugs

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1,9 +1,9 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import os, tables, strtabs, json, browsers, algorithm, sets, uri, sugar, sequtils, osproc,
-       strformat
+import os, tables, strtabs, browsers, algorithm, sets, uri, sugar, strformat
 
+import nimblepkg/compat/[json, sequtils, osproc]
 import std/options as std_opt
 
 import strutils except toLower
@@ -65,7 +65,7 @@ proc displayUsingSpecialVersionWarning(solvedPkgs: seq[SolvedPackage], options: 
   for pkg in solvedPkgs:
     for req in pkg.requirements:
       if req.ver.isSpecial:
-        nimblesat.addUnique(messages, &"Package {pkg.pkgName} lists an underspecified version of {req.name} ({req.ver})")
+        addUnique(messages, &"Package {pkg.pkgName} lists an underspecified version of {req.name} ({req.ver})")
   
   for msg in messages:
     displayWarning(msg)
@@ -2596,7 +2596,7 @@ proc openNimbleManual =
   openDefaultBrowser(NimbleGuideURL)
 
 proc loadFilePathPkgs*(entryPkg: PackageInfo, options: var Options, nimBin: string) =
-  nimblesat.addUnique(options.filePathPkgs, entryPkg)
+  addUnique(options.filePathPkgs, entryPkg)
   for require in entryPkg.requires:
     if require.name.isFileURL:
       let path = require.name.extractFilePathFromURL()
@@ -2641,7 +2641,7 @@ proc solvePkgs(rootPackage: PackageInfo, options: var Options, nimBin: string) {
   options.satResult.pkgs.incl(resolvedNim.pkg.get) #Make sure its in the solution
   # Only add nim to solvedPkgs if there isn't already one (e.g., with a special version like #devel)
   if not options.satResult.solvedPkgs.anyIt(it.pkgName.isNim):
-    nimblesat.addUnique(options.satResult.solvedPkgs, SolvedPackage(pkgName: "nim", version: resolvedNim.version))
+    addUnique(options.satResult.solvedPkgs, SolvedPackage(pkgName: "nim", version: resolvedNim.version))
   options.satResult.solutionToFullInfo(options)
   if rootPackage.hasLockFile(options) and not options.disableLockFile:
     options.satResult.solveLockFileDeps(pkgList, options, nimBin)

--- a/src/nimblepkg/compat/json.nim
+++ b/src/nimblepkg/compat/json.nim
@@ -1,0 +1,12 @@
+import std/json
+
+export json except parseFile, parseJson
+
+proc parseFile*(filename: string): JsonNode {.raises: [CatchableError], gcsafe.} =
+  {.cast(raises: [CatchableError]).}:
+    {.cast(gcsafe).}:
+      json.parseFile(filename)
+proc parseJson*(j: string): JsonNode {.raises: [CatchableError], gcsafe.} =
+  {.cast(raises: [CatchableError]).}:
+    {.cast(gcsafe).}:
+      json.parseJson(j)

--- a/src/nimblepkg/compat/msgs.nim
+++ b/src/nimblepkg/compat/msgs.nim
@@ -1,0 +1,35 @@
+import compiler/[lineinfos, msgs, options, pathutils]
+
+export msgs except fileInfoIdx, liMessage, localError
+
+# TODO https://github.com/nim-lang/Nim/pull/25399
+proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool): FileIndex =
+  {.cast(raises: [CatchableError]).}:
+    {.cast(gcsafe).}:
+      msgs.fileInfoIdx(conf, filename, isKnownFile)
+
+proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile): FileIndex =
+  var dummy: bool = false
+  result = fileInfoIdx(conf, filename, dummy)
+
+proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
+               eh: TErrorHandling, info2: InstantiationInfo, isRaw = false,
+               ignoreError = false) {.gcsafe, noinline, raises: [CatchableError].} =
+  {.cast(raises: [CatchableError]).}:
+    {.cast(gcsafe).}:
+      when compiles(msgs.liMessage(conf, info, msg, arg, eh, info2, isRaw, ignoreError)):
+        msgs.liMessage(conf, info, msg, arg, eh, info2, isRaw, ignoreError)
+      else:
+        msgs.liMessage(conf, info, msg, arg, eh, info2, isRaw)
+
+proc liMessage2*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
+               eh: TErrorHandling, info2: InstantiationInfo, isRaw = false,
+               ignoreError = false) {.gcsafe, noinline, raises: [CatchableError].} =
+  {.cast(raises: [CatchableError]).}:
+    liMessage(conf, info, msg, arg, eh, info2, isRaw, ignoreError)
+
+template localError*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg = "") =
+  liMessage2(conf, info, msg, arg, doNothing, instLoc())
+
+template localError*(conf: ConfigRef; info: TLineInfo, arg: string) =
+  liMessage2(conf, info, errGenerated, arg, doNothing, instLoc())

--- a/src/nimblepkg/compat/osproc.nim
+++ b/src/nimblepkg/compat/osproc.nim
@@ -1,0 +1,13 @@
+import std/[strtabs, osproc]
+
+export osproc except execCmdEx
+
+proc execCmdEx*(command: string, options: set[ProcessOption] = {
+                poStdErrToStdOut, poUsePath}, env: StringTableRef = nil,
+                workingDir = "", input = ""): tuple[
+                output: string,
+                exitCode: int] {.raises: [OSError, IOError], tags:
+                [ExecIOEffect, ReadIOEffect, RootEffect], gcsafe.} =
+  {.cast(raises: [OSError, IOError]).}:
+    {.cast(gcsafe).}:
+      osproc.execCmdEx(command, options, env, workingDir, input)

--- a/src/nimblepkg/compat/parsecfg.nim
+++ b/src/nimblepkg/compat/parsecfg.nim
@@ -1,0 +1,12 @@
+import std/[parsecfg, streams]
+
+export parsecfg except open, close
+
+proc open*(c: var CfgParser, input: Stream, filename: string,
+           lineOffset = 0) =
+  {.cast(raises: [CatchableError]).}:
+    parsecfg.open(c, input, filename, lineOffset)
+
+proc close*(c: var CfgParser) =
+  {.cast(raises: [CatchableError]).}:
+    parsecfg.close(c)

--- a/src/nimblepkg/compat/pegs.nim
+++ b/src/nimblepkg/compat/pegs.nim
@@ -1,0 +1,8 @@
+# https://github.com/nim-lang/Nim/pull/25399
+import std/pegs
+
+export pegs except peg
+
+func peg*(s: string): Peg {.raises: [EInvalidPeg], gcsafe.} =
+  {.cast(raises: [EInvalidPeg]).}:
+    pegs.peg(s)

--- a/src/nimblepkg/compat/sequtils.nim
+++ b/src/nimblepkg/compat/sequtils.nim
@@ -1,0 +1,20 @@
+import std/sequtils
+export sequtils
+
+when not declared(addUnique):
+  #From the STD as it is not available in older Nim versions
+  func addUnique*[T](s: var seq[T], x: T) =
+    ## Adds `x` to the container `s` if it is not already present.
+    ## Uses `==` to check if the item is already present.
+    runnableExamples:
+      var a = @[1, 2, 3]
+      a.addUnique(4)
+      a.addUnique(4)
+      assert a == @[1, 2, 3, 4]
+
+    for i in 0..high(s):
+      if s[i] == x: return
+    when declared(ensureMove):
+      s.add ensureMove(x)
+    else:
+      s.add x

--- a/src/nimblepkg/compat/syntaxes.nim
+++ b/src/nimblepkg/compat/syntaxes.nim
@@ -1,0 +1,15 @@
+import compiler/[ast, idents, lineinfos, options, syntaxes]
+
+export syntaxes except parseAll, setupParser
+
+proc parseAll*(p: var Parser): PNode {.raises: [CatchableError], gcsafe.} =
+  # TODO fix upstream
+  {.cast(gcsafe).}:
+    {.cast(raises: [CatchableError]).}:
+      syntaxes.parseAll(p)
+
+proc setupParser*(p: var Parser; fileIdx: FileIndex; cache: IdentCache;
+                   config: ConfigRef): bool {.raises: [CatchableError], gcsafe.} =
+  {.cast(gcsafe).}:
+    {.cast(raises: [CatchableError]).}:
+      syntaxes.setupParser(p, fileIdx, cache, config)

--- a/src/nimblepkg/developfile.nim
+++ b/src/nimblepkg/developfile.nim
@@ -4,11 +4,11 @@
 ## This module implements operations required for working with Nimble develop
 ## files.
 
-import sets, json, sequtils, os, strformat, tables, hashes, strutils, math,
+import sets, sequtils, os, strformat, tables, hashes, strutils, math,
        std/jsonutils
 
 import typetraits except distinctBase
-
+import compat/json
 import common, cli, packageinfotypes, packageinfo, packageparser, options,
        version, paths, displaymessages, sha1hashes,
        tools, vcstools, syncfile, lockfile, declarativeparser

--- a/src/nimblepkg/jsonhelpers.nim
+++ b/src/nimblepkg/jsonhelpers.nim
@@ -1,7 +1,7 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json
+import compat/json
 
 proc newJObjectIfKeyNotExists(obj: JsonNode, key: string): JsonNode =
   assert obj.kind == JObject

--- a/src/nimblepkg/lockfile.nim
+++ b/src/nimblepkg/lockfile.nim
@@ -1,8 +1,9 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import tables, os, json
+import tables, os
 import version, sha1hashes, packageinfotypes
+import compat/json
 
 type
   LockFileJsonKeys* = enum

--- a/src/nimblepkg/nimbledatafile.nim
+++ b/src/nimblepkg/nimbledatafile.nim
@@ -1,8 +1,9 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json, os, strformat
+import os, strformat
 import common, options, jsonhelpers, version, cli
+import compat/json
 
 type
   NimbleDataJsonKeys* = enum

--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -4,8 +4,10 @@
 ## Implements the new configuration system for Nimble. Uses Nim as a
 ## scripting language.
 
-import hashes, json, os, strutils, tables, times, osproc
+import hashes, os, strutils, tables, times
+import compat/json
 import common, options, cli, tools
+import compat/osproc
 
 type
   Flags = TableRef[string, seq[string]]

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -1,10 +1,13 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json, strutils, os, parseopt, uri, tables, terminal, osproc, strscans, strformat
+import strutils, os, parseopt, uri, tables, terminal, strscans, strformat
+import compat/json
 import sequtils, sugar
 import std/options as std_opt
 from httpclient import Proxy, newProxy
+
+import compat/osproc
 
 import config, version, common, cli, packageinfotypes, displaymessages, urls
 

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -3,9 +3,10 @@
 
 # Stdlib imports
 import system except TResult
-import hashes, json, strutils, os, sets, tables, times, httpclient, strformat
+import hashes, strutils, os, sets, tables, times, httpclient, strformat
 from net import SslError
 
+import compat/json
 # Local imports
 import version, tools, common, options, cli, config, lockfile, packageinfotypes,
        packagemetadatafile, sha1hashes
@@ -222,7 +223,7 @@ proc readPackageList(name: string, options: Options, ignorePackageCache = false)
     getGPackageJson()[name] = newJArray()
   return getGPackageJson()[name]
 
-proc getPackage*(pkg: string, options: Options, resPkg: var Package, ignorePackageCache = false): bool {.gcsafe.} 
+proc getPackage*(pkg: string, options: Options, resPkg: var Package, ignorePackageCache = false): bool {.gcsafe, raises: [CatchableError].}
 proc resolveAlias(pkg: Package, options: Options): Package =
   result = pkg
   # Resolve alias.

--- a/src/nimblepkg/packagemetadatafile.nim
+++ b/src/nimblepkg/packagemetadatafile.nim
@@ -1,8 +1,9 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json, os, strformat, sets, sequtils
+import os, strformat, sets, sequtils
 import common, version, packageinfotypes, cli, tools, sha1hashes, options
+import compat/json
 
 type
   MetaDataError* = object of NimbleError

--- a/src/nimblepkg/paths.nim
+++ b/src/nimblepkg/paths.nim
@@ -4,7 +4,9 @@
 ## This module implements operations with file system paths in a way independent
 ## of weather the path is absolute or relative to the current directory.
 
-import os, json, hashes
+import os, hashes
+
+import compat/json
 
 type Path* = distinct string
 

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -7,7 +7,7 @@
 import system except TResult
 import httpclient, strutils, json, os, browsers, times, uri
 import common, tools, cli, config, options, packageinfotypes, sha1hashes, version, download
-import strformat, sequtils, pegs, sets
+import strformat, sequtils, sets
 {.warning[UnusedImport]: off.}
 from net import SslCVerifyMode, newContext
 
@@ -247,69 +247,3 @@ proc publish*(p: PackageInfo, o: Options) =
     doCmd("git push https://" & auth.token & "@github.com/" & auth.user & "/packages " & branchName)
     let prUrl = createPullRequest(auth, p, url, branchName)
     display("Success:", "Pull request successful, check at " & prUrl , Success, HighPriority)
-
-proc vcsFindCommits*(repoDir, nimbleFile: string, downloadMethod: DownloadMethod): seq[(Sha1Hash, string)] =
-  var output: string
-  case downloadMethod:
-    of DownloadMethod.git:
-      output = tryDoCmdEx(&"git -C {repoDir.quoteShell} log --format=\"%H %s\" -- $2")
-    of DownloadMethod.hg:
-      assert false, "hg not supported"
-  
-  for line in output.splitLines():
-    let line = line.strip()
-    if line != "":
-      result.add((line[0..39].initSha1Hash(), line[40..^1]))
-
-proc vcsDiff*(commit: Sha1Hash, repoDir, nimbleFile: string, downloadMethod: DownloadMethod): seq[string] =
-  case downloadMethod:
-    of DownloadMethod.git:
-      let (output, exitCode) = doCmdEx(&"git -C {repoDir.quoteShell} diff {commit}~ {commit} {nimbleFile}")
-      if exitCode != QuitSuccess:
-        return @[]
-      else:
-        return output.splitLines()
-    of DownloadMethod.hg:
-      assert false, "hg not supported"
-  
-proc createTag*(tag: string, commit: Sha1Hash, message, repoDir, nimbleFile: string, downloadMethod: DownloadMethod): bool =
-  case downloadMethod:
-    of DownloadMethod.git:
-      let (output, code) = doCmdEx(&"git -C {repoDir.quoteShell} tag -a {tag.quoteShell()} {commit} -m {message.quoteShell()}")
-      result = code == QuitSuccess
-      if not result:
-        displayError(&"Failed to create tag {tag.quoteShell()} with error {output}")
-    of DownloadMethod.hg:
-      assert false, "hg not supported"
-  
-proc findVersions*(commits: seq[(Sha1Hash, string)], projdir, nimbleFile: string, downloadMethod: DownloadMethod, options: Options) =
-  ## parse the versions
-  var
-    versions: HashSet[Version]
-    existingTags: HashSet[Version]
-  for tag in getTagsList(projdir, downloadMethod):
-    let tag = tag.strip(leading=true, chars={'v'})
-    try:
-      existingTags.incl(newVersion(tag))
-    except ParseVersionError:
-      discard
-
-  # adapted from @beef331's algorithm https://github.com/beef331/graffiti/blob/master/src/graffiti.nim
-  for (commit, message) in commits:
-    # echo "commit: ", commit
-    let diffs = vcsDiff(commit, projdir, nimbleFile, downloadMethod)
-    for line in diffs:
-      var matches: array[0..MaxSubpatterns, string]
-      if line.find(peg"'+version' \s* '=' \s* {[\34\39]} {@} $1", matches) > -1:
-        let version = newVersion(matches[1])
-        if version notin versions: 
-          versions.incl(version)
-          if version in existingTags:
-            displayInfo(&"Found existing tag for version {version} at commit {commit}", HighPriority)
-          else:
-            displayInfo(&"Found new version {version} at {commit}", HighPriority)
-            displayWarning(&"Creating tag for new version {version} at {commit}", HighPriority)
-            let res = createTag(&"v{version}", commit, message, projdir, nimbleFile, downloadMethod)
-            if not res:
-                displayError(&"Unable to create tag {version}", HighPriority)
-

--- a/src/nimblepkg/reversedeps.nim
+++ b/src/nimblepkg/reversedeps.nim
@@ -1,8 +1,8 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import json, sets, os, hashes
-
+import sets, os, hashes
+import compat/json
 import options, version, download, jsonhelpers, nimbledatafile, sha1hashes,
        packageinfotypes, packageinfo, packageparser
 

--- a/src/nimblepkg/sha1hashes.nim
+++ b/src/nimblepkg/sha1hashes.nim
@@ -1,10 +1,10 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # BSD License. Look at license.txt for more info.
 
-import strformat, strutils, json,  hashes
+import strformat, strutils, hashes
 import common
 import pkg/checksums/sha1
-
+import compat/json
 type
   InvalidSha1HashError* = object of NimbleError
     ## Represents an error caused by invalid value of a sha1 hash.

--- a/src/nimblepkg/tools.nim
+++ b/src/nimblepkg/tools.nim
@@ -2,8 +2,10 @@
 # BSD License. Look at license.txt for more info.
 #
 # Various miscellaneous utility functions reside here.
-import osproc, pegs, strutils, os, uri, sets, json, parseutils, strformat,
+import compat/pegs, strutils, os, uri, sets, json, parseutils, strformat,
        sequtils, macros, times
+
+import compat/osproc
 
 from net import SslCVerifyMode, newContext, SslContext
 

--- a/src/nimblepkg/urls.nim
+++ b/src/nimblepkg/urls.nim
@@ -1,4 +1,4 @@
-import std/pegs, std/strutils
+import compat/pegs, std/strutils
 
 proc isURL*(name: string): bool =
   name.startsWith(peg" @'://' ") or name.startsWith(peg"\ident+'@'@':'.+")

--- a/src/nimblepkg/version.nim
+++ b/src/nimblepkg/version.nim
@@ -2,9 +2,10 @@
 # BSD License. Look at license.txt for more info.
 
 ## Module for handling versions and version ranges such as ``>= 1.0 & <= 1.5``
-import json, sets
+import sets
 import common, strutils, tables, hashes, parseutils, forge_aliases, urls
 import std/[strscans, options]
+import compat/json
 type
   Version* = object
     version*: string


### PR DESCRIPTION
Depending on the Nim version used to compile nimble, we'll encounter a different set of bugs - `compat/` is an easy way to deal with them and not have to spread compatiblity code all over the codebase (like the ugly layers of exception handlers).

Often, Exception effects come from forward declarations and a few strategically placed explicit raises list can do wonders to limit  the spread of workarounds.