### PR TITLE
clean up tests and testing artifacts

### DIFF
--- a/tests/tdevelopfeature.nim
+++ b/tests/tdevelopfeature.nim
@@ -99,6 +99,7 @@ requires "nim >= 1.6.0", "packagea"
         let pkgCacheDir = installDir / "pkgcache"
         createDir(pkgCacheDir)
         let taggedVersionsFile = pkgCacheDir / "tagged_versions.json"
+        cleanFile taggedVersionsFile
         writeFile(taggedVersionsFile, $(%*{
           "packagea": [
             {"name": "PackageA",

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -471,17 +471,14 @@ requires "nim >= 2.0.0"
     let binDir = getCurrentDir() / "issue1609" / "bin"
     let nimWrapper = binDir / (when defined(windows): "nim.cmd" else: "nim")
     proc checkWrapperInvoked(log: string, args: varargs[string]) =
-      removeFile(log)
-      defer: removeFile(log)
+      cleanFiles log, "issue1609"
       let res = execNimble(args)
-      check res.exitCode == QuitSuccess
+      verify res
       check res.output.contains("Executing $1 c" % nimWrapper )
       check fileExists(log)
       check readFile(log).contains("c ")
 
     cd "issue1609":
-      defer: removeFile("issue1609")
-
       # Check 1: wrapper specified via --nim
       checkWrapperInvoked(binDir / "calls.log", "--useSystemNim", "--nim:" & nimWrapper, "--debug", "build")
 


### PR DESCRIPTION
This is a quick follow-up to #1642, to reuse some of the testscommon machinery that I didn't know about.

Also, a change to prevent a lingering `tests/tagged_versions.json` after tests. 