### PR TITLE
Use packages.nim-lang.org CDN by default for packages.json

### DIFF
--- a/src/nimblepkg/config.nim
+++ b/src/nimblepkg/config.nim
@@ -23,6 +23,7 @@ proc initConfig(): Config =
   result.chcp = true
   result.cloneUsingHttps = true
   result.packageLists["official"] = PackageList(name: "Official", urls: @[
+    "https://packages.nim-lang.org/packages.json",
     "https://raw.githubusercontent.com/nim-lang/packages/master/packages.json",
     "https://nim-lang.org/nimble/packages.json"
   ])


### PR DESCRIPTION
This commit sets the default package list URL to `https://packages.nim-lang.org/packages.json`, which is a CDN-hosted URL. The subdomain itself is a CNAME to the actual CDN URL.

This will have a few benefits for Nimble users:

1. The CDN is replicated across numerous regions, meaning fetching the index is _fast_ for most users, but more importantly...
2. We no longer depend on GitHub for the package list, which in turn means:
   1. No issues with being rate limited and requiring the user to supply a GitHub token.
   2. No issues with people trying to use Nimble in regions where GitHub HTTPS is blocked (China, etc).
3. We are able to collect basic telemetry about how often the package list is downloaded by Nimble and which Nimble versions are used to do so. No non-anonymous data is logged at any point.
4. In the future, if we ever decide to host the package index elsewhere, we may simply update the CNAME record for `packages.nim-lang.org` and no actions are required by the user.