### PR TITLE
Accept gzip for `packages.json` if server supports it

### DIFF
--- a/src/nimblepkg/common.nim
+++ b/src/nimblepkg/common.nim
@@ -44,6 +44,7 @@ proc getVersionFromNimble(): string =
 
 const
   nimbleVersion* = getVersionFromNimble()
+  nimbleUserAgent* = "nimble/" & nimbleVersion
   nimblePackagesDirName* = "pkgs2"
   nimblePackagesLinksDirName* ="links"
   nimbleBinariesDirName* = "bin"

--- a/src/nimblepkg/download.nim
+++ b/src/nimblepkg/download.nim
@@ -10,8 +10,6 @@ from algorithm import SortOrder, sorted
 import packageinfotypes, version, tools, common, options, cli,
        sha1hashes, vcstools, displaymessages, packageinfo, config, declarativeparser, packagemetadatafile
 
-const userAgent = "nimble/" & nimbleVersion
-
 type
   DownloadPkgResult* = tuple
     dir: string
@@ -455,7 +453,7 @@ proc getProxy*(): Proxy =
 proc retrieveUrl*(url: string): string =
   display("Http", "Requesting " & url, priority = DebugPriority)
   {.cast(raises: [CatchableError]).}:
-    var client = newHttpClient(proxy = getProxy(), userAgent = userAgent)
+    var client = newHttpClient(proxy = getProxy(), userAgent = nimbleUserAgent)
     return client.getContent(url)
 
 {.warning[ProveInit]: off.}

--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -345,7 +345,7 @@ when defined(curl):
 
 proc downloadFileNim(url, outputPath: string) =
   displayDebug("Downloading using HttpClient")
-  var client = newHttpClient(proxy = getProxy())
+  var client = newHttpClient(proxy = getProxy(), userAgent = nimbleUserAgent)
 
   var lastProgressPos = 0
   proc onProgressChanged(total, progress, speed: BiggestInt) {.closure, gcsafe.} =

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -6,6 +6,8 @@ import system except TResult
 import hashes, strutils, os, sets, tables, times, httpclient, strformat
 from net import SslError
 
+import zippy
+
 import compat/json
 # Local imports
 import version, tools, common, options, cli, config, lockfile, packageinfotypes,
@@ -154,7 +156,16 @@ proc fetchList*(list: PackageList, options: Options) =
       try:
         let ctx = newSSLContext(options.disableSslCertCheck)
         let client = newHttpClient(proxy = proxy, sslContext = ctx)
-        client.downloadFile(url, tempPath)
+        client.headers = newHttpHeaders({"Accept-Encoding": "gzip"})
+        let resp = client.get(url)
+        if resp.code.is4xx or resp.code.is5xx:
+          raise newException(HttpRequestError,
+            "Server returned status: " & $resp.code & " " & resp.status)
+        var body = resp.body
+        let encoding = ($resp.headers.getOrDefault("content-encoding")).strip.toLowerAscii
+        if encoding == "gzip":
+          body = uncompress(body, dfGzip)
+        writeFile(tempPath, body)
       except SslError:
         let message = "Failed to verify the SSL certificate for " & url
         raise nimbleError(message, "Use --noSSLCheck to ignore this error.")

--- a/src/nimblepkg/packageinfo.nim
+++ b/src/nimblepkg/packageinfo.nim
@@ -155,7 +155,8 @@ proc fetchList*(list: PackageList, options: Options) =
 
       try:
         let ctx = newSSLContext(options.disableSslCertCheck)
-        let client = newHttpClient(proxy = proxy, sslContext = ctx)
+        let client = newHttpClient(proxy = proxy, sslContext = ctx,
+                                   userAgent = nimbleUserAgent)
         client.headers = newHttpHeaders({"Accept-Encoding": "gzip"})
         let resp = client.get(url)
         if resp.code.is4xx or resp.code.is5xx:

--- a/src/nimblepkg/publish.nim
+++ b/src/nimblepkg/publish.nim
@@ -56,7 +56,8 @@ proc requestNewToken(cfg: Config): string =
 proc getGithubAuth(o: Options): Auth =
   let cfg = o.config
   let ctx = newSSLContext(o.disableSslCertCheck)
-  result.http = newHttpClient(proxy = getProxy(o), sslContext = ctx)
+  result.http = newHttpClient(proxy = getProxy(o), sslContext = ctx,
+                              userAgent = nimbleUserAgent)
   # always prefer the environment variable to asking for a new one
   if existsEnv(ApiTokenEnvironmentVariable):
     result.token = getEnv(ApiTokenEnvironmentVariable)


### PR DESCRIPTION
The index is a massive JSON file and compresses well. 

This patch makes nimble advertise gzip support with `Accept-Encoding: gzip` and decompress the `packages.json` file should it be served to us compressed.

The patch also adds the `User-Agent` header to every request for better server-side logging capabilities down the line.

This is in preparation of switching the default `packages.json` to point to `packages.nim-lang.org/packages.json`, which will be done in another PR.