### PR TITLE
Fix build failure under FreeBSD.

### DIFF
--- a/src/nimblepkg/downloadnim.nim
+++ b/src/nimblepkg/downloadnim.nim
@@ -123,7 +123,7 @@ proc getPlatformString*(arch: int): string =
       "macosx"
     else:
       # For other platforms, fall back to source
-      return "source_tar"
+      "source_tar"
 
   when defined(macosx):
     if isAppleSilicon():


### PR DESCRIPTION
Was seeing this error when building nimble under FreeBSD:

```
% ./koch nimble
bin/nim c -o:bin/nimble -d:release --noNimblePath  dist/nimble/src/nimble.nim
/nim-2.2.10/dist/nimble/src/nimblepkg/downloadnim.nim(118, 5) Error: expression 'return "source_tar"' has no type (or is ambiguous)
FAILURE
```

This repairs it.