### PR TITLE
added EUPL-1.2

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1465,6 +1465,7 @@ This should ideally be a valid SPDX identifier. See https://spdx.org/licenses/.
     "LGPL-3.0-linking-exception",
     "EPL-2.0",
     "AGPL-3.0",
+    "EUPL-1.2",
     # This is what npm calls "UNLICENSED" (which is too similar to "Unlicense")
     "Proprietary",
     "Other"


### PR DESCRIPTION
EUPLv1.2 is the European Union Public License 1.2. It's a strong copyleft (with SaaS clause, without Linking clause, so like ALGPL).

The text can be found [here](https://interoperable-europe.ec.europa.eu/collection/eupl/eupl-text-eupl-12) in multiple languages

I am sending this PR because I use the EUPL exclusively, since I am a citizen of a country-member of the EU.

Of note is that the EUPL is equally valid in multiple languages of the EU, but the SPDX identifier is the same for all of them, without distinction for, as an example, EUPLv1.2-BG vs EUPLv1.2-SL.

Also of note, the EUPL includes an "or later" clause by default, so it doesn't have the need for a `-or-later`, nor any of the issues with the GPL.