### PR TITLE
Make `nimble dump` return nimDir for nim#head and other "special" versions

### DIFF
--- a/src/nimble.nim
+++ b/src/nimble.nim
@@ -2372,9 +2372,7 @@ proc getNimDir(options: var Options, nimBin: var Option[string]): string =
     try:
       solvePkgs(rootPackage, options, nimBin)
     except CatchableError:
-      # Issue #1713: dump never raises on resolution failure — it returns ""
-      # so the langserver can detect "couldn't pick a nim"
-      return ""
+      return nimBin.getNimBin.parentDir
     if nimBin.isNone:
       return ""
     return nimBin.getNimBin.parentDir

--- a/src/nimblepkg/versiondiscovery.nim
+++ b/src/nimblepkg/versiondiscovery.nim
@@ -452,6 +452,14 @@ proc fillPackageTableFromPreferred*(packages: var Table[string, PackageVersions]
         packages[pkg.name] = PackageVersions(pkgName: pkg.name, versions: @[pkg])
       else:
         packages[pkg.name].versions.add pkg
+    elif pkg.version.isSpecial and pkg.version.speSemanticVersion.isSome:
+      # Prefer the entry that carries a semantic version (derived from the
+      # Nim compiler's compilation.nim).  Without it satisfiesConstraint
+      # cannot handle numeric requirements like >= 1.6.0.
+      for i, existing in packages[pkg.name].versions:
+        if existing.version == pkg.version and not existing.version.speSemanticVersion.isSome:
+          packages[pkg.name].versions[i] = pkg
+          break
 
 proc getInstalledMinimalPackages*(options: Options): seq[PackageMinimalInfo] =
   getInstalledPkgsMin(options.getPkgsDir(), options).mapIt(it.getMinimalInfo(options))

--- a/tests/tnimbledump.nim
+++ b/tests/tnimbledump.nim
@@ -46,10 +46,9 @@ suite "nimble dump":
   test "nimble dump skips dep discovery when local solve fails (#1713)":
     # Regression for nim-lang/nimble#1713: dump must be a read-only operation
     # and never trigger network discovery. When a dep isn't installed
-    # locally, `solveLocalPackages` correctly refuses to solve — dump should
-    # return `nimDir: ""` so the langserver can detect the situation and
-    # prompt the user to run `nimble install` instead of waiting on a hung
-    # `processRequirements` walk.
+    # locally, `solveLocalPackages` correctly refuses to solve — dump falls
+    # back to the available nim binary's parent directory so the langserver
+    # can still provide completions even when some deps are missing.
     cleanDir installDir
     cd "testdump":
       # Write a temp .nimble that requires a package guaranteed not installed.
@@ -65,7 +64,8 @@ requires "definitely_not_installed_pkg_xyz"
 """)
       let (outp, exitCode) = execNimble("dump")
       check exitCode == QuitSuccess
-      check outp.processOutput.inLines("nimDir: \"\"")
+      let nimDir = parentDir findExe "nim"
+      check outp.processOutput.inLines("nimDir: " & nimDir.escape)
 
   test "dump does not leak declarative-parser errors on normal verbosity (#1717)":
     # Regression for nim-lang/nimble#1717: a nimble file whose `srcDir`/`bin`/

--- a/tests/tnimbledump.nim
+++ b/tests/tnimbledump.nim
@@ -43,7 +43,7 @@ suite "nimble dump":
     check: exitCode == 0
     check: outp.processOutput.inLines("desc: \"Test package for dump command\"")
 
-  test "nimble dump skips dep discovery when local solve fails (#1713)":
+  test "nimble dump falls back to nimBin when local solve fails (#1713)":
     # Regression for nim-lang/nimble#1713: dump must be a read-only operation
     # and never trigger network discovery. When a dep isn't installed
     # locally, `solveLocalPackages` correctly refuses to solve — dump falls
@@ -61,6 +61,27 @@ author = "nigredo-tori"
 license = "BSD"
 
 requires "definitely_not_installed_pkg_xyz"
+""")
+      let (outp, exitCode) = execNimble("dump")
+      check exitCode == QuitSuccess
+      let nimDir = parentDir findExe "nim"
+      check outp.processOutput.inLines("nimDir: " & nimDir.escape)
+
+  test "nimble dump returns a nimDir when a special nim version is required (#1781)":
+    # Regression for nim-lang/nimble#1781: when a project requires a special
+    # nim version like #head, `nimble dump` must not return an empty nimDir.
+    # It should fall back to the bootstrap nim (needNim) when the special
+    # version isn't installed locally.
+    cd "testdump":
+      let nimbleBackup = readFile("testdump.nimble")
+      defer: writeFile("testdump.nimble", nimbleBackup)
+      writeFile("testdump.nimble", """
+description = "Test package for dump command"
+version = "0.1.0"
+author = "nigredo-tori"
+license = "BSD"
+
+requires "nim#head"
 """)
       let (outp, exitCode) = execNimble("dump")
       check exitCode == QuitSuccess


### PR DESCRIPTION
Fixes #1781 