### PR TITLE
Publish: Add missing workflow scope to the message.

### DIFF
--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -37,7 +37,7 @@ proc requestNewToken(cfg: Config): string =
   display("Info:", "Please create a new personal access token on GitHub in" &
           " order to allow Nimble to fork the packages repository.",
           priority = HighPriority)
-  display("Hint:", "Make sure to give the access token access to public repos" &
+  display("Hint:", "Make sure to give the access token access to public repos and workflows" &
           " (public_repo and workflow scopes)!", Warning, HighPriority)
   sleep(5000)
   display("Info:", "Your default browser should open with the following URL: " &


### PR DESCRIPTION
Tried publishing a package today and it seems like this can't be done without creating a token with workflow scope. The message says otherwise as if repo_public is enough.

```shell
$ nimble publish
      Info: Using GitHub API Token in file: C:\Users\moigagoo\.nimble\github_api_token
   Success: Verified as moigagoo
    Copying packages fork into: C:\Users\moigagoo\AppData\Local\Temp\nimble-packages-fork
   Updating the fork
       Tip: 4 messages have been suppressed, use --verbose to show them.
tools.nim(47)            doCmd

    Error:  Execution failed with exit code 1
        ... Command: git push https://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@github.com/moigagoo/packages master
        ... Output: To https://github.com/moigagoo/packages
        ...  ! [remote rejected] master -> master (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/testpr.yml` without `workflow` scope)
        ... error: failed to push some refs to 'https://github.com/moigagoo/packages'
```