### PR TITLE
Propagate exit codes from nimble tasks

### DIFF
--- a/src/nimblepkg/nimscriptwrapper.nim
+++ b/src/nimblepkg/nimscriptwrapper.nim
@@ -166,6 +166,10 @@ proc execScript(
     )
 
   if exitCode != 0:
+    if isCustomTask(actionName, options) and not isHook:
+      # The task ran with live output, so its errors are already visible.
+      # Propagate its exit code so `nimble <task>` is usable in scripts/CI.
+      raise nimbleQuit(exitCode)
     let errMsg =
       if stdout.len != 0:
         stdout

--- a/tests/tasks/exitcode/tasks.nimble
+++ b/tests/tasks/exitcode/tasks.nimble
@@ -1,0 +1,20 @@
+# Package
+
+version       = "0.1.0"
+author        = "nimble tests"
+description   = "Test exit code propagation from tasks"
+license       = "MIT"
+
+# Dependencies
+
+requires "nim >= 0.19.0"
+
+
+task ok, "A task that succeeds":
+    echo "all good"
+
+task fail, "A task that quits with exit code 3":
+    quit(3)
+
+task failexec, "A task that runs a failing external command":
+    exec "exit 7"

--- a/tests/tnimbletasks.nim
+++ b/tests/tnimbletasks.nim
@@ -32,3 +32,19 @@ suite "nimble tasks":
       let (output, exitCode) = execNimble("tasks")
       check output.contains("a         Description for a")
       check exitCode == QuitSuccess
+
+  test "successful task exits with code 0":
+    cd "tasks/exitcode":
+      let (output, exitCode) = execNimble("ok")
+      check output.contains("all good")
+      check exitCode == QuitSuccess
+
+  test "task exit code is propagated":
+    cd "tasks/exitcode":
+      let (_, exitCode) = execNimble("fail")
+      check exitCode == 3
+
+  test "failing exec in task produces non-zero exit code":
+    cd "tasks/exitcode":
+      let (_, exitCode) = execNimble("failexec")
+      check exitCode != QuitSuccess


### PR DESCRIPTION
Fixes #634

## Problem

Exit codes from nimble tasks are not propagated, which makes `nimble <task>` unreliable in scripting and CI. In stable v0.22.2 a failing task even exits with code 0, so CI treats the job as successful. On master, task failures are collapsed into a generic `NimbleError` and always exit with 1, losing the task's actual exit code: a task calling `quit(3)` cannot make nimble exit with 3.

## Solution

Tasks run via a `nim e` child process, and `nim e` already propagates `quit(N)` from nimscript as its own exit code. `execScript` in `nimscriptwrapper.nim` received that code but only checked it for zero/non-zero. Now, when a custom task's child process exits non-zero, we raise `NimbleQuit` with the child's exit code (the same mechanism `nimble run` already uses) so it passes through to nimble's own exit code.

Custom tasks run with live output, so their errors are already visible on the terminal; the redundant generic "Exception raised during nimble script execution" message is dropped for this path. Hook execution and package metadata parsing keep the existing error behavior.

Note: a failing `exec "cmd"` inside a task still yields exit code 1 rather than the inner command's code, because nimscript's `exec` in the Nim stdlib raises `OSError` instead of forwarding the code. Task authors who need a specific code can wrap `exec` and call `quit(N)`.

## Testing

Added a `tests/tasks/exitcode` fixture and three tests in `tnimbletasks.nim`:

- a successful task exits with 0
- a task calling `quit(3)` makes nimble exit with 3
- a task with a failing `exec` exits non-zero

The `nimble tasks`, `nimscript`, and `Task level dependencies` suites all pass locally.