### PR TITLE
fix(#1827): match url requires to lock file properly

### DIFF
--- a/src/nimblepkg/nimblesat.nim
+++ b/src/nimblepkg/nimblesat.nim
@@ -1399,9 +1399,9 @@ proc repairInconsistentPins(satResult: var SATResult, solution: seq[SolvedPackag
 proc solveLockFileDeps*(satResult: var SATResult, pkgList: seq[PackageInfo], options: Options, nimBin: Option[string]) =
   let lockFile = options.lockFile(satResult.rootPackage.myPath.parentDir())
   let currentRequires = satResult.rootPackage.requires
-  var existingRequires = newSeq[(string, Version)]()
+  var existingRequires = newSeq[(string, string, Version)]()
   for name, dep in lockFile.getLockedDependencies.lockedDepsFor(options):
-    existingRequires.add((name, dep.version))
+    existingRequires.add((name, dep.url, dep.version))
 
   # Check for new requirements not in lock file
   var shouldSolve = false
@@ -1420,7 +1420,11 @@ proc solveLockFileDeps*(satResult: var SATResult, pkgList: seq[PackageInfo], opt
     var found = false
     for existing in existingRequires:
       let existingName = existing[0].resolveAlias(options).toLowerAscii()
-      if currentName == existingName and existing[1].withinRange(current.ver):
+      # match name or url against the lockfile requires
+      let matches =
+        if current.name.isURL: cmpIgnoreCase(current.name, existing[1]) == 0
+        else: currentName == existingName
+      if matches and existing[2].withinRange(current.ver):
         found = true
         break
     if not found:

--- a/tests/tissues.nim
+++ b/tests/tissues.nim
@@ -624,3 +624,55 @@ requires "results"
       checkpoint output
       check exitCode == QuitSuccess
       check not output.contains("Package not found in solution")
+  test "issue 1827. Match url requires to lock file properly":
+    let tmpDir = getTempDir() / "tissue_1827"
+    removeDir(tmpDir)
+    createDir(tmpDir)
+    defer:  removeDir(tmpDir)
+    writeFile(tmpDir / "tissue_1827.nimble", """
+version = "0.1.0"
+author = "test"
+description = "test"
+license = "MIT"
+requires "jsony"
+requires "https://github.com/arnetheduck/nim-results"
+""")
+    writeFile(tmpDir / "nimble.lock", """
+{
+  "version": 2,
+  "packages": {
+    "results": {
+      "version": "0.5.1",
+      "vcsRevision": "df8113dda4c2d74d460a8fa98252b0b771bf1f27",
+      "url": "https://github.com/arnetheduck/nim-results",
+      "downloadMethod": "git",
+      "dependencies": ["nim"],
+      "checksums": {"sha1": "a9c011f74bc9ed5c91103917b9f382b12e82a9e7"}
+    },
+    "jsony": {
+      "version": "1.1.4",
+      "vcsRevision": "981f868cfca6e2ccde820cc20bb18d835d283233",
+      "url": "https://github.com/treeform/jsony",
+      "downloadMethod": "git",
+      "dependencies": ["nim"],
+      "checksums": {"sha1": "0b40135953033a217eb163e2a73d1e628216a9aa"}
+    }
+  },
+  "tasks": {}
+}
+""")
+    let nimbleDir = tmpDir / "nimbledir"
+    cd tmpDir:
+      let (output, exitCode) = execNimbleYes(
+        "--nimbleDir:" & nimbleDir, "deps",  "--format:json"
+      )
+      checkpoint output
+      check exitCode == QuitSuccess
+      check output.contains("""
+    "name": "jsony",
+    "version": "@any",
+    "resolvedTo": "1.1.4",
+""")
+
+
+


### PR DESCRIPTION
Closes #1827.

This keeps track of the url from a requires section to match against the lockfile so that it doesn't trigger a re-solve.