### PR TITLE
Fix FieldDefect in isNim() special-case when action has no packages field

### DIFF
--- a/src/nimblepkg/nimresolution.nim
+++ b/src/nimblepkg/nimresolution.nim
@@ -296,10 +296,12 @@ proc resolveAndConfigureNim*(rootPackage: PackageInfo, pkgList: seq[PackageInfo]
     # Use the requested version from the command line (e.g. #head, #devel, >= 2.0.0)
     # not the declared version from nim.nimble (e.g. 2.3.1) which may not have binaries
     var requestedVer = parseVersionRange(rootPackage.basicInfo.version)
-    for pkg in options.action.packages:
-      if pkg.name.isNim:
-        requestedVer = pkg.ver
-        break
+    if options.action.typ in {actionInstall, actionPath, actionUninstall, actionDevelop,
+                               actionUpgrade, actionLock, actionAdd}:
+      for pkg in options.action.packages:
+        if pkg.name.isNim:
+          requestedVer = pkg.ver
+          break
     let nimPkg = (name: "nim", ver: requestedVer)
     let nimInstalled = installNimFromBinariesDir(nimPkg, options)
     if nimInstalled.isSome:


### PR DESCRIPTION
## Summary
- `resolveAndConfigureNim` in `src/nimblepkg/nimresolution.nim` unconditionally reads `options.action.packages` inside the `rootPackage.basicInfo.name.isNim` special-case block.
- `packages` only exists on the `Action` variant for `actionInstall, actionPath, actionUninstall, actionDevelop, actionUpgrade, actionLock, actionAdd` (see `src/nimblepkg/options.nim`).
- Any other action (e.g. `actionRun`, `actionBuild`) on a package named `nim`/`nimrod`/`compiler` crashes with:
  ```
  Error: unhandled exception: field 'packages' is not accessible for type 'Action' using 'typ = actionRun' [FieldDefect]
  ```

## Repro
```
mkdir demo && cd demo
nimble init   # name the package "nim"
nimble run
```

## Fix
Guard the `options.action.packages` loop with a check that the action variant actually has that field.

## Test plan
- [ ] `nimble run` on a project whose `.nimble` file is named `nim.nimble` no longer crashes
- [ ] `nimble install` on the actual `nim` package still resolves the requested version correctly