### PR TITLE
project validation: fix ordering, more helpful error

### DIFF
--- a/src/nimblepkg/packageparser.nim
+++ b/src/nimblepkg/packageparser.nim
@@ -360,7 +360,8 @@ proc readPackageInfo(pkgInfo: var PackageInfo, nf: NimbleFile, options: Options,
 
   # Validate the rest of the package info last.
   if not options.disableValidation:
-    validateVersion($pkgInfo.basicInfo.version)
+    if pkgInfo.basicInfo.version != notSetVersion:
+      validateVersion($pkgInfo.basicInfo.version)
     validatePackageInfo(pkgInfo, options)
 
 proc getPkgInfoFromFile*(nimBin: Option[string],file: NimbleFile, options: Options,


### PR DESCRIPTION
Nimble uses `-1` as a sentinel for a not-set version value. `validateVersion "-1"` rejects the `-` character which results in an obscure and unverifiable error message

> `Version may only consist of numbers and the '.' character but found '-'.

This check runs before the more descriptive `validatePackageInfo` check. As the error aborts parsing,, this prevents `nimble dump` from producing any output, which, besides other things, makes LSP/MCP in nimlangserver fail.

Fix: skip `validateVersion` when the version equals the `notSetVersion` sentinel. `validatePackageInfo` handles the missing-version case.