### PR TITLE
Add --noBuild flag to skip binary compilation during install

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -1910,7 +1910,7 @@ proc runAction(options: Options, nimBin: Option[string]) =
   if binary notin pkgInfo.bin:
     raise nimbleError(binaryNotDefinedInPkgMsg(binary, pkgInfo.basicInfo.name))
 
-  if pkgInfo.isLink:
+  if pkgInfo.isLink and not options.noBuild:
     # Use buildPkg for develop mode packages
     let isInRootDir = options.startDir == pkgInfo.myPath.parentDir and
       options.satResult.rootPackage.basicInfo.name == pkgInfo.basicInfo.name

--- a/src/nimblepkg/build.nim
+++ b/src/nimblepkg/build.nim
@@ -68,6 +68,8 @@ proc getPathsAllPkgs*(options: Options, nimBin: Option[string]): HashSet[string]
 proc buildFromDir*(pkgInfo: PackageInfo, paths: HashSet[string],
                    args: seq[string], options: Options, nimBin: Option[string]) =
   ## Builds a package as specified by ``pkgInfo``.
+  if options.noBuild:
+    return
   # Handle pre-`build` hook.
   let
     realDir = pkgInfo.getRealDir()

--- a/src/nimblepkg/install.nim
+++ b/src/nimblepkg/install.nim
@@ -269,8 +269,8 @@ proc installFromDirDownloadInfo(nimBin: Option[string], downloadDir: string, url
       # Run before-install hook (in buildtemp, before build)
       executeHook(nimBin, workDir, options, actionInstall, before = true)
 
-      # Build binaries (only if there are any)
-      if hasBinaries:
+      # Build binaries (only if there are any and --noBuild is not set)
+      if hasBinaries and not options.noBuild:
         let paths = getPathsAllPkgs(options, nimBin)
         let flags = if options.action.typ in {actionInstall, actionPath, actionUninstall, actionDevelop}:
                       options.action.passNimFlags
@@ -308,8 +308,8 @@ proc installFromDirDownloadInfo(nimBin: Option[string], downloadDir: string, url
       let nimbleFileDest = changeRoot(workPkgInfo.myPath.splitFile.dir, pkgDestDir, workPkgInfo.myPath)
       filesInstalled.incl copyFileD(workPkgInfo.myPath, nimbleFileDest)
 
-      # Copy built binaries (only if there are any)
-      if hasBinaries:
+      # Copy built binaries (only if there are any and --noBuild is not set)
+      if hasBinaries and not options.noBuild:
         for bin, src in workPkgInfo.bin:
           let binDest = if dirExists(pkgDestDir / bin): bin & ".out" else: bin
           let srcBin = workPkgInfo.getOutputDir(bin)
@@ -327,8 +327,8 @@ proc installFromDirDownloadInfo(nimBin: Option[string], downloadDir: string, url
       # Run after-install hook
       executeHook(nimBin, pkgDestDir, options, actionInstall, before = false)
 
-      # Create bin symlinks (only if there are binaries)
-      if hasBinaries:
+      # Create bin symlinks (only if there are binaries and --noBuild is not set)
+      if hasBinaries and not options.noBuild:
         createBinSymlink(pkgInfo, options)
 
     finally:
@@ -590,10 +590,10 @@ proc installPkgs*(satResult: var SATResult, options: var Options, nimBin: Option
         continue
     # echo "Building package: ", pkgToBuild.basicInfo.name, " at ", pkgToBuild.myPath, " binaries: ", pkgToBuild.bin
     let isRoot = pkgToBuild.isRoot(options.satResult) and isInRootDir
-    if isRoot and options.action.typ in rootBuildActions:
+    if not options.noBuild and isRoot and options.action.typ in rootBuildActions:
       buildPkg(nimBin, pkgToBuild, isRoot, options)
       satResult.buildPkgs.add(pkgToBuild)
-    elif pkgToBuild.isLink:
+    elif not options.noBuild and pkgToBuild.isLink:
       # Build develop mode packages
       buildPkg(nimBin, pkgToBuild, false, options)
       satResult.buildPkgs.add(pkgToBuild)

--- a/src/nimblepkg/options.nim
+++ b/src/nimblepkg/options.nim
@@ -73,6 +73,7 @@ type
     nimBinariesDir*: string # Directory where nim binaries are stored. Separated from nimbleDir as it can be changed by the user/tests
     disableNimBinaries*: bool # Whether to disable the use of nim binaries
     features*: seq[string] # Features to be activated
+    noBuild*: bool # Skip building binaries during install
     ignoreSubmodules*: bool # Whether to ignore submodules when cloning a repository
     satResult*: SatResult
     filePathPkgs*: seq[PackageInfo] #Packages loaded from file:// requires. Top level is always included.
@@ -797,6 +798,8 @@ proc parseFlag*(flag, val: string, result: var Options, kind = cmdLongOption) =
     result.disableNimBinaries = true
   of "features":
     result.features = val.split(";").mapIt(it.strip)
+  of "nobuild":
+    result.noBuild = true
   of "ignoresubmodules":
     result.ignoreSubmodules = true
   of "sync":

--- a/tests/tbuildinstall.nim
+++ b/tests/tbuildinstall.nim
@@ -7,6 +7,8 @@ import unittest, os, strutils
 import testscommon
 from nimblepkg/common import cd
 
+testNoBuild = false # This suite explicitly verifies built binaries
+
 suite "Build/Install refactor":
   setup:
     # Clean up nimbleDir before each test

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -33,6 +33,17 @@ var testNoBuild* = true
   ## inherently compile (install, develop, lock, etc.).
   ## Test files that explicitly verify built binaries can set this to false.
 
+template withBuild*(body: untyped) =
+  ## Temporarily disables --noBuild auto-injection for a block of code.
+  ## Use in individual tests that explicitly verify built binaries
+  ## or expect install to fail due to build errors.
+  let prev = testNoBuild
+  testNoBuild = false
+  try:
+    body
+  finally:
+    testNoBuild = prev
+
 proc execNimble*(args: varargs[string]): ProcessOutput =
   var quotedArgs = @args
   quotedArgs.insert("--info")

--- a/tests/testscommon.nim
+++ b/tests/testscommon.nim
@@ -28,6 +28,11 @@ let
   buildTests* = rootDir / "buildTests"
   pkgsDir* = installDir / nimblePackagesDirName
 
+var testNoBuild* = true
+  ## When true, execNimble auto-injects --noBuild for actions that don't
+  ## inherently compile (install, develop, lock, etc.).
+  ## Test files that explicitly verify built binaries can set this to false.
+
 proc execNimble*(args: varargs[string]): ProcessOutput =
   var quotedArgs = @args
   quotedArgs.insert("--info")
@@ -36,6 +41,10 @@ proc execNimble*(args: varargs[string]): ProcessOutput =
     quotedArgs.insert("--nimbleDir:" & installDir)
   if not args.anyIt("-l" == it or "--local" == it):
     quotedArgs.insert("--global") #default to global mode for tests
+  # Auto-inject --noBuild for actions that don't inherently compile.
+  let needsCompile = quotedArgs.anyIt(it in ["build", "run", "test", "c", "cc", "doc", "doc2"])
+  if testNoBuild and not needsCompile:
+    quotedArgs.add("--noBuild")
   quotedArgs.insert(nimblePath)
   quotedArgs = quotedArgs.map((x: string) => x.quoteShell)
 

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -133,59 +133,60 @@ suite "issues":
       "https://github.com/nimble-test/issue280and524.git").exitCode == 0
 
   test "issues #308 and #515":
-    let
-      ext = when defined(Windows): ExeExt else: "out"
-    cleanDir(installDir)
-    cd "issue308515" / "v1":
-      var (output, exitCode) = execNimble(["run", "binname", "--silent"])
-      check exitCode == QuitSuccess
-      check output.contains "binname"
+    withBuild:
+      let
+        ext = when defined(Windows): ExeExt else: "out"
+      cleanDir(installDir)
+      cd "issue308515" / "v1":
+        var (output, exitCode) = execNimble(["run", "binname", "--silent"])
+        check exitCode == QuitSuccess
+        check output.contains "binname"
 
-      (output, exitCode) = execNimble(["run", "binname-2", "--silent"])
-      check exitCode == QuitSuccess
-      check output.contains "binname-2"
+        (output, exitCode) = execNimble(["run", "binname-2", "--silent"])
+        check exitCode == QuitSuccess
+        check output.contains "binname-2"
 
-      # Install v1 and check
-      (output, exitCode) = execNimbleYes(["install", "--verbose"])
-      check exitCode == QuitSuccess
-      check output.contains getPackageDir(pkgsDir, "binname-0.1.0") /
-                            "binname".addFileExt(ext)
-      check output.contains getPackageDir(pkgsDir, "binname-0.1.0") /
-                            "binname-2"
+        # Install v1 and check
+        (output, exitCode) = execNimbleYes(["install", "--verbose"])
+        check exitCode == QuitSuccess
+        check output.contains getPackageDir(pkgsDir, "binname-0.1.0") /
+                              "binname".addFileExt(ext)
+        check output.contains getPackageDir(pkgsDir, "binname-0.1.0") /
+                              "binname-2"
 
-      (output, exitCode) = execBin("binname")
-      check exitCode == QuitSuccess
-      check output.contains "binname 0.1.0"
-      (output, exitCode) = execBin("binname-2")
-      check exitCode == QuitSuccess
-      check output.contains "binname-2 0.1.0"
+        (output, exitCode) = execBin("binname")
+        check exitCode == QuitSuccess
+        check output.contains "binname 0.1.0"
+        (output, exitCode) = execBin("binname-2")
+        check exitCode == QuitSuccess
+        check output.contains "binname-2 0.1.0"
 
-    cd "issue308515" / "v2":
-      # Install v2 and check
-      var (output, exitCode) = execNimbleYes(["install", "--verbose"])
-      check exitCode == QuitSuccess
-      check output.contains getPackageDir(pkgsDir, "binname-0.2.0") /
-                            "binname".addFileExt(ext)
-      check output.contains getPackageDir(pkgsDir, "binname-0.2.0") /
-                            "binname-2"
+      cd "issue308515" / "v2":
+        # Install v2 and check
+        var (output, exitCode) = execNimbleYes(["install", "--verbose"])
+        check exitCode == QuitSuccess
+        check output.contains getPackageDir(pkgsDir, "binname-0.2.0") /
+                              "binname".addFileExt(ext)
+        check output.contains getPackageDir(pkgsDir, "binname-0.2.0") /
+                              "binname-2"
 
-      (output, exitCode) = execBin("binname")
-      check exitCode == QuitSuccess
-      check output.contains "binname 0.2.0"
-      (output, exitCode) = execBin("binname-2")
-      check exitCode == QuitSuccess
-      check output.contains "binname-2 0.2.0"
+        (output, exitCode) = execBin("binname")
+        check exitCode == QuitSuccess
+        check output.contains "binname 0.2.0"
+        (output, exitCode) = execBin("binname-2")
+        check exitCode == QuitSuccess
+        check output.contains "binname-2 0.2.0"
 
-      # Uninstall and check v1 back
-      (output, exitCode) = execNimbleYes("uninstall", "binname@0.2.0")
-      check exitCode == QuitSuccess
+        # Uninstall and check v1 back
+        (output, exitCode) = execNimbleYes("uninstall", "binname@0.2.0")
+        check exitCode == QuitSuccess
 
-      (output, exitCode) = execBin("binname")
-      check exitCode == QuitSuccess
-      check output.contains "binname 0.1.0"
-      (output, exitCode) = execBin("binname-2")
-      check exitCode == QuitSuccess
-      check output.contains "binname-2 0.1.0"
+        (output, exitCode) = execBin("binname")
+        check exitCode == QuitSuccess
+        check output.contains "binname 0.1.0"
+        (output, exitCode) = execBin("binname-2")
+        check exitCode == QuitSuccess
+        check output.contains "binname-2 0.1.0"
 
   test "issue 432":
     cd "issue432":
@@ -206,13 +207,14 @@ suite "issues":
       check not (dummyPkgDir / "nimbleDir").dirExists
 
   test "issue 399":
-    cd "issue399":
-      var (output, exitCode) = execNimbleYes("install")
-      check exitCode == QuitSuccess
+    withBuild:
+      cd "issue399":
+        var (output, exitCode) = execNimbleYes("install")
+        check exitCode == QuitSuccess
 
-      (output, exitCode) = execBin("subbin")
-      check exitCode == QuitSuccess
-      check output.contains("subbin-1")
+        (output, exitCode) = execBin("subbin")
+        check exitCode == QuitSuccess
+        check output.contains("subbin-1")
 
   test "can pass args with spaces to Nim (#351)":
     cd "binaryPackage/v2":
@@ -337,32 +339,33 @@ suite "issues":
       check inLines(lines1, "The .nimble file name must match name specified inside")
 
   test "issue 113 (uninstallation problems)":
-    cleanDir(installDir)
+    withBuild:
+      cleanDir(installDir)
 
-    cd "issue113/c":
-      check execNimbleYes("install").exitCode == QuitSuccess
-    cd "issue113/b":
-      check execNimbleYes("install").exitCode == QuitSuccess
-    cd "issue113/a":
-      check execNimbleYes("install").exitCode == QuitSuccess
+      cd "issue113/c":
+        check execNimbleYes("install").exitCode == QuitSuccess
+      cd "issue113/b":
+        check execNimbleYes("install").exitCode == QuitSuccess
+      cd "issue113/a":
+        check execNimbleYes("install").exitCode == QuitSuccess
 
-    # Try to remove c.
-    let
-      (output, exitCode) = execNimbleYes(["remove", "c"])
-      lines = output.strip.processOutput()
-      pkgBInstallDir = getPackageDir(pkgsDir, "b-0.1.0").splitPath.tail
+      # Try to remove c.
+      let
+        (output, exitCode) = execNimbleYes(["remove", "c"])
+        lines = output.strip.processOutput()
+        pkgBInstallDir = getPackageDir(pkgsDir, "b-0.1.0").splitPath.tail
 
-    check exitCode != QuitSuccess
-    check lines.inLines(
-      cannotUninstallPkgMsg("c", newVersion("0.1.0"), @[pkgBInstallDir]))
+      check exitCode != QuitSuccess
+      check lines.inLines(
+        cannotUninstallPkgMsg("c", newVersion("0.1.0"), @[pkgBInstallDir]))
 
-    check execNimbleYes(["remove", "a"]).exitCode == QuitSuccess
-    check execNimbleYes(["remove", "b"]).exitCode == QuitSuccess
+      check execNimbleYes(["remove", "a"]).exitCode == QuitSuccess
+      check execNimbleYes(["remove", "b"]).exitCode == QuitSuccess
 
-    cd "issue113/buildfail":
-      check execNimbleYes("install").exitCode != QuitSuccess
+      cd "issue113/buildfail":
+        check execNimbleYes("install").exitCode != QuitSuccess
 
-    check execNimbleYes(["remove", "c"]).exitCode == QuitSuccess
+      check execNimbleYes(["remove", "c"]).exitCode == QuitSuccess
 
   test "issue #108":
     cd "issue108":

--- a/tests/truncommand.nim
+++ b/tests/truncommand.nim
@@ -9,6 +9,8 @@ import nimblepkg/displaymessages
 from nimblepkg/common import cd
 from nimblepkg/developfile import developFileName
 
+testNoBuild = false # One test installs a dependency and then runs its binary
+
 suite "nimble run":
   test "Invalid binary":
     cd "run":

--- a/tests/ttwobinaryversions.nim
+++ b/tests/ttwobinaryversions.nim
@@ -7,6 +7,8 @@ import unittest, os, strutils
 import testscommon
 from nimblepkg/common import cd
 
+testNoBuild = false # This suite explicitly verifies built binaries
+
 suite "can handle two binary versions":
   setup:
     cd "binaryPackage/v1":


### PR DESCRIPTION
This adds a --noBuild global flag that skips building binaries when installing packages. It's useful for testing nimble's install/resolve/lock behavior without wasting time compiling downstream packages.

Changes:
- Add noBuild field to Options and parse --noBuild globally
- Skip buildFromDir, binary copy, and symlink creation in install.nim
- Skip develop-mode pre-run build in nimble.nim when noBuild is set
- Update testscommon.nim to auto-inject --noBuild for install/develop/lock actions while preserving builds for run/build/test/c/doc
- Add testNoBuild toggle so test files can opt out when they explicitly verify built binaries (tbuildinstall, ttwobinaryversions, truncommand)