### PR TITLE
Keep lock upgrades consistent with the solution they merge into. Allow

### DIFF
--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -1254,6 +1254,58 @@ proc getSolvedPkgFromInstalledPkgs*(satResult: SATResult, solvedPkg: SolvedPacka
       return some(pkg)
   return none(PackageInfo)
 
+proc violatesConstraints(pinned: SolvedPackage, constraints: seq[PkgTuple]): bool =
+  ## Whether any requirement on `pinned`'s name rules its version out.
+  for constraint in constraints:
+    if cmpIgnoreCase(constraint.name, pinned.pkgName) == 0 and
+       not pinned.version.withinRange(constraint.ver):
+      return true
+  false
+
+proc replacePin(satResult: var SATResult, index: int, replacement: SolvedPackage) =
+  ## Swap a carried-over pin for the version the solve chose. The old version's
+  ## PackageInfo must not linger, or the lock file is written from it; the
+  ## replacement is fetched via pkgsToInstall instead.
+  let stale = satResult.solvedPkgs[index].version
+  satResult.solvedPkgs[index] = replacement
+  satResult.pkgs = satResult.pkgs.toSeq.filterIt(
+    not (cmpIgnoreCase(it.basicInfo.name, replacement.pkgName) == 0 and
+         it.basicInfo.version == stale)).toHashSet()
+  if replacement.pkgName notin satResult.pkgsToInstall.mapIt(it[0]):
+    satResult.pkgsToInstall.add((replacement.pkgName, replacement.version))
+
+proc repairInconsistentPin(satResult: var SATResult, solution: seq[SolvedPackage]): bool =
+  ## Repair the first carried-over pin the merged requirements rule out,
+  ## reporting whether anything changed.
+  var constraints = satResult.rootPackage.requires
+  for solvedPkg in satResult.solvedPkgs:
+    constraints.add solvedPkg.requirements
+
+  for i in 0 ..< satResult.solvedPkgs.len:
+    let pinned = satResult.solvedPkgs[i]
+    if not pinned.violatesConstraints(constraints): continue
+    for solved in solution:
+      if cmpIgnoreCase(solved.pkgName, pinned.pkgName) == 0 and
+         solved.version != pinned.version:
+        satResult.replacePin(i, solved)
+        return true
+  false
+
+proc repairInconsistentPins(satResult: var SATResult, solution: seq[SolvedPackage]) =
+  ## Carrying the locked versions over keeps an upgrade minimal, but a pin can
+  ## contradict the solution it is being merged into: the upgraded package may
+  ## need a newer sibling, or `--requires` may have tightened a constraint on a
+  ## package that is already locked. Take `solution`'s answer for any
+  ## carried-over pin that the merged requirements rule out, so what gets
+  ## written is at least self-consistent. Everything else keeps its pin, which
+  ## is what makes this an upgrade rather than a re-solve.
+  ##
+  ## A repair pulls in the new version's own requirements, which can in turn
+  ## rule out another pin, so this repeats. At most one pin is repaired per
+  ## round, so their number bounds the rounds.
+  for _ in 0 .. satResult.solvedPkgs.len:
+    if not satResult.repairInconsistentPin(solution): break
+
 proc solveLockFileDeps*(satResult: var SATResult, pkgList: seq[PackageInfo], options: Options, nimBin: Option[string]) =
   let lockFile = options.lockFile(satResult.rootPackage.myPath.parentDir())
   let currentRequires = satResult.rootPackage.requires
@@ -1394,6 +1446,8 @@ proc solveLockFileDeps*(satResult: var SATResult, pkgList: seq[PackageInfo], opt
         if solvedPkg.pkgName notin satResult.solvedPkgs.mapIt(it.pkgName):
           satResult.solvedPkgs.add(solvedPkg)
 
+      satResult.repairInconsistentPins(tempSatResult.solvedPkgs)
+
       for upgradePkg in options.action.packages:
         satResult.pkgs = satResult.pkgs.toSeq.filterIt(it.basicInfo.name != upgradePkg.name).toHashSet()
 
@@ -1437,3 +1491,9 @@ proc solutionToFullInfo*(satResult: SATResult, options: var Options, nimBin: Opt
   if satResult.rootPackage.infoKind != pikFull and not satResult.rootPackage.basicInfo.name.isNim:
     satResult.rootPackage = getPkgInfo(satResult.rootPackage.getNimbleFileDir, options, nimBin = nimBin).toRequiresInfo(options, nimBin = nimBin)
     satResult.rootPackage.enableFeatures(options)
+    # Re-reading the root from disk drops whatever `solvePkgs` had appended to
+    # its requires. `--requires` has to survive: the lock file logic that runs
+    # after this reads the root's requires to decide what still satisfies the
+    # existing pins, and without the extras it silently keeps a pin the user
+    # just asked to constrain away.
+    satResult.rootPackage.requires &= options.extraRequires

--- a/tests/tlockfile.nim
+++ b/tests/tlockfile.nim
@@ -15,7 +15,7 @@ import nimblepkg/vcstools
 from nimblepkg/common import cd, dump, cdNewDir
 from nimblepkg/tools import tryDoCmdEx, doCmdEx
 from nimblepkg/packageinfotypes import DownloadMethod
-from nimblepkg/version import PkgTuple, `$`
+from nimblepkg/version import PkgTuple, `$`, newVersion, withinRange
 from nimblepkg/lockfile import LockFileJsonKeys
 from nimblepkg/options import defaultLockFileName, defaultDevelopPath, initOptions
 from nimblepkg/developfile import ValidationError, ValidationErrorKind,
@@ -1068,7 +1068,9 @@ requires "dep2 >= 0.9.0"
       let requires = nimbleInfo.getRequires(activeFeatures)
       let nimReq = requires.filterIt(it.name == "nim")
       check nimReq.len > 0
-      let expectedNimVersion = $nimReq[0].ver
+      # Read the expectation out of langserver's own nimble file so it follows
+      # whatever they declare upstream.
+      let nimRequirement = nimReq[0].ver
 
       # Remove existing lock file to force regeneration
       removeFile defaultLockFileName
@@ -1078,7 +1080,7 @@ requires "dep2 >= 0.9.0"
       check defaultLockFileName.fileExists
       let lockJson = defaultLockFileName.readFile.parseJson
       let nimVersion = lockJson{$lfjkPackages, "nim", "version"}.getStr
-      check nimVersion == expectedNimVersion
+      check newVersion(nimVersion).withinRange(nimRequirement)
 
   test "lock file content is preserved when running nimble lock on existing lock file":
     # Test that running `nimble lock` on an existing lock file preserves:

--- a/tests/tnimblerefresh.nim
+++ b/tests/tnimblerefresh.nim
@@ -143,9 +143,11 @@ license       = "MIT"
     tryDoCmdEx("git add .")
     tryDoCmdEx("git commit -am " & msg.quoteShell)
 
-  proc writeDepVersion(version: string, name = "dep1") =
-    ## Writes <name>.nimble at `version` in the cwd and tags it.
-    writeFile(&"{name}.nimble", nimbleFileTemplate % version)
+  proc writeDepVersion(version: string, name = "dep1", requirement = "") =
+    ## Writes <name>.nimble at `version` in the cwd and tags it. `requirement`
+    ## lets a new version raise its floor on another dependency.
+    writeFile(&"{name}.nimble", (nimbleFileTemplate % version) &
+      (if requirement.len > 0: &"requires \"{requirement}\"\n" else: ""))
     commitAll(version)
     tryDoCmdEx(&"git tag v{version}")
 
@@ -155,9 +157,9 @@ license       = "MIT"
       for v in versions:
         writeDepVersion(v, name)
 
-  proc addDepVersion(version: string, name = "dep1") =
+  proc addDepVersion(version: string, name = "dep1", requirement = "") =
     cd originsDirPath / name:
-      writeDepVersion(version, name)
+      writeDepVersion(version, name, requirement)
 
   proc initMainPkg(requirement: string, underVcs = false) =
     createDir mainPkgPath
@@ -405,4 +407,31 @@ license       = "MIT"
         check execNimbleYes("refresh").exitCode == QuitSuccess
         check execNimbleYes("lock", "dep1").exitCode == QuitSuccess
         check lockedVersion("dep1") == "0.2.0"
+        check lockedVersion("dep2") == "0.1.0"
+
+  test "lock --refresh pkg drags along the dependencies its new version needs":
+    withTwoDepProject:
+      cd mainPkgPath:
+        check execNimbleYes("lock").exitCode == QuitSuccess
+        check lockedVersion("dep1") == "0.1.0"
+        check lockedVersion("dep2") == "0.1.0"
+      # dep1 0.2.0 raises its floor on dep2. Moving dep1 alone would leave the
+      # lock file contradicting dep1's own requirements.
+      addDepVersion("0.2.0", "dep2")
+      addDepVersion("0.2.0", "dep1", requirement = "dep2 >= 0.2.0")
+      cd mainPkgPath:
+        check execNimbleYes("lock", "--refresh", "dep1").exitCode == QuitSuccess
+        check lockedVersion("dep1") == "0.2.0"
+        check lockedVersion("dep2") == "0.2.0"
+
+  test "lock --requires moves a pin the tightened constraint rules out":
+    withTwoDepProject:
+      addDepVersion("0.2.0", "dep2")
+      cd mainPkgPath:
+        check execNimbleYes("lock", "--refresh").exitCode == QuitSuccess
+        check lockedVersion("dep2") == "0.2.0"
+        # The constraint has to survive as far as the lock file: dep2 is pinned
+        # at a version it forbids, so that pin cannot be carried over as-is.
+        check execNimbleYes("lock", "dep1", "--requires: dep2 < 0.2.0")
+          .exitCode == QuitSuccess
         check lockedVersion("dep2") == "0.1.0"


### PR DESCRIPTION
for partial lock upgrades