### PR TITLE
Fix invalid features flag name

### DIFF
--- a/nimble-guide/docs/create-packages.md
+++ b/nimble-guide/docs/create-packages.md
@@ -242,7 +242,7 @@ There are two ways to activate a feature:
 
 1. By passing a flag to the root package:  
    ```sh
-   nimble --features:"chronos" install
+   nimble --features:chronos install
    ```
 2. By activating it in a dependency using the `[]` operator:  
    ```nim


### PR DESCRIPTION
In the docs on features, the example states that features are passed to nimble subcommands as `--feature:featurename` but in reality it's `--features:featurename`.