### PR TITLE
fix(#1609): fix --useSystemNim for wrapper scripts

### DIFF
--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -735,7 +735,8 @@ proc makeNimBin*(options: Options, path: string, nimVersion: Option[Version] = n
   var nimVersion = nimVersion
   if nimVersion.isNone:
     nimVersion = getNimVersionFromBin(path)
-  
+  if nimVersion.isNone:
+    raise nimbleError("Unable to get version from `nim` binary at " & path)
   return NimBin(path: path, version: nimVersion.get())
 
 proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =

--- a/src/nimblepkg/packageinfotypes.nim
+++ b/src/nimblepkg/packageinfotypes.nim
@@ -81,6 +81,8 @@ type
     activeFeatures*: Table[PkgTuple, seq[string]] #features that dependencies of this package have activated. #i.e. requires package[feature1, feature2]
     testEntryPoint*: string ## The entry point for the test task.
     declarativeParserErrors*: seq[string] ## Errors from declarative parser (shown only for packages in solution)
+    nimBinPath*: Option[string] ## path to the system nim binary. Only to be used by PackageInfo created for `nim` with --useSystemNim
+                                ## Used to preserve portability for non-standard layouts (NixOS, custom symlink). See #1609.
 
   Package* = object ## Definition of package from packages.json.
     # Required fields in a package.
@@ -185,10 +187,12 @@ proc initSATResult*(pass: SATPass): SATResult =
 proc getNimbleFileDir*(pkgInfo: PackageInfo): string =
   pkgInfo.myPath.splitFile.dir
 
-proc getNimPath*(pkgInfo: PackageInfo): string = 
+proc getNimPath*(pkgInfo: PackageInfo): string =
+  if pkgInfo.nimBinPath.isSome:
+    return pkgInfo.nimBinPath.get()
   var binaryPath = "bin" / "nim"
   when defined(windows):
-    binaryPath &= ".exe"      
+    binaryPath &= ".exe"
   pkgInfo.getNimbleFileDir() / binaryPath
 
 proc getNimBin*(nimResolved: NimResolved): string =

--- a/src/nimblepkg/vnext.nim
+++ b/src/nimblepkg/vnext.nim
@@ -150,9 +150,17 @@ proc getNimFromSystem*(options: Options): Option[PackageInfo] =
                 effectivePnim = resolvedPath
           except CatchableError:
             discard # Fall back to original pnim
-    let dir = effectivePnim.parentDir.parentDir
+    var dir = effectivePnim.parentDir.parentDir
+    if not fileExists(dir / "nim.nimble"):
+      # Non-standard layout (e.g. NixOS wrapper, custom symlink): query the compiler
+      # directly for its lib path to find the actual installation root. See #1609.
+      let (output, exitCode) = doCmdEx(pnim.quoteShell & " --hints:off --eval:" & quoteShell("import std/compilesettings; echo querySetting(libPath)"))
+      if exitCode == 0:
+        dir = output.strip().parentDir
     try:
-      return some getPkgInfoFromDirWithDeclarativeParser(dir, options, nimBin = "") #Can be empty as the code path for nim doesnt need it.
+      var pkgInfo = getPkgInfoFromDirWithDeclarativeParser(dir, options, nimBin = "") #Can be empty as the code path for nim doesnt need it.
+      pkgInfo.nimBinPath = some pnim  # preserve the PATH-resolved binary for later use
+      return some pkgInfo
     except CatchableError:
       discard # Fall back to original pnim
   return none(PackageInfo)
@@ -511,6 +519,15 @@ proc solveLockFileDeps*(satResult: var SATResult, pkgList: seq[PackageInfo], opt
 
 proc setNimBin*(pkgInfo: PackageInfo, options: var Options) {.instrument.} =
   assert pkgInfo.basicInfo.name.isNim
+  if pkgInfo.nimBinPath.isSome():
+    # System nim with non-standard layout: set options.nimBin directly from the
+    # PATH-resolved binary rather than deriving from getRealDir. See #1609.
+    if options.nimBin.isSome and options.nimBin.get.path == pkgInfo.nimBinPath.get:
+      return
+    options.nimBin = some makeNimBin(options, pkgInfo.nimBinPath.get)
+    display("Info:", "using $1 for compilation" % pkgInfo.nimBinPath.get,
+            priority = HighPriority)
+    return
   if options.nimBin.isSome and options.nimBin.get.path == pkgInfo.getRealDir / "bin" / "nim":
     return #We dont want to set the same Nim twice. Notice, this can only happen when installing multiple packages outside of the project dir i.e nimble install pkg1 pkg2 if voth
   options.useNimFromDir(pkgInfo.getRealDir, pkgInfo.basicInfo.version.toVersionRange(), tryCompiling = true)
@@ -1006,10 +1023,7 @@ proc getNimBin(satResult: SATResult): string =
   #TODO change this so nim is passed as a parameter but we also need to change getPkgInfo so for the time being its also in options
   if satResult.nimResolved.pkg.isSome:
     let nimPkgInfo = satResult.nimResolved.pkg.get
-    var binaryPath = "bin" / "nim"
-    when defined(windows):
-      binaryPath &= ".exe" 
-    return nimPkgInfo.getNimbleFileDir() / binaryPath
+    return nimPkgInfo.getNimPath()  # respects nimBinPath for non-standard layouts
   else:
     raise newNimbleError[NimbleError]("No Nim found")
 

--- a/tests/issue1609/bin/nim
+++ b/tests/issue1609/bin/nim
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Nim wrapper for issue #1609 test.
+# Logs invocations to calls.log, then delegates to the real nim by
+# finding the first 'nim' executable in PATH that isn't this script's directory.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+echo "$@" >> "$SCRIPT_DIR/calls.log"
+REAL_NIM=$(IFS=:; for dir in $PATH; do
+  if [ "$dir" != "$SCRIPT_DIR" ] && [ -x "$dir/nim" ]; then
+    echo "$dir/nim"
+    break
+  fi
+done)
+exec "$REAL_NIM" "$@"

--- a/tests/issue1609/bin/nim.cmd
+++ b/tests/issue1609/bin/nim.cmd
@@ -1,0 +1,28 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Nim wrapper for issue #1609 test.
+rem Logs invocations to calls.log, then delegates to the real nim by
+rem finding the first 'nim' in PATH that isn't this wrapper's directory.
+
+rem Normalize current script directory to short path to avoid mismatch issues
+for %%A in ("%~dp0") do set "MYDIR=%%~sA"
+
+rem Log the call (using ( to handle empty arguments safely)
+echo(%* >> "%~dp0calls.log"
+
+rem Iterate through all 'nim' executables found in PATH
+for /f "delims=" %%i in ('where nim 2^>nul') do (
+    set "CANDIDATE=%%i"
+    for %%B in ("%%~dpi") do set "CAN_DIR=%%~sB"
+
+    rem If the directory of the found nim is not our own directory
+    if /i not "!CAN_DIR!"=="!MYDIR!" (
+        "!CANDIDATE!" %*
+        exit /b !ERRORLEVEL!
+    )
+)
+
+rem If we got here, we didn't find the real nim
+echo Error: Real nim.exe not found in PATH >&2
+exit /b 1

--- a/tests/issue1609/issue1609.nimble
+++ b/tests/issue1609/issue1609.nimble
@@ -1,0 +1,7 @@
+version = "0.1.0"
+author = "Test"
+description = "Test for issue #1609: --useSystemNim with non-standard nim layouts"
+license = "MIT"
+srcDir = "src"
+bin = @["issue1609"]
+requires "nim >= 1.6.0"

--- a/tests/issue1609/src/issue1609.nim
+++ b/tests/issue1609/src/issue1609.nim
@@ -1,0 +1,1 @@
+echo "issue1609"

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -466,3 +466,29 @@ requires "nim >= 2.0.0"
     cd "issue1636":
       let (_, exitCode) = execNimbleYes("failme")
       check exitCode == QuitFailure
+
+  test "issue #1609 ensure useSystemNim uses wrapper":
+    let binDir = getCurrentDir() / "issue1609" / "bin"
+    let nimWrapper = binDir / (when defined(windows): "nim.cmd" else: "nim")
+    proc checkWrapperInvoked(log: string, args: varargs[string]) =
+      removeFile(log)
+      defer: removeFile(log)
+      let res = execNimble(args)
+      check res.exitCode == QuitSuccess
+      check res.output.contains("Executing $1 c" % nimWrapper )
+      check fileExists(log)
+      check readFile(log).contains("c ")
+
+    cd "issue1609":
+      defer: removeFile("issue1609")
+
+      # Check 1: wrapper specified via --nim
+      checkWrapperInvoked(binDir / "calls.log", "--useSystemNim", "--nim:" & nimWrapper, "--debug", "build")
+
+      # Check 2: wrapper discovered via PATH (no --nim flag).
+      # Temporarily inject binDir into PATH so nimble finds the wrapper script
+      let sep = when defined(windows): ";" else: ":"
+      let oldPath = getEnv("PATH")
+      putEnv("PATH", binDir & sep & oldPath)
+      checkWrapperInvoked(binDir / "calls.log", "--useSystemNim", "--debug", "build")
+      putEnv("PATH", oldPath)


### PR DESCRIPTION
This attempts to preserve the previous behavior of --useSystemNim, for example allowing a wrapper script or symlink in a non-standard location so long as it was on the PATH to be used as `nim`.

Since `vnext` code relies on the compiler having a `nim.nimble` file I use the strategy from the issue of calling the compiler and extracting it's libPath, while then preserving the original `nim` binary used to invoke it (a future optimization should probably reduce the calls to `vnext.getNimFromSystem` which occurs at least 3 times as far as I can tell when debug messages are active.)

This required adding a field to `PackageInfo` that is specific to the compiler but doesn't seem to result in any new test failures (locally `./src/nimble test`, has some failures on HEAD, which might be specific to my environment).

Closes #1609 